### PR TITLE
Turn on clang-tidy in the CI build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,7 +52,7 @@ steps:
 
   # Build generic target and test
   - label: "Build generic and Test"
-    command: "./b configure -- -DBUILD_TESTS=ON && ./b build && ./b tests run"
+    command: "./b configure -- -DBUILD_TESTS=ON -DCI_BUILD=ON && ./b build && ./b tests run"
     plugins:
       - docker-compose#v3.0.3:
           config: .buildkite/docker-compose.yml


### PR DESCRIPTION
This will enforce all the clang-tidy rules we have (so this won't merge yet)
Keep merging fixes into master until this PR has a green tick!