### PR TITLE
Fix the travis icon to show the status of master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-NUbots Codebase [![Build Status](https://travis-ci.org/NUbots/NUbots.png)](https://travis-ci.org/NUbots/NUbots)
+NUbots Codebase [![Build Status](https://travis-ci.org/NUbots/NUbots.svg?branch=master)](https://travis-ci.org/NUbots/NUbots)
 ==========================
 
 Vagrant


### PR DESCRIPTION
Currently the travis badge says failed a lot because of other PRs that failed. The badge on master should reflect master.