### PR TITLE
Added descriptions to protobuf messages

### DIFF
--- a/shared/message/Geometry.proto
+++ b/shared/message/Geometry.proto
@@ -24,21 +24,33 @@ package message;
 import "Vector.proto";
 import "Matrix.proto";
 
+/**
+ * A normal vector and the distance to the line.
+ */
 message Line {
     fvec3 normal   = 1;
     float distance = 2;
 }
 
+/**
+ * The circle's centre position and radius.
+ */
 message Circle {
     double radius = 1;
     vec2   centre = 2;
 }
 
+/**
+ * A 3D matrix representation of the Ellipse.
+ */
 message Ellipse {
     // See http://en.wikipedia.org/wiki/Matrix_representation_of_conic_sections
     mat3 ellipse = 1;
 }
 
+/**
+ * Four corner points of a quadrilateral.
+ */
 message Quad {
     vec2 tl = 1;
     vec2 tr = 2;
@@ -46,10 +58,16 @@ message Quad {
     vec2 br = 4;
 }
 
+/**
+ * Contains the polygon's location.
+ */
 message Polygon {
     vec2 point = 1;
 }
 
+/**
+ * Contains the positions of the four corners of a frustrum.
+ */
 message Frustum {
     vec3 tl = 1;
     vec3 tr = 2;
@@ -57,6 +75,9 @@ message Frustum {
     vec3 br = 4;
 }
 
+/**
+ * Contains the cone's axis, gradient, and radius.
+ */
 message Cone {
     fvec3 axis     = 1;
     float gradient = 2;

--- a/shared/message/behaviour/Behaviour.proto
+++ b/shared/message/behaviour/Behaviour.proto
@@ -21,6 +21,10 @@ syntax = "proto3";
 
 package message.behaviour;
 
+/**
+ * enum with state of robot's behaviour
+ */
+
 message Behaviour {
 
     enum State {

--- a/shared/message/behaviour/Behaviour.proto
+++ b/shared/message/behaviour/Behaviour.proto
@@ -26,6 +26,9 @@ package message.behaviour;
  */
 message Behaviour {
 
+    /**
+     * Behaviour state enum.
+     */
     enum State {
         UNKNOWN          = 0;
         INIT             = 1;
@@ -44,5 +47,8 @@ message Behaviour {
         LOCALISING       = 14;
     }
 
+    /**
+     * Robot's current behaviour state.
+     */
     State state = 1;
 }

--- a/shared/message/behaviour/Behaviour.proto
+++ b/shared/message/behaviour/Behaviour.proto
@@ -22,9 +22,8 @@ syntax = "proto3";
 package message.behaviour;
 
 /**
- * enum with state of robot's behaviour
+ * enum with state of robot's behaviour.
  */
-
 message Behaviour {
 
     enum State {

--- a/shared/message/behaviour/FieldTarget.proto
+++ b/shared/message/behaviour/FieldTarget.proto
@@ -25,11 +25,18 @@ package message.behaviour;
  * enum saying what the target is (SELF, BALL or GOAL).
  */
 message FieldTarget {
+
+    /**
+     * Robot targets enum.
+     */
     enum Target {
         SELF = 0;
         BALL = 1;
         GOAL = 2;
     }
 
+    /**
+     * The current target of the robot's behaviour.
+     */
     Target target = 1;
 }

--- a/shared/message/behaviour/FieldTarget.proto
+++ b/shared/message/behaviour/FieldTarget.proto
@@ -24,7 +24,6 @@ package message.behaviour;
 /**
  * enum saying what the target is (SELF, BALL or GOAL).
  */
-
 message FieldTarget {
     enum Target {
         SELF = 0;

--- a/shared/message/behaviour/FieldTarget.proto
+++ b/shared/message/behaviour/FieldTarget.proto
@@ -21,6 +21,10 @@ syntax = "proto3";
 
 package message.behaviour;
 
+/**
+ * enum saying what the target is (SELF, BALL or GOAL).
+ */
+
 message FieldTarget {
     enum Target {
         SELF = 0;

--- a/shared/message/behaviour/FixedWalkCommand.proto
+++ b/shared/message/behaviour/FixedWalkCommand.proto
@@ -49,13 +49,40 @@ message WalkOptimiserCommand {
  * Set of 'fixed' walk segments, making up a walk command.
  */
 message FixedWalkCommand {
+
+    /**
+     * One segment of a larger set, which comprises a command.
+     */
     message WalkSegment {
+
+        /**
+         * A vector in the direction of movement.
+         */
         vec2                     direction                 = 1;
+
+        /**
+         * The period of the wave which represents robot rotations.
+         */
         double                   curvePeriod               = 2;
+
+        /**
+         * The movement speed of the robot for the segment.
+         */
         double                   normalisedVelocity        = 3;
+
+        /**
+         * The rotational speed of the robot for the segment.
+         */
         double                   normalisedAngularVelocity = 4;
+
+        /**
+         * The time length of the segment.
+         */
         google.protobuf.Duration duration                  = 5;
     };
 
+    /**
+     * The set of walk segments which comprise a command.
+     */
     repeated WalkSegment segments = 1;
 }

--- a/shared/message/behaviour/FixedWalkCommand.proto
+++ b/shared/message/behaviour/FixedWalkCommand.proto
@@ -23,14 +23,31 @@ package message.behaviour;
 import "google/protobuf/duration.proto";
 import "Vector.proto";
 
+/**
+ * Empty message declaring the 'fixed' walk is finished.
+ */
 message FixedWalkFinished {}
+
+/**
+ * Empty message declaring the walk config was saved.
+ */
 message WalkConfigSaved {}
+
+/**
+ * Empty message asking to cancel the 'fixed' walk.
+ */
 message CancelFixedWalk {}
 
+/**
+ * string containing walk config.
+ */
 message WalkOptimiserCommand {
     string walkConfig = 1;
 }
 
+/**
+ * Set of 'fixed' walk segments, making up a walk command.
+ */
 message FixedWalkCommand {
     message WalkSegment {
         vec2                     direction                 = 1;

--- a/shared/message/behaviour/FixedWalkCommand.proto
+++ b/shared/message/behaviour/FixedWalkCommand.proto
@@ -58,27 +58,27 @@ message FixedWalkCommand {
         /**
          * A vector in the direction of movement.
          */
-        vec2                     direction                 = 1;
+        vec2 direction = 1;
 
         /**
          * The period of the wave which represents robot rotations.
          */
-        double                   curvePeriod               = 2;
+        double curvePeriod = 2;
 
         /**
          * The movement speed of the robot for the segment.
          */
-        double                   normalisedVelocity        = 3;
+        double normalisedVelocity = 3;
 
         /**
          * The rotational speed of the robot for the segment.
          */
-        double                   normalisedAngularVelocity = 4;
+        double normalisedAngularVelocity = 4;
 
         /**
          * The time length of the segment.
          */
-        google.protobuf.Duration duration                  = 5;
+        google.protobuf.Duration duration = 5;
     };
 
     /**

--- a/shared/message/behaviour/KickPlan.proto
+++ b/shared/message/behaviour/KickPlan.proto
@@ -38,7 +38,7 @@ message KickPlan {
     /**
      * Where the robot wants to kick to.
      */
-    vec2     target   = 1;
+    vec2 target = 1;
 
     /**
      * The type of this kick plan - scripted or IK.

--- a/shared/message/behaviour/KickPlan.proto
+++ b/shared/message/behaviour/KickPlan.proto
@@ -22,6 +22,9 @@ package message.behaviour;
 
 import "Vector.proto";
 
+/**
+ * Type of kick (scripted or IK) and kick target.
+ */
 message KickPlan {
     enum KickType {
         SCRIPTED = 0;
@@ -32,6 +35,9 @@ message KickPlan {
     KickType kickType = 2;
 }
 
+/**
+ * Boolean whether the robot wants to kick.
+ */
 message WantsToKick {
     bool kick = 1;
 }

--- a/shared/message/behaviour/KickPlan.proto
+++ b/shared/message/behaviour/KickPlan.proto
@@ -26,12 +26,23 @@ import "Vector.proto";
  * Type of kick (scripted or IK) and kick target.
  */
 message KickPlan {
+
+    /**
+     * Whether the kick is scripted or dynamic with inverse kinematics.
+     */
     enum KickType {
         SCRIPTED = 0;
         IK_KICK  = 1;
     }
 
+    /**
+     * Where the robot wants to kick to.
+     */
     vec2     target   = 1;
+
+    /**
+     * The type of this kick plan - scripted or IK.
+     */
     KickType kickType = 2;
 }
 

--- a/shared/message/behaviour/Look.proto
+++ b/shared/message/behaviour/Look.proto
@@ -23,6 +23,9 @@ package message.behaviour;
 import "google/protobuf/duration.proto";
 import "Vector.proto";
 
+/**
+ * Details of where and when to look.
+ */
 message Look {
     message Fixation {
         vec2 angle   = 1;

--- a/shared/message/behaviour/MotionCommand.proto
+++ b/shared/message/behaviour/MotionCommand.proto
@@ -22,6 +22,9 @@ package message.behaviour;
 
 import "Vector.proto";
 
+/**
+ * Details of which walk behaviour to execute and where on the field to do it.
+ */
 message MotionCommand {
     // Defines the possible types of motion command:
     enum Type {

--- a/shared/message/behaviour/Nod.proto
+++ b/shared/message/behaviour/Nod.proto
@@ -20,6 +20,9 @@ syntax = "proto3";
 
 package message.behaviour;
 
+/**
+ * Boolean indicating to nod.
+ */
 message Nod {
     bool value = 1;
 }

--- a/shared/message/behaviour/ServoCommand.proto
+++ b/shared/message/behaviour/ServoCommand.proto
@@ -22,6 +22,9 @@ package message.behaviour;
 
 import "google/protobuf/timestamp.proto";
 
+/**
+ * A command for a servo to execute.
+ */
 message ServoCommand {
     uint64                    source   = 1;
     google.protobuf.Timestamp time     = 2;

--- a/shared/message/behaviour/SoccerObjectPriority.proto
+++ b/shared/message/behaviour/SoccerObjectPriority.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 package message.behaviour;
 
 /**
- *
+ * Information to prioritise what the head behaviour should look at.
  */
 message SoccerObjectPriority {
     enum SearchType {

--- a/shared/message/behaviour/SoccerObjectPriority.proto
+++ b/shared/message/behaviour/SoccerObjectPriority.proto
@@ -20,6 +20,9 @@ syntax = "proto3";
 
 package message.behaviour;
 
+/**
+ *
+ */
 message SoccerObjectPriority {
     enum SearchType {
         LOST                    = 0;
@@ -29,7 +32,7 @@ message SoccerObjectPriority {
         GOAL_RIGHT              = 4;
         GROUND_LEFT             = 5;
         GROUND_RIGHT            = 6;
-        OTHE                    = 7;
+        OTHER                   = 7;
     }
 
     int32      ball       = 1;

--- a/shared/message/behaviour/Subsumption.proto
+++ b/shared/message/behaviour/Subsumption.proto
@@ -21,6 +21,9 @@ syntax = "proto3";
 
 package message.behaviour;
 
+/**
+ *
+ */
 message Subsumption {
 
     message LimbSet {

--- a/shared/message/behaviour/WalkPath.proto
+++ b/shared/message/behaviour/WalkPath.proto
@@ -23,6 +23,9 @@ package message.behaviour;
 import "message/behaviour/MotionCommand.proto";
 import "Vector.proto";
 
+/**
+ * Information used to make a path, to complete a MotionCommand which is included in the message.
+ */
 message WalkPath {
     // Sequence of robot states that form a path:
     repeated fvec3 states = 1;

--- a/shared/message/input/GameEvents.proto
+++ b/shared/message/input/GameEvents.proto
@@ -23,6 +23,9 @@ package message.input;
 import "google/protobuf/timestamp.proto";
 import "message/input/GameState.proto";
 
+/**
+ * Contains event tracking information.
+ */
 message GameEvents {
 
     enum Context {

--- a/shared/message/input/GameState.proto
+++ b/shared/message/input/GameState.proto
@@ -22,6 +22,9 @@ package message.input;
 
 import "google/protobuf/timestamp.proto";
 
+/**
+ * Contains lots of game state information.
+ */
 message GameState {
     message Data {
         enum Mode {

--- a/shared/message/input/Image.proto
+++ b/shared/message/input/Image.proto
@@ -25,6 +25,9 @@ import "google/protobuf/timestamp.proto";
 import "Matrix.proto";
 import "Vector.proto";
 
+/**
+ * Camera, lens, and output image information.
+ */
 message Image {
     message Lens {
         enum Projection {

--- a/shared/message/input/MotionCapture.proto
+++ b/shared/message/input/MotionCapture.proto
@@ -23,6 +23,9 @@ package message.input;
 
 import "Vector.proto";
 
+/**
+ * Contains Marker, Rigidbody, and message metadata information.
+ */
 message MotionCapture {
     message Marker {
         uint32 id       = 1;

--- a/shared/message/input/Sensors.proto
+++ b/shared/message/input/Sensors.proto
@@ -26,6 +26,9 @@ import "Matrix.proto";
 import "Neutron.proto";
 import "Vector.proto";
 
+/**
+ * Contains all sensor information for all sensors.
+ */
 message Sensors {
 
     message Servo {

--- a/shared/message/localisation/Ball.proto
+++ b/shared/message/localisation/Ball.proto
@@ -23,6 +23,9 @@ package message.localisation;
 import "Vector.proto";
 import "Matrix.proto";
 
+/**
+ * Contains ball position and position covariance.
+ */
 message Ball {
     // The ball measured in world space (rBWw)
     vec2 position = 1;

--- a/shared/message/localisation/Field.proto
+++ b/shared/message/localisation/Field.proto
@@ -23,6 +23,9 @@ package message.localisation;
 import "Vector.proto";
 import "Matrix.proto";
 
+/**
+ * Contains field position and position covariance.
+ */
 message Field {
     // Measures the position of the field centre in world space position[0,1] = (rFWw)
     // and measures the orientation of the field from the world position[2] = (thetafw)

--- a/shared/message/localisation/ResetRobotHypotheses.proto
+++ b/shared/message/localisation/ResetRobotHypotheses.proto
@@ -23,6 +23,9 @@ package message.localisation;
 import "Matrix.proto";
 import "Vector.proto";
 
+/**
+ * Contains the robot's position hypotheses.
+ */
 message ResetRobotHypotheses {
     message Self {
         vec2   position     = 1;

--- a/shared/message/motion/FootTarget.proto
+++ b/shared/message/motion/FootTarget.proto
@@ -23,6 +23,9 @@ package message.motion;
 import "Matrix.proto";
 import "google/protobuf/timestamp.proto";
 
+/**
+ * Target position for foot, with timestamp.
+ */
 message FootTarget {
 
     google.protobuf.Timestamp timestamp = 1;

--- a/shared/message/motion/GetupCommand.proto
+++ b/shared/message/motion/GetupCommand.proto
@@ -20,5 +20,12 @@ syntax = "proto3";
 
 package message.motion;
 
+/**
+ * Empty message asking to execute getup.
+ */
 message ExecuteGetup {}
+
+/**
+ * Empty message asking to stop getup.
+ */
 message KillGetup {}

--- a/shared/message/motion/HeadCommand.proto
+++ b/shared/message/motion/HeadCommand.proto
@@ -33,6 +33,9 @@ message HeadCommand {
     bool  robotSpace = 3;  // if true, the yaw and pitch are interpreted in robot space, instead of IMU space
 }
 
+/**
+ * Empty message, not implemented
+ */
 message HeadMotionUpdate {
     // TODO...
 }

--- a/shared/message/motion/KickCommand.proto
+++ b/shared/message/motion/KickCommand.proto
@@ -33,23 +33,27 @@ enum KickCommandType {
     POWER  = 1;
 }
 
+/**
+ * Contains kick target, direction, and magnitude.
+ */
 message KickCommand {
     vec3            target          = 1;  // The point to kick
     vec3            direction       = 2;  // force is the magnitude
     KickCommandType kickCommandType = 3;
 }
 
+
 /**
- * TODO document
- *
- * @author Trent Houliston
- * @author Brendan Annable
+ * Contains kick direction and which leg to kick with.
  */
 message KickScriptCommand {
     vec3   direction = 1;  // Direction to kick with magnitude determining force
     uint32 leg       = 2;  // Leg to kick with
 }
 
+/**
+ * Contains config info for kick planner.
+ */
 message KickPlannerConfig {
     float max_ball_distance        = 1;
     float kick_corridor_width      = 2;
@@ -57,8 +61,14 @@ message KickPlannerConfig {
     float kick_forward_angle_limit = 4;
 }
 
+/**
+ * Empty message which indicates a kick is finished.
+ */
 message KickFinished {}
 
+/**
+ * Contains stand heigh for IK kick.
+ */
 message IKKickParams {
     float stand_height = 1;
 }

--- a/shared/message/motion/KickCommand.proto
+++ b/shared/message/motion/KickCommand.proto
@@ -67,7 +67,7 @@ message KickPlannerConfig {
 message KickFinished {}
 
 /**
- * Contains stand heigh for IK kick.
+ * Contains stand height for IK kick.
  */
 message IKKickParams {
     float stand_height = 1;

--- a/shared/message/motion/KickCommand.proto
+++ b/shared/message/motion/KickCommand.proto
@@ -23,10 +23,7 @@ package message.motion;
 import "Vector.proto";
 
 /**
- * TODO document
- *
- * @author Trent Houliston
- * @author Brendan Annable
+ * Type is NORMAL or POWER (disregard robot safety and smash it).
  */
 enum KickCommandType {
     NORMAL = 0;

--- a/shared/message/motion/KinematicsModel.proto
+++ b/shared/message/motion/KinematicsModel.proto
@@ -23,11 +23,17 @@ package message.motion;
 import "Vector.proto";
 import "Matrix.proto";
 
+/**
+ * enum which is LEFT or RIGHT.
+ */
 enum BodySide {
     LEFT  = 0;
     RIGHT = 1;
 }
 
+/**
+ * Contains lots of kinematics measurements and transforms.
+ */
 message KinematicsModel {
     // Convention: all values positive
     message Leg {

--- a/shared/message/motion/ServoTarget.proto
+++ b/shared/message/motion/ServoTarget.proto
@@ -22,10 +22,9 @@ package message.motion;
 
 import "google/protobuf/timestamp.proto";
 
+
 /**
- * TODO document
- *
- * @author Trent Houliston
+ * Contains details of a servo's state objective.
  */
 message ServoTarget {
     google.protobuf.Timestamp time     = 1;
@@ -35,6 +34,9 @@ message ServoTarget {
     float                     torque   = 5;
 }
 
+/**
+ * Contains a set of ServoTargets.
+ */
 message ServoTargets {
     repeated ServoTarget targets = 1;
 }

--- a/shared/message/motion/WalkCommand.proto
+++ b/shared/message/motion/WalkCommand.proto
@@ -22,26 +22,48 @@ package message.motion;
 
 import "Vector.proto";
 
+/**
+ * Empty message to indicate walk has begun.
+ */
 message WalkStarted {}
+
+/**
+ * Empty message to indicate walk has stopped.
+ */
 message WalkStopped {}
 
+/**
+ * Contains subsumption id and {x, y, radians} command vector.
+ */
 message WalkCommand {
     uint64 subsumptionId = 1;  // reservation identifier for servo control
     vec3   command       = 2;  // x and y are velocity in m/s and angle is in rads/s
 }
 
+/**
+ * Contains subsumption id to be stopped.
+ */
 message StopCommand {
     uint64 subsumptionId = 1;  // reservation identifier for servo control
 }
 
+/**
+ * Is a velocity target vector.
+ */
 message NewWalkCommand {
     vec3 velocityTarget = 1;
 }
 
+/**
+ * Contains subsumption id to be enabled.
+ */
 message EnableWalkEngineCommand {
     uint64 subsumptionId = 1;  // reservation identifier for servo control
 }
 
+/**
+ * Contains subsumption id to be disabled.
+ */
 message DisableWalkEngineCommand {
     uint64 subsumptionId = 1;  // reservation identifier for servo control
 }

--- a/shared/message/output/CompressedImage.proto
+++ b/shared/message/output/CompressedImage.proto
@@ -25,6 +25,9 @@ import "google/protobuf/timestamp.proto";
 import "Matrix.proto";
 import "Vector.proto";
 
+/**
+ * Contains lens and image output information.
+ */
 message CompressedImage {
     message Lens {
         enum Projection {

--- a/shared/message/output/Say.proto
+++ b/shared/message/output/Say.proto
@@ -21,9 +21,7 @@ syntax = "proto3";
 package message.output;
 
 /**
- * TODO document
- *
- * @author Trent Houliston
+ * Is a string for the robot to say.
  */
 message Say {
     string message = 1;

--- a/shared/message/platform/darwin/DarwinSensors.proto
+++ b/shared/message/platform/darwin/DarwinSensors.proto
@@ -22,10 +22,9 @@ package message.platform.darwin;
 
 import "google/protobuf/timestamp.proto";
 
+
 /**
- * TODO document
- *
- * @author Trent Houliston
+ * Contains all of the sensor and servo information.
  */
 message DarwinSensors {
     // bitmask values
@@ -143,7 +142,23 @@ message DarwinSensors {
 }
 
 // Button press events
+
+/**
+ * Empty message to indicate button press.
+ */
 message ButtonLeftDown {}
+
+/**
+ * Empty message to indicate button press.
+ */
 message ButtonLeftUp {}
+
+/**
+ * Empty message to indicate button press.
+ */
 message ButtonMiddleDown {}
+
+/**
+ * Empty message to indicate button press.
+ */
 message ButtonMiddleUp {}

--- a/shared/message/platform/gazebo/Ball.proto
+++ b/shared/message/platform/gazebo/Ball.proto
@@ -22,6 +22,9 @@ package message.platform.gazebo;
 
 import "Vector.proto";
 
+/**
+ * Contains ball position and velocity.
+ */
 message Ball {
     // Vector from world origin to ball in world space
     vec3 rBWw = 1;

--- a/shared/message/platform/gazebo/Command.proto
+++ b/shared/message/platform/gazebo/Command.proto
@@ -20,6 +20,9 @@ syntax = "proto3";
 
 package message.platform.gazebo;
 
+/**
+ * Command to reset time, or entire simulation.
+ */
 message Command {
     enum Type {
         RESET      = 0;  // Reset the entire simulation

--- a/shared/message/platform/gazebo/RawSensors.proto
+++ b/shared/message/platform/gazebo/RawSensors.proto
@@ -22,6 +22,9 @@ package message.platform.gazebo;
 
 import "message/platform/darwin/DarwinSensors.proto";
 
+/**
+ * A set of DarwinSensors with an associated model.
+ */
 message RawSensors {
     // The name of the model in the simulation that these sensors are from
     string model = 1;

--- a/shared/message/platform/gazebo/ServoTargets.proto
+++ b/shared/message/platform/gazebo/ServoTargets.proto
@@ -23,6 +23,9 @@ package message.platform.gazebo;
 import "google/protobuf/timestamp.proto";
 import "message/motion/ServoTarget.proto";
 
+/**
+ * Servo targets, the model they are for and a timestamp.
+ */
 message ServoTargets {
     // The name of the model in the simulation that these servo targets are for
     string model = 1;

--- a/shared/message/platform/gazebo/Simulation.proto
+++ b/shared/message/platform/gazebo/Simulation.proto
@@ -20,6 +20,9 @@ syntax = "proto3";
 
 package message.platform.gazebo;
 
+/**
+ * Time which has passed in the simulation and time passed IRL.
+ */
 message Simulation {
     // The amount of time that has passed in the simulation
     double simulation_time = 1;

--- a/shared/message/platform/gazebo/Torso.proto
+++ b/shared/message/platform/gazebo/Torso.proto
@@ -23,6 +23,9 @@ package message.platform.gazebo;
 import "Matrix.proto";
 import "Vector.proto";
 
+/**
+ * Contains torso transforms and velocities.
+ */
 message Torso {
     // The name of the model in the simulation that this position is for
     string model = 1;

--- a/shared/message/support/FieldDescription.proto
+++ b/shared/message/support/FieldDescription.proto
@@ -22,6 +22,9 @@ package message.support;
 
 import "Vector.proto";
 
+/**
+ * Information about location and size of field objects and markers.
+ */
 message FieldDescription {
     enum GoalpostType {
         RECTANGLE = 0;

--- a/shared/message/support/GlobalConfig.proto
+++ b/shared/message/support/GlobalConfig.proto
@@ -20,7 +20,9 @@ syntax = "proto3";
 
 package message.support;
 
-// Field dimensions as defined in the Robocup rules:
+/**
+ * Field dimensions as defined in the Robocup rules.
+ */
 message GlobalConfig {
     uint32 playerId = 1;
     uint32 teamId   = 2;

--- a/shared/message/support/SaveConfiguration.proto
+++ b/shared/message/support/SaveConfiguration.proto
@@ -20,6 +20,9 @@ syntax = "proto3";
 
 package message.support;
 
+/**
+ * Contains config file to save, and the path.
+ */
 message SaveConfiguration {
     string path   = 1;
     string config = 2;

--- a/shared/message/support/nuclear/ReactionStatistics.proto
+++ b/shared/message/support/nuclear/ReactionStatistics.proto
@@ -21,6 +21,9 @@ syntax = "proto3";
 
 package message.support.nuclear;
 
+/**
+ * Contains reaction metadata.
+ */
 message ReactionStatistics {
     string name            = 1;
     string triggerName     = 2;

--- a/shared/message/support/nusight/Command.proto
+++ b/shared/message/support/nusight/Command.proto
@@ -21,6 +21,9 @@ syntax = "proto3";
 
 package message.support.nusight;
 
+/**
+ * Command string.
+ */
 message Command {
     string command = 1;
 }

--- a/shared/message/support/nusight/DataPoint.proto
+++ b/shared/message/support/nusight/DataPoint.proto
@@ -23,6 +23,9 @@ package message.support.nusight;
 
 import "google/protobuf/timestamp.proto";
 
+/**
+ * Contains labels, values, and a timestamp.
+ */
 message DataPoint {
     string                    label     = 1;
     repeated float            value     = 2 [packed = true];

--- a/shared/message/support/nusight/Overview.proto
+++ b/shared/message/support/nusight/Overview.proto
@@ -27,6 +27,9 @@ import "message/input/GameState.proto";
 import "Vector.proto";
 import "Matrix.proto";
 
+/**
+ * Contains almost everything NUsight related.
+ */
 message Overview {
 
     // The timestamp this overview packet was sent

--- a/shared/message/vision/Ball.proto
+++ b/shared/message/vision/Ball.proto
@@ -26,6 +26,9 @@ import "Vector.proto";
 import "message/Geometry.proto";
 import "Matrix.proto";
 
+/**
+ * Contains ball measurement details.
+ */
 message Ball {
     enum MeasurementType {
         UNKNOWN      = 0;
@@ -45,6 +48,9 @@ message Ball {
     fvec4                colour         = 5;
 }
 
+/**
+ * Sets of ball measurements, with timestamps, camera id's, and Hcw transforms.
+ */
 message Balls {
     uint32                    camera_id = 1;
     google.protobuf.Timestamp timestamp = 2;

--- a/shared/message/vision/Goal.proto
+++ b/shared/message/vision/Goal.proto
@@ -25,6 +25,9 @@ import "google/protobuf/timestamp.proto";
 import "Vector.proto";
 import "Matrix.proto";
 
+/**
+ * Goal position measurements and information.
+ */
 message Goal {
     enum Side {
         UNKNOWN_SIDE = 0;
@@ -63,6 +66,9 @@ message Goal {
     Team                 team           = 7;
 }
 
+/**
+ * Set of Goals measurements, with timestamps, camera ids, and Hcw transforms.
+ */
 message Goals {
     uint32                    camera_id = 1;
     google.protobuf.Timestamp timestamp = 2;

--- a/shared/message/vision/GreenHorizon.proto
+++ b/shared/message/vision/GreenHorizon.proto
@@ -28,6 +28,9 @@ import "Vector.proto";
 
 import "message/vision/VisualMesh.proto";
 
+/**
+ * Contains green horizon measurement details.
+ */
 message GreenHorizon {
     repeated fvec3            horizon   = 1;
     mat4                      Hcw       = 2;

--- a/shared/message/vision/Line.proto
+++ b/shared/message/vision/Line.proto
@@ -24,6 +24,9 @@ package message.vision;
 import "google/protobuf/timestamp.proto";
 import "Vector.proto";
 
+/**
+ * Contains line position measurements and information.
+ */
 message Line {
     uint32                    camera_id = 1;
     google.protobuf.Timestamp timestamp = 2;
@@ -32,6 +35,9 @@ message Line {
     vec4                      colour    = 5;
 }
 
+/**
+ * Set of line measurements.
+ */
 message Lines {
     repeated Line lines = 1;
 }

--- a/shared/message/vision/Obstacle.proto
+++ b/shared/message/vision/Obstacle.proto
@@ -24,6 +24,9 @@ package message.vision;
 import "google/protobuf/timestamp.proto";
 import "message/Geometry.proto";
 
+/**
+ * Contains details of an obstacle.
+ */
 message Obstacle {
     enum Team {
         UNKNOWN_TEAM = 0;
@@ -37,6 +40,9 @@ message Obstacle {
     Team                      team      = 4;
 }
 
+/**
+ * A set of Obstacles.
+ */
 message Obstacles {
     repeated Obstacle lines = 1;
 }

--- a/shared/message/vision/VisualMesh.proto
+++ b/shared/message/vision/VisualMesh.proto
@@ -24,6 +24,9 @@ package message.vision;
 import "google/protobuf/timestamp.proto";
 import "Matrix.proto";
 
+/**
+ * Contains the details of a Visual Mesh (tm) measurement.
+ */
 message VisualMesh {
     message Row {
         float phi      = 1;


### PR DESCRIPTION
Mission is to add brief descriptions to the proto messages, ready for the upcoming NUbots docu-lution.
Descriptions I didn't write:
~`SoccerObjectPriority.proto` has one message, which I have no idea how to describe.~
`Subsumption.proto` has one message and I am not sure about what it really does.
~`KickCommand.proto` has one `enum` `KickCommandType`, and I don't know what it means for a kick to be `NORMAL` vs `POWER` (also, we don't ever seem to do `POWER` kicks?)~

@TrentHouliston suggested I add descriptions to some of the nested objects. I have done this for `Behaviour.proto`, `FieldTarget.proto`, `FixedWalkCommand.proto`, `KickPlan.proto` so far. Was this along the lines you were thinking?
