### PR TITLE
Adds missing zlib dependency to build vm.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,6 +39,16 @@ Vagrant.configure("2") do |config|
     shell.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
   end
 
+  # Before anything else runs make sure dpkg isnt locked.
+  # Might as well do a quick update while we are here
+  config.vm.provision "unlock-dpkg", type: "shell", run: "always" do |shell|
+    shell.inline = "rm /var/lib/dpkg/lock;
+                    apt-get update;
+                    apt-get upgrade;
+                    apt-get dist-upgrade;
+                    apt-get autoremove --purge;"
+  end
+
   # Before the puppet provisioner runs
   # install puppet modules that are used
   config.vm.provision "install-puppet-modules", type: "shell" do |shell|

--- a/puppet/modules/build_tools/manifests/init.pp
+++ b/puppet/modules/build_tools/manifests/init.pp
@@ -46,6 +46,7 @@ class build_tools {
   package { 'gettext': ensure => latest, }
   package { 'python3-pip': ensure => latest, }
   package { 'python-pip': ensure => latest, }
+  package { 'zlib1g-dev': ensure => latest, }
 
   # CM730 firmware compilation.
   package { 'gcc-arm-none-eabi': ensure => latest, }


### PR DESCRIPTION
System-level protobuf requires zlib, but no zlib was being installed.

Vagrantfile also incorporates the troubleshooting commands that @JakeFountain  added to the readme. This addition will cause these troubleshooting commands to run every time `vagrant up` or `vagrant reload` is run.