### PR TITLE
Fix Docker mount error in WSL 2

### DIFF
--- a/tools/dockerise/__init__.py
+++ b/tools/dockerise/__init__.py
@@ -23,6 +23,7 @@ def is_docker():
     path = "/proc/self/cgroup"
     return os.path.exists("/.dockerenv") or os.path.isfile(path) and any("docker" in line for line in open(path))
 
+
 def is_wsl1():
     if shutil.which("wslpath") is None:
         return False
@@ -37,6 +38,7 @@ def is_wsl1():
 
     # WSL 2 has kernel release version >= 4.19 (https://askubuntu.com/a/1177730)
     return int(major) <= 4 and int(minor) < 19
+
 
 def build_platform(platform):
     pty = WrapPty()

--- a/tools/dockerise/__init__.py
+++ b/tools/dockerise/__init__.py
@@ -35,7 +35,8 @@ def is_wsl1():
     if major is None or minor is None:
         return False
 
-    return int(major) <= 4 and int(minor) < 19 # WSL 2 has kernel release version >= 4.19
+    # WSL 2 has kernel release version >= 4.19 (https://askubuntu.com/a/1177730)
+    return int(major) <= 4 and int(minor) < 19
 
 def build_platform(platform):
     pty = WrapPty()

--- a/tools/dockerise/__init__.py
+++ b/tools/dockerise/__init__.py
@@ -217,7 +217,7 @@ def run_on_docker(func):
 
                 # If we are running in WSL 1 we need to translate our path to a windows one for docker.
                 # Docker with WSL 2 doesn't need this as it supports binding paths directly from WSL into a container.
-                if (is_wsl1()):
+                if is_wsl1():
                     bind_path = subprocess.check_output(["wslpath", "-m", b.project_dir])[:-1].decode("utf-8")
 
                 pty = WrapPty()

--- a/tools/dockerise/__init__.py
+++ b/tools/dockerise/__init__.py
@@ -23,6 +23,19 @@ def is_docker():
     path = "/proc/self/cgroup"
     return os.path.exists("/.dockerenv") or os.path.isfile(path) and any("docker" in line for line in open(path))
 
+def is_wsl1():
+    if shutil.which("wslpath") is None:
+        return False
+
+    kernel_release = strip(subprocess.check_output(["uname", "-r"]).decode("utf-8"))
+    search = re.search("^(\d+)\.(\d+)\.\d+", kernel_release)
+    major = search.group(1)
+    minor = search.group(2)
+
+    if major is None or minor is None:
+        return False
+
+    return int(major) <= 4 and int(minor) < 19 # WSL 2 has kernel release version >= 4.19
 
 def build_platform(platform):
     pty = WrapPty()
@@ -199,12 +212,12 @@ def run_on_docker(func):
                 code_to_cwd = os.path.relpath(os.getcwd(), b.project_dir)
                 cwd_to_code = os.path.relpath(b.project_dir, os.getcwd())
 
-                # If we are running in WSL we need to translate our path to a windows one for docker
-                bind_path = (
-                    b.project_dir
-                    if shutil.which("wslpath") is None
-                    else subprocess.check_output(["wslpath", "-m", b.project_dir])[:-1].decode("utf-8")
-                )
+                bind_path = b.project_dir
+
+                # If we are running in WSL 1 we need to translate our path to a windows one for docker.
+                # Docker with WSL 2 doesn't need this as it supports binding paths directly from WSL into a container.
+                if (is_wsl1()):
+                    bind_path = subprocess.check_output(["wslpath", "-m", b.project_dir])[:-1].decode("utf-8")
 
                 pty = WrapPty()
                 exit(

--- a/tools/dockerise/__init__.py
+++ b/tools/dockerise/__init__.py
@@ -27,7 +27,7 @@ def is_wsl1():
     if shutil.which("wslpath") is None:
         return False
 
-    kernel_release = strip(subprocess.check_output(["uname", "-r"]).decode("utf-8"))
+    kernel_release = subprocess.check_output(["uname", "-r"]).decode("utf-8").strip()
     search = re.search("^(\d+)\.(\d+)\.\d+", kernel_release)
     major = search.group(1)
     minor = search.group(2)


### PR DESCRIPTION
The current `run_in_docker()` implementation detects if it's running in WSL and translates the source bind path to a WSL path. This doesn't works in WSL 2, and causes the mount to fail; leading to this error when running the `b` script:

```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"./b\": stat ./b: no such file or directory": unknown.
```

This PR ensures that the path translation is done only in WSL 1.