### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Vagrant
     In the commands that follow, `{target}` is one of the supported build targets.
 
         $ vagrant ssh
+        $ cd NUbots
         $ ./b platform select {target}
-        $ cd NUbots/build
+        $ cd build
         $ ninja
 
 4. If quex permission error occurs run


### PR DESCRIPTION
The `./b platform select {target}` command must be ran inside of the NUbots folder.

Update the readme to first cd into NUbots before running the command.