### PR TITLE
Update team ID for RoboCup 2019

### DIFF
--- a/module/support/configuration/GlobalConfig/data/config/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/GlobalConfig.yaml
@@ -1,2 +1,2 @@
 playerId: 1
-teamId: 14
+teamId: 23


### PR DESCRIPTION
This updates the `teamId` in `GlobalConfig.yaml` for RoboCup 2019.

New team ID is 23, from https://github.com/RoboCup-Humanoid-TC/GameController/commit/7af05c7c0a01e2755fd5e930f57263108035cd2e#diff-0289f5237e915741aec10411f9bbacbeR8

This was tested and works with the Game Controller.