### PR TITLE
Removes `wget` from first arch install script

### DIFF
--- a/doc/ArchInstall/arch_install.sh
+++ b/doc/ArchInstall/arch_install.sh
@@ -36,8 +36,8 @@ pacstrap /mnt base linux linux-firmware
 genfstab -U /mnt >> /mnt/etc/fstab
 
 # Download install script into chroot drive
-wget https://raw.githubusercontent.com/NUbots/NUbots/master/doc/ArchInstall/arch-chroot_install.sh \
-    -O /mnt/arch-chroot_install.sh
+curl -L https://raw.githubusercontent.com/NUbots/NUbots/master/doc/ArchInstall/arch-chroot_install.sh \
+    -o /mnt/arch-chroot_install.sh
 chmod +x /mnt/arch-chroot_install.sh
 
 echo ""


### PR DESCRIPTION
wget has been removed from newer arch iso's, so we have to use curl for this instance. The NUbook arch flash guide will have to change too.