### PR TITLE
Make dockerise copy over the current users UID to avoid permissions errors

### DIFF
--- a/tools/dockerise/__init__.py
+++ b/tools/dockerise/__init__.py
@@ -74,6 +74,8 @@ def build_platform(platform):
             "BUILDKIT_INLINE_CACHE=1",
             "--build-arg",
             "platform={}".format(platform if platform != "buildkit" else "generic"),
+            "--build-arg",
+            "user_uid={}".format(os.getuid()),
             "-t",
             local_tag,
         ],


### PR DESCRIPTION
Currently, if you are not the first user on your computer (your UID is not 1000) then when you run in your docker image you'll get permissions errors. This sets the user id to the same as your current user when generating images.