### PR TITLE
Fix Aravis Buffer on Invalid Image from Camera.

### DIFF
--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -201,7 +201,7 @@ namespace behaviour {
 
                     arma::vec3 rBWw_temp = {ball.position[0], ball.position[1], fieldDescription.ball_radius};
                     rBWw                 = timeSinceBallSeen < search_timeout ? rBWw_temp :  // Place last seen
-                               Htw.x() + Htw.translation();                                  // In front of the robot
+                               Htw.i().x() + Htw.i().translation();                          // In front of the robot
                     arma::vec3 pos = Htw.transformPoint(rBWw);
                     position       = pos.rows(0, 1);
 

--- a/module/input/Camera/src/AravisCamera.cpp
+++ b/module/input/Camera/src/AravisCamera.cpp
@@ -176,8 +176,6 @@ namespace input {
         else {
             // In the case where it fails, reinsert the Buffer back into the stream, so we don't run out.
             if (buffer != NULL) {
-                // std::cout << "Buffer Failed: " << context->cameraID << " " << arv_buffer_get_status(buffer) <<
-                // std::endl;
                 arv_stream_push_buffer(stream, buffer);
             }
         }

--- a/module/input/Camera/src/AravisCamera.cpp
+++ b/module/input/Camera/src/AravisCamera.cpp
@@ -152,30 +152,30 @@ namespace input {
         ArvBuffer* buffer;
         buffer = arv_stream_try_pop_buffer(stream);
 
-        if ((buffer != NULL) && (arv_buffer_get_status(buffer) == ARV_BUFFER_STATUS_SUCCESS)) {
-            int width, height;
-            size_t buffSize;
-            arv_buffer_get_image_region(buffer, NULL, NULL, &width, &height);
-            const uint8_t* buff = reinterpret_cast<const uint8_t*>(arv_buffer_get_data(buffer, &buffSize));
+        if (buffer != NULL) {
+            if (arv_buffer_get_status(buffer) == ARV_BUFFER_STATUS_SUCCESS) {
+                int width, height;
+                size_t buffSize;
+                arv_buffer_get_image_region(buffer, NULL, NULL, &width, &height);
+                const uint8_t* buff = reinterpret_cast<const uint8_t*>(arv_buffer_get_data(buffer, &buffSize));
 
-            auto msg = std::make_unique<ImageData>();
-            msg->data.insert(msg->data.end(), buff, buff + buffSize);
+                auto msg = std::make_unique<ImageData>();
+                msg->data.insert(msg->data.end(), buff, buff + buffSize);
 
-            msg->dimensions << (unsigned int) (width), (unsigned int) (height);
-            msg->timestamp = NUClear::clock::time_point(std::chrono::nanoseconds(arv_buffer_get_timestamp(buffer)));
+                msg->dimensions << (unsigned int) (width), (unsigned int) (height);
+                msg->timestamp = NUClear::clock::time_point(std::chrono::nanoseconds(arv_buffer_get_timestamp(buffer)));
 
-            msg->format        = context->fourcc;
-            msg->serial_number = context->deviceID;
-            msg->camera_id     = context->cameraID;
-            msg->isLeft        = context->isLeft;
-            msg->lens          = context->lens;
+                msg->format        = context->fourcc;
+                msg->serial_number = context->deviceID;
+                msg->camera_id     = context->cameraID;
+                msg->isLeft        = context->isLeft;
+                msg->lens          = context->lens;
 
-            context->reactor.emit<Scope::DIRECT>(msg);
-            arv_stream_push_buffer(stream, buffer);
-        }
-        else {
-            // In the case where it fails, reinsert the Buffer back into the stream, so we don't run out.
-            if (buffer != NULL) {
+                context->reactor.emit<Scope::DIRECT>(msg);
+                arv_stream_push_buffer(stream, buffer);
+            }
+            else {
+                // In the case where it fails, reinsert the Buffer back into the stream, so we don't run out.
                 arv_stream_push_buffer(stream, buffer);
             }
         }

--- a/module/input/Camera/src/AravisCamera.cpp
+++ b/module/input/Camera/src/AravisCamera.cpp
@@ -173,6 +173,14 @@ namespace input {
             context->reactor.emit<Scope::DIRECT>(msg);
             arv_stream_push_buffer(stream, buffer);
         }
+        else {
+            // In the case where it fails, reinsert the Buffer back into the stream, so we don't run out.
+            if (buffer != NULL) {
+                // std::cout << "Buffer Failed: " << context->cameraID << " " << arv_buffer_get_status(buffer) <<
+                // std::endl;
+                arv_stream_push_buffer(stream, buffer);
+            }
+        }
     }
 
     void Camera::ShutdownAravisCamera() {


### PR DESCRIPTION
Please check if this breaks your robot. We had issues where cameras stopped sending images after some timeouts, after close investigation, the camera was running out of buffers to insert images.
