### PR TITLE
Allow passing container network as arg to `./b run`

### DIFF
--- a/tools/dockerise/__init__.py
+++ b/tools/dockerise/__init__.py
@@ -148,9 +148,7 @@ def run_on_docker(func):
                 nargs="?",
                 help="The image to use for the docker container",
             )
-            command.add_argument(
-                "--network", dest="network", help="Run the container on the specified docker network"
-            )
+            command.add_argument("--network", dest="network", help="Run the container on the specified docker network")
 
             func(command)
 

--- a/tools/dockerise/__init__.py
+++ b/tools/dockerise/__init__.py
@@ -148,6 +148,9 @@ def run_on_docker(func):
                 nargs="?",
                 help="The image to use for the docker container",
             )
+            command.add_argument(
+                "--network", dest="network", help="Run the container on the specified docker network"
+            )
 
             func(command)
 
@@ -155,7 +158,7 @@ def run_on_docker(func):
 
     elif func.__name__ == "run":
 
-        def run(rebuild, clean, platform, **kwargs):
+        def run(rebuild, clean, platform, network, **kwargs):
             # If we are running in docker, then execute the command as normal
             if is_docker():
                 func(rebuild=rebuild, clean=clean, platform=platform, **kwargs)
@@ -246,7 +249,7 @@ def run_on_docker(func):
                             "--hostname",
                             "docker",
                             "--network",
-                            "host",
+                            network or "host",
                             "--mount",
                             "type=bind,source={},target=/home/{}/{},consistency=cached".format(
                                 bind_path, user, directory


### PR DESCRIPTION
Pairs with https://github.com/NUbots/NUsight2/pull/335.

This allows for connecting the container to a custom docker network, for communication with NUsight when it's run in a container.

A custom network for the containers can be created like so:

```sh
docker network create nuclearnet
```

And usage of `./b run` can be adjusted like so:

```sh
./b run keyboardwalkfake --network nuclearnet
```

This is the only way to get the two to talk on Windows when NUbots is running in a container: run NUsight in a container too, and connect both containers to the same Docker network.

The other options:

- `host` networking (the current default): [not available on Windows](https://docs.docker.com/network/network-tutorial-host/#prerequisites), though it works on Linux ~(and probably macOS too)~
- `bridge` networking: [also doesn't work on Windows](https://docs.docker.com/docker-for-windows/networking/#there-is-no-docker0-bridge-on-windows)