### PR TITLE
Split up the docker image pushing to multiple agents

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   # Push up new images to DockerHub when they get to master
   # Makes development faster as you can just pull the images rather than building them yourself
   # If you make modifications to the Dockerfile it should resume from the common point in master
-  - label: ":docker: Push new images"
+  - label: "Push generic :docker: image"
     branches: master
     agents:
       dockerhub: true
@@ -14,7 +14,31 @@ steps:
           config: .buildkite/docker-compose.yml
           push:
             - generic:nubots/nubots:generic
+  
+  - label: "Push nuc7i7bnh :docker: image"
+    branches: master
+    agents:
+      dockerhub: true
+    plugins:
+      - docker-login#v2.0.1:
+          username: nubotsdocker
+          # Dockerhub password is loaded from the environment hook via DOCKER_LOGIN_PASSWORD environment variable
+      - docker-compose#v3.1.0:
+          config: .buildkite/docker-compose.yml
+          push:
             - nuc7i7bnh:nubots/nubots:nuc7i7bnh
+            
+  - label: "Push nuc8i7beh :docker: image"
+    branches: master
+    agents:
+      dockerhub: true
+    plugins:
+      - docker-login#v2.0.1:
+          username: nubotsdocker
+          # Dockerhub password is loaded from the environment hook via DOCKER_LOGIN_PASSWORD environment variable
+      - docker-compose#v3.1.0:
+          config: .buildkite/docker-compose.yml
+          push:
             - nuc8i7beh:nubots/nubots:nuc8i7beh
 
   # Wait to finish uploading the image before doing the next steps


### PR DESCRIPTION
Split the docker image pushing so it goes to multiple agents, this should help improve time for image pushing