### PR TITLE
Fix issues so that b works on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.travis/build_code.sh
+++ b/.travis/build_code.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 export PATH=/usr/lib/ccache:$PATH
-/usr/bin/python3 ./b platform select $PLATFORM
+/usr/bin/python3 nuclear/b platform select $PLATFORM
 cd build
 ninja

--- a/b
+++ b/b
@@ -1,1 +1,0 @@
-nuclear/b

--- a/b
+++ b/b
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec nuclear/b.py "$@"

--- a/tools/platform.py
+++ b/tools/platform.py
@@ -40,7 +40,12 @@ def run(workspace_command, **kwargs):
             os.remove('build')
         except FileNotFoundError:
             pass
-        os.symlink(path, 'build')
+
+        # Try to make the symlink, this will fail if you use windows
+        try:
+            os.symlink(path, 'build')
+        except OSError:
+            print("Windows does not support symlinks, you will need to cd to build_{}".format(platform))
 
         # Change to that directory
         os.chdir(path)

--- a/tools/platform.py
+++ b/tools/platform.py
@@ -2,6 +2,7 @@
 
 import os
 import b
+from termcolor import cprint
 from subprocess import call, STDOUT
 
 def register(command):
@@ -42,15 +43,21 @@ def run(workspace_command, **kwargs):
             pass
 
         # Try to make the symlink, this will fail if you use windows
+        symlink_success = True
         try:
             os.symlink(path, 'build')
         except OSError:
-            print("Windows does not support symlinks, you will need to cd to build_{}".format(platform))
+            symlink_success = False
 
         # Change to that directory
         os.chdir(path)
 
         # Run cmake
         call(['cmake', b.project_dir, '-GNinja', '-DCMAKE_TOOLCHAIN_FILE=/nubots/toolchain/{}.cmake'.format(platform)])
+
+        # Yell at windows users for having a crappy OS
+        if not symlink_success:
+            cprint('Windows does not support symlinks so we can\'t link to the build directory', 'red', attrs=['bold'])
+            cprint('Instead you will need to change to the build_{} directory to build'.format(platform), 'red', attrs=['bold'])
 
 


### PR DESCRIPTION
Windows users often pull with \r\n line endings. This breaks all the bash scripts and the b script since bash interprets it to start with.
This PR forces git to pull using newlines.