### PR TITLE
Overloads operator* for Transform3D

### DIFF
--- a/shared/utility/math/matrix/Transform3D.h
+++ b/shared/utility/math/matrix/Transform3D.h
@@ -87,6 +87,15 @@ namespace math {
              */
             Transform(const arma::vec3& in);
 
+            Transform3D operator*(const Transform3D& B) {
+                return Transform3D(arma::mat44(*this) * arma::mat44(B));
+            }
+
+            template <typename T>
+            arma::mat44 operator*(const T& B) {
+                return arma::mat44(*this) * B;
+            }
+
             /**
              * @brief Translate the current basis by the given 3D vector in local space
              *


### PR DESCRIPTION
Resolves issue #18 
This is to handle the case where (A * B).i() should use the affine inverse for homogeneous matrices if both A and B are Transform3D. If B is not a Transform3D then default to the generic inverse calculation.