### PR TITLE
Pins version of OpenCL to fix linker errors

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,7 +148,7 @@ RUN /usr/local/package/intel-compute-runtime.sh https://github.com/intel/compute
 
 # Install OpenCL C and C++ headers
 COPY usr/local/package/opencl-headers.sh /usr/local/package/opencl-headers.sh
-RUN /usr/local/package/opencl-headers.sh https://github.com/KhronosGroup/OpenCL-Headers/archive/master.tar.gz
+RUN /usr/local/package/opencl-headers.sh https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.12.18.tar.gz
 RUN install-from-source https://github.com/KhronosGroup/OpenCL-CLHPP/archive/master.tar.gz \
     -DOPENCL_INCLUDE_DIR=/usr/local/include/CL \
     -DOPENCL_LIB_DIR=/usr/local/lib \


### PR DESCRIPTION
Fixes linking errors when building `ocl-icd` a bit later.

Fix verfied by @JosephusPaye  - I am having certificate issues for github related domains when building packages after that one atm, so I haven't been able to build the full image myself.