### PR TITLE
Fixes typo in ActionPriorities message name.

### DIFF
--- a/module/behaviour/Controller/src/Controller.cpp
+++ b/module/behaviour/Controller/src/Controller.cpp
@@ -29,7 +29,7 @@ namespace behaviour {
     using message::behaviour::ServoCommand;
     using message::motion::ServoTarget;
     using utility::behaviour::ActionKill;
-    using utility::behaviour::ActionPriorites;
+    using utility::behaviour::ActionPriorities;
     using utility::behaviour::ActionStart;
     using utility::behaviour::RegisterAction;
 
@@ -87,9 +87,9 @@ namespace behaviour {
             selectAction();
         });
 
-        on<Trigger<ActionPriorites>, Sync<Controller>, Priority::HIGH>().then(
+        on<Trigger<ActionPriorities>, Sync<Controller>, Priority::HIGH>().then(
             "Action Priority Update",
-            [this](const ActionPriorites& update) {
+            [this](const ActionPriorities& update) {
                 auto& request = requests[update.id];
 
                 // Find the largest priority

--- a/module/behaviour/planning/BezierWalkPathPlanner/src/BezierWalkPathPlanner.cpp
+++ b/module/behaviour/planning/BezierWalkPathPlanner/src/BezierWalkPathPlanner.cpp
@@ -56,7 +56,7 @@ namespace behaviour {
         using Self             = message::localisation::Self;
         using VisionBall       = message::vision::Ball;
 
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
         using LimbID  = utility::input::LimbID;
         using ServoID = utility::input::ServoID;
@@ -127,7 +127,7 @@ namespace behaviour {
                 std::unique_ptr<WalkCommand> command =
                     std::make_unique<WalkCommand>(subsumptionId, latestCommand.walkCommand);
                 emit(std::move(command));
-                emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {26, 11}}));
+                emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {26, 11}}));
             });
 
             on<Trigger<MotionCommand>, Sync<BezierWalkPathPlanner>>().then([this](const MotionCommand& cmd) {
@@ -150,7 +150,7 @@ namespace behaviour {
                             // log("Stand still motion command");
 
                             emit(std::make_unique<StopCommand>(subsumptionId));
-                            emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {26, 11}}));
+                            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {26, 11}}));
 
                             return;
                         }
@@ -161,7 +161,7 @@ namespace behaviour {
                             std::unique_ptr<WalkCommand> command =
                                 std::make_unique<WalkCommand>(subsumptionId, latestCommand.walkCommand);
                             emit(std::move(command));
-                            emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {26, 11}}));
+                            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {26, 11}}));
                         }
                         else {
                             // log("MotionCommand:", int(latestCommand.type));
@@ -353,7 +353,7 @@ namespace behaviour {
                                                               Transform2D({finalForwardSpeed, 0, angle}));
                             // command->command = Transform2D({bezXdash[1], bezYdash[1], angle});
                             emit(std::move(command));
-                            emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {26, 11}}));
+                            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {26, 11}}));
                         }
                     });
         }

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -68,7 +68,7 @@ namespace behaviour {
         using utility::math::matrix::Transform3D;
         using utility::nusight::graph;
 
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
 
         using message::motion::DisableWalkEngineCommand;
@@ -131,7 +131,7 @@ namespace behaviour {
                 }}));
 
             on<Trigger<WalkStopped>>().then([this] {
-                emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {0, 0}}));
+                emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {0, 0}}));
             });
 
             // on<Trigger<std::vector<Ball>>>().then([this]{
@@ -179,7 +179,7 @@ namespace behaviour {
 
 
                         emit(std::make_unique<StopCommand>(subsumptionId));
-                        // emit(std::make_unique<ActionPriorites>(ActionPriorites { subsumptionId, { 40, 11 }}));
+                        // emit(std::make_unique<ActionPriorities>(ActionPriorities { subsumptionId, { 40, 11 }}));
 
                         return;
                     }
@@ -188,7 +188,7 @@ namespace behaviour {
                         std::unique_ptr<WalkCommand> command =
                             std::make_unique<WalkCommand>(subsumptionId, latestCommand.walkCommand);
                         emit(std::move(command));
-                        emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {40, 11}}));
+                        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
                         return;
                     }
 
