### PR TITLE
Upgrade to new version of NUClear which will support better networking

### DIFF
--- a/.travis/install_toolchain.sh
+++ b/.travis/install_toolchain.sh
@@ -2,8 +2,8 @@
 
 # Download and install our current toolchain version
 cd $TRAVIS_BUILD_DIR/toolchain
-sudo wget -N http://nubots.net/debs/nubots-toolchain-2.1.2-travis.deb
-sudo dpkg -i nubots-toolchain-2.1.2-travis.deb
+sudo wget -N http://nubots.net/debs/nubots-toolchain-2.1.3-travis.deb
+sudo dpkg -i nubots-toolchain-2.1.3-travis.deb
 
 # Setup ruby so puppet works
 rvm install ruby --latest

--- a/module/support/configuration/NetworkConfiguration/src/NetworkConfiguration.cpp
+++ b/module/support/configuration/NetworkConfiguration/src/NetworkConfiguration.cpp
@@ -29,10 +29,10 @@ namespace support {
             : Reactor(std::move(environment)) {
 
             on<Configuration>("NetworkConfiguration.yaml").then([this](const Configuration& config) {
-                auto netConfig             = std::make_unique<NUClear::message::NetworkConfiguration>();
-                netConfig->name            = config["name"];
-                netConfig->multicast_group = config["address"];
-                netConfig->multicast_port  = config["port"];
+                auto netConfig              = std::make_unique<NUClear::message::NetworkConfiguration>();
+                netConfig->name             = config["name"];
+                netConfig->announce_address = config["address"];
+                netConfig->announce_port    = config["port"];
                 emit<Scope::DIRECT>(netConfig);
             });
 

--- a/puppet/manifests/nubots.pp
+++ b/puppet/manifests/nubots.pp
@@ -14,7 +14,7 @@ node default {
   }
 
   # Get and install our toolchain
-  $toolchain_version = '2.1.2'
+  $toolchain_version = '2.1.3'
   wget::fetch { 'nubots_deb':
     destination => "/root/nubots-toolchain-${toolchain_version}.deb",
     source      => "http://nubots.net/debs/nubots-toolchain-${toolchain_version}.deb",

--- a/puppet/modules/toolchain_deb/files/control
+++ b/puppet/modules/toolchain_deb/files/control
@@ -1,5 +1,5 @@
 Package: nubots-toolchain
-Version: 2.1.2
+Version: 2.1.3
 Section: base
 Priority: optional
 Architecture: amd64


### PR DESCRIPTION
New NUClear networking supports unicast and broadcast networks which will work better when there is no default route to send multicast packets on.