### PR TITLE
Remove the name from the container

### DIFF
--- a/tools/dockerise/__init__.py
+++ b/tools/dockerise/__init__.py
@@ -236,8 +236,6 @@ def run_on_docker(func):
                             "--tty",
                             "--workdir",
                             "/home/{}/{}/{}".format(user, directory, code_to_cwd),
-                            "--name",
-                            "{}_{}".format(repository, platform),
                             "--attach",
                             "stdin",
                             "--attach",


### PR DESCRIPTION
Don't name the container, it means you can't run multiple ./b things at once (e.g. if you're in a ./b shell in one terminal you can't ./b build in another etc)