### PR TITLE
Ignore line endings on binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 * text=auto eol=lf
+*.png binary
+*.ggb binary
+*.ods binary
+*.zip binary
+*.jpg binary


### PR DESCRIPTION
adds backwards compatibility with git.