### PR TITLE
Suppresses "ISO C++ forbids flexible array member" warnings

### DIFF
--- a/module/input/Camera/src/Camera.h
+++ b/module/input/Camera/src/Camera.h
@@ -16,8 +16,10 @@
 #include <nuclear>
 
 // clang-format off
+extern "C" {
 #include <arvconfig.h>
-#include <arv.h>
+#include <aravis-0.6/arv.h>
+}
 // clang-format on
 
 #include "extension/Configuration.h"

--- a/shared/utility/vision/Vision.h
+++ b/shared/utility/vision/Vision.h
@@ -26,7 +26,9 @@
 #include <string>
 #include <vector>
 
+extern "C" {
 #include <aravis-0.6/arv.h>
+}
 
 #include "message/input/Image.h"
 


### PR DESCRIPTION
Aravis is a C library and it should be treated as such