@@ -263,7 +263,7 @@ namespace behaviour {
                     command->command = convert(Transform2D({finalForwardSpeed, finalSideSpeed, angle}));
 
                     emit(std::move(command));
-                    emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {40, 11}}));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
                 });
 
             on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then([this](const MotionCommand& cmd) {

--- a/module/behaviour/skills/DirectWalkController/src/DirectWalkController.cpp
+++ b/module/behaviour/skills/DirectWalkController/src/DirectWalkController.cpp
@@ -43,7 +43,7 @@ namespace behaviour {
         using LimbID  = utility::input::LimbID;
         using ServoID = utility::input::ServoID;
 
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
 
         DirectWalkController::DirectWalkController(std::unique_ptr<NUClear::Environment> environment)
@@ -76,22 +76,22 @@ namespace behaviour {
 
             on<Trigger<MotionCommand>>().then([this](const MotionCommand& command) {
                 if (command.type == MotionCommand::Type::DirectCommand) {
-                    emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {26, 11}}));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {26, 11}}));
                     emit(std::move(std::make_unique<WalkCommand>(subsumptionId, command.walkCommand)));
                 }
                 else if (command.type == MotionCommand::Type::StandStill) {
-                    emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {26, 11}}));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {26, 11}}));
                     emit(std::move(std::make_unique<StopCommand>(subsumptionId)));
                 }
                 else {
-                    emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {0, 0}}));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {0, 0}}));
                 }
             });
 
             on<Trigger<WalkStopped>>().then([this] {
                 // TODO : Right now, this causes the walk engine to become unaware of positions and negatively impact
                 // servo positions...
-                // emit(std::make_unique<ActionPriorites>(ActionPriorites { subsumptionId, { 0, 0 }}));
+                // emit(std::make_unique<ActionPriorities>(ActionPriorities { subsumptionId, { 0, 0 }}));
             });
         }
     }  // namespace skills

--- a/module/behaviour/skills/FallingRelax/src/FallingRelax.cpp
+++ b/module/behaviour/skills/FallingRelax/src/FallingRelax.cpp
@@ -45,7 +45,7 @@ namespace behaviour {
 
         using message::input::Sensors;
 
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
         using LimbID  = utility::input::LimbID;
         using ServoID = utility::input::ServoID;
@@ -130,7 +130,7 @@ namespace behaviour {
         }
 
         void FallingRelax::updatePriority(const float& priority) {
-            emit(std::make_unique<ActionPriorites>(ActionPriorites{id, {priority}}));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{id, {priority}}));
         }
 
     }  // namespace skills

--- a/module/behaviour/skills/Getup/src/Getup.cpp
+++ b/module/behaviour/skills/Getup/src/Getup.cpp
@@ -42,7 +42,7 @@ namespace behaviour {
         using message::motion::ExecuteGetup;
         using message::motion::KillGetup;
 
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
         using LimbID  = utility::input::LimbID;
         using ServoID = utility::input::ServoID;
@@ -120,7 +120,7 @@ namespace behaviour {
         }
 
         void Getup::updatePriority(const float& priority) {
-            emit(std::make_unique<ActionPriorites>(ActionPriorites{id, {priority}}));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{id, {priority}}));
         }
 
     }  // namespace skills

--- a/module/behaviour/skills/GoalSaver/src/GoalSaver.cpp
+++ b/module/behaviour/skills/GoalSaver/src/GoalSaver.cpp
@@ -50,7 +50,7 @@ namespace behaviour {
 
         using LimbID  = utility::input::LimbID;
         using ServoID = utility::input::ServoID;
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
 
         GoalSaver::GoalSaver(std::unique_ptr<NUClear::Environment> environment)
@@ -101,7 +101,7 @@ namespace behaviour {
         }
 
         void GoalSaver::updatePriority(const float& priority) {
-            emit(std::make_unique<ActionPriorites>(ActionPriorites{id, {priority}}));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{id, {priority}}));
         }
 
         int GoalSaver::getDirectionalQuadrant(float x, float y) {

--- a/module/behaviour/skills/KickScript/src/KickScript.cpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.cpp
@@ -46,7 +46,7 @@ namespace behaviour {
         using message::motion::KickFinished;
         using message::motion::KickScriptCommand;
 
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
 
         KickScript::KickScript(std::unique_ptr<NUClear::Environment> environment)
@@ -156,7 +156,7 @@ namespace behaviour {
         }
 
         void KickScript::updatePriority(const float& priority) {
-            emit(std::make_unique<ActionPriorites>(ActionPriorites{id, {priority}}));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{id, {priority}}));
         }
 
         int KickScript::getDirectionalQuadrant(float x, float y) {

--- a/module/behaviour/skills/Nod/src/Nod.cpp
+++ b/module/behaviour/skills/Nod/src/Nod.cpp
@@ -42,7 +42,7 @@ namespace behaviour {
         using LimbID  = utility::input::LimbID;
         using ServoID = utility::input::ServoID;
 
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
 
         Nod::Nod(std::unique_ptr<NUClear::Environment> environment)
@@ -78,7 +78,7 @@ namespace behaviour {
         }
 
         void Nod::updatePriority(const float& priority) {
-            emit(std::make_unique<ActionPriorites>(ActionPriorites{id, {priority}}));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{id, {priority}}));
         }
     }  // namespace skills
 }  // namespace behaviour

--- a/module/behaviour/skills/WalkEngineStand/src/WalkEngineStand.cpp
+++ b/module/behaviour/skills/WalkEngineStand/src/WalkEngineStand.cpp
@@ -42,7 +42,7 @@ namespace behaviour {
         using message::motion::WalkCommand;
         using message::motion::WalkStopped;
 
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
 
         // internal only callback messages to start and stop our action

--- a/module/behaviour/skills/WalkPathFollower/src/WalkPathFollower.cpp
+++ b/module/behaviour/skills/WalkPathFollower/src/WalkPathFollower.cpp
@@ -55,7 +55,7 @@ namespace behaviour {
         using message::motion::StopCommand;
         using message::motion::WalkCommand;
 
-        using utility::behaviour::ActionPriorites;
+        using utility::behaviour::ActionPriorities;
         using utility::behaviour::RegisterAction;
 
         using LimbID  = utility::input::LimbID;
@@ -114,13 +114,13 @@ namespace behaviour {
                     followPathReaction.enable();
                     updatePathReaction.enable();
                     // Increase priority?
-                    emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {25, 10}}));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {25, 10}}));
                 }
                 else {
                     followPathReaction.disable();
                     updatePathReaction.disable();
                     // Decrease priority?
-                    emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {0, 0}}));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {0, 0}}));
                 }
             });
 

--- a/module/motion/IKKick/src/IKKick.cpp
+++ b/module/motion/IKKick/src/IKKick.cpp
@@ -56,7 +56,7 @@ namespace motion {
     using message::motion::KinematicsModel;
     using message::support::FieldDescription;
 
-    using utility::behaviour::ActionPriorites;
+    using utility::behaviour::ActionPriorities;
     using utility::behaviour::RegisterAction;
     using utility::math::matrix::Transform3D;
     using utility::motion::kinematics::calculateLegJoints;
@@ -259,7 +259,7 @@ namespace motion {
     }
 
     void IKKick::updatePriority(const float& priority) {
-        emit(std::make_unique<ActionPriorites>(ActionPriorites{subsumptionId, {priority}}));
+        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {priority}}));
     }
 
 

--- a/module/motion/OldWalkEngine/src/OldWalkEngine.cpp
+++ b/module/motion/OldWalkEngine/src/OldWalkEngine.cpp
@@ -458,7 +458,7 @@ namespace motion {
 
     void OldWalkEngine::stop() {
         state = State::STOPPED;
-        // emit(std::make_unique<ActionPriorites>(ActionPriorites { subsumptionId, {
+        // emit(std::make_unique<ActionPriorities>(ActionPriorities { subsumptionId, {
         // 0, 0 }})); // TODO: config
         log<NUClear::TRACE>("Walk Engine:: Stop request complete");
         emit(std::make_unique<WalkStopped>());

--- a/module/support/NUsight/src/Subsumption.cpp
+++ b/module/support/NUsight/src/Subsumption.cpp
@@ -30,7 +30,7 @@ namespace support {
     using message::behaviour::Subsumption;
 
     using utility::behaviour::ActionKill;
-    using utility::behaviour::ActionPriorites;
+    using utility::behaviour::ActionPriorities;
     using utility::behaviour::ActionStart;
     using utility::behaviour::RegisterAction;
     using utility::input::LimbID;
@@ -91,10 +91,10 @@ namespace support {
             emit<Scope::NETWORK>(subsumption, "nusight", true);
         }));
 
-        handles["subsumption"].push_back(on<Trigger<ActionPriorites>>().then([this](const ActionPriorites& action) {
+        handles["subsumption"].push_back(on<Trigger<ActionPriorities>>().then([this](const ActionPriorities& action) {
             auto subsumption = std::make_unique<Subsumption>();
 
-            Subsumption::ActionPriorites actionPriorityChange;
+            Subsumption::ActionPriorities actionPriorityChange;
             actionPriorityChange.id = action.id;
 
             Subsumption::ActionRegister actionRegister = actionRegisters.find(action.id)->second;

--- a/nusight2/src/shared/proto/message/behaviour/Subsumption.proto
+++ b/nusight2/src/shared/proto/message/behaviour/Subsumption.proto
@@ -46,12 +46,12 @@ message Subsumption {
         repeated uint32 limbs = 3;
     }
 
-    message ActionPriorites {
+    message ActionPriorities {
         uint32         id         = 1;
         repeated float priorities = 2;
     }
 
     repeated ActionRegister    action_register        = 1;
     repeated ActionStateChange action_state_change    = 2;
-    repeated ActionPriorites   action_priority_change = 3;
+    repeated ActionPriorities  action_priority_change = 3;
 }

--- a/shared/message/behaviour/Subsumption.proto
+++ b/shared/message/behaviour/Subsumption.proto
@@ -46,12 +46,12 @@ message Subsumption {
         repeated uint32 limbs = 3;
     }
 
-    message ActionPriorites {
+    message ActionPriorities {
         uint32         id         = 1;
         repeated float priorities = 2;
     }
 
     repeated ActionRegister    action_register        = 1;
     repeated ActionStateChange action_state_change    = 2;
-    repeated ActionPriorites   action_priority_change = 3;
+    repeated ActionPriorities  action_priority_change = 3;
 }

--- a/shared/utility/behaviour/Action.hpp
+++ b/shared/utility/behaviour/Action.hpp
@@ -43,7 +43,7 @@ namespace behaviour {
         std::function<void(std::set<ServoID>)> completed;
     };
 
-    struct ActionPriorites {
+    struct ActionPriorities {
         size_t id;
 
         std::vector<float> priorities;


### PR DESCRIPTION
The name of this message is typo'd in master. This PR corrects the typo.
It builds, which I think is sufficient to say that it doesn't break anything?