### PR TITLE
Removes cmake configuration warning.

### DIFF
--- a/cmake/Modules/FindLibGFortran.cmake
+++ b/cmake/Modules/FindLibGFortran.cmake
@@ -45,7 +45,7 @@ else(LIBGFORTRAN_LIBRARIES)
   endif(GFORTRAN_LIBRARY AND QUADMATH_LIBRARY)
 
   include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(LIBGFORTRAN DEFAULT_MSG GFORTRAN_LIBRARY QUADMATH_LIBRARY)
+  find_package_handle_standard_args(LibGFortran DEFAULT_MSG GFORTRAN_LIBRARY QUADMATH_LIBRARY)
 
   # show the LIBGFORTRAN_LIBRARIES variables only in the advanced view
   mark_as_advanced(LIBGFORTRAN_LIBRARIES GFORTRAN_LIBRARY QUADMATH_LIBRARY _GFORTRAN_EXECUTABLE)


### PR DESCRIPTION
One line change to remove this warning:
```
CMake Warning (dev) at /usr/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:426 (message):
  The package name passed to `find_package_handle_standard_args`
  (LIBGFORTRAN) does not match the name of the calling package (LibGFortran).
  This can lead to problems in calling code that expects `find_package`
  result variables (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/Modules/FindLibGFortran.cmake:48 (find_package_handle_standard_args)
  cmake/Modules/SharedLibraries.cmake:3 (find_package)
  CMakeLists.txt:26 (include)
```