### PR TITLE
Fixes hardware simulator

### DIFF
--- a/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
+++ b/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
@@ -235,11 +235,15 @@ namespace platform {
                             gyroQueue.pop();
                         }
                     }
-                    sumGyro               = (sumGyro * UPDATE_FREQUENCY + Eigen::Vector3d(0.0, 0.0, imu_drift_rate));
-                    sumGyro.x()           = -sumGyro.x();
-                    sensors.gyroscope     = sumGyro;
-                    sensors.accelerometer = Eigen::Vector3d(-9.8 * std::sin(bodyTilt), 0.0, -9.8 * std::cos(bodyTilt));
-                    sensors.timestamp     = NUClear::clock::now();
+                    sumGyro                 = (sumGyro * UPDATE_FREQUENCY + Eigen::Vector3d(0.0, 0.0, imu_drift_rate));
+                    sumGyro.x()             = -sumGyro.x();
+                    sensors.gyroscope.x     = sumGyro.x();
+                    sensors.gyroscope.y     = sumGyro.y();
+                    sensors.gyroscope.z     = sumGyro.z();
+                    sensors.accelerometer.x = -9.8 * std::sin(bodyTilt);
+                    sensors.accelerometer.y = 0.0;
+                    sensors.accelerometer.z = -9.8 * std::cos(bodyTilt);
+                    sensors.timestamp       = NUClear::clock::now();
 
                     // Add some noise so that sensor fusion doesnt converge to a singularity
                     auto sensors_message = std::make_unique<DarwinSensors>(sensors);

--- a/roles/keyboardwalkfake.role
+++ b/roles/keyboardwalkfake.role
@@ -2,24 +2,19 @@ nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
   # and without it many roles do not run support::SignalCatcher
   extension::FileWatcher
-
   # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
   motion::KinematicsConfiguration
-
   # Support and Configuration
   support::configuration::GlobalConfig
   support::configuration::SoccerConfig
   support::configuration::NetworkConfiguration
   support::NUsight
-
   # Hardware Interface
   platform::darwin::HardwareSimulator
   platform::darwin::SensorFilter
-
   # Motion
   motion::OldWalkEngine
   motion::HeadController
-
   # Behaviour
   behaviour::Controller
   behaviour::skills::DirectWalkController

--- a/roles/keyboardwalkfake.role
+++ b/roles/keyboardwalkfake.role
@@ -1,0 +1,27 @@
+nuclear_role(
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
+  # and without it many roles do not run support::SignalCatcher
+  extension::FileWatcher
+
+  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
+  motion::KinematicsConfiguration
+
+  # Support and Configuration
+  support::configuration::GlobalConfig
+  support::configuration::SoccerConfig
+  support::configuration::NetworkConfiguration
+  support::NUsight
+
+  # Hardware Interface
+  platform::darwin::HardwareSimulator
+  platform::darwin::SensorFilter
+
+  # Motion
+  motion::QuinticWalk
+  motion::HeadController
+
+  # Behaviour
+  behaviour::Controller
+  behaviour::skills::DirectWalkController
+  behaviour::strategy::KeyboardWalk
+)

--- a/roles/keyboardwalkfake.role
+++ b/roles/keyboardwalkfake.role
@@ -17,7 +17,7 @@ nuclear_role(
   platform::darwin::SensorFilter
 
   # Motion
-  motion::QuinticWalk
+  motion::OldWalkEngine
   motion::HeadController
 
   # Behaviour


### PR DESCRIPTION
Hardware simulator had errors. Was never picked up in GitHub since no roles used hardware simulator. Added `keyboardwalkfake.role`, which uses hardware simulator, to test. 