### PR TITLE
Cleans up calls which were .transformPoint(arma::vec3) in the arma era

### DIFF
--- a/module/behaviour/planning/KickPlanner/src/KickPlanner.cpp
+++ b/module/behaviour/planning/KickPlanner/src/KickPlanner.cpp
@@ -111,13 +111,12 @@ namespace module::behaviour::planning {
 
                 Eigen::Affine3d Htw(sensors.Htw);
                 Eigen::Vector3d ballPosition =
-                    (Htw * Eigen::Vector4d(ball.position.x(), ball.position.y(), fd.ball_radius, 1.0)).head<3>();
+                    (Htw * Eigen::Vector3d(ball.position.x(), ball.position.y(), fd.ball_radius));
 
                 // Transform target from field to torso space
-                Eigen::Affine3d Htf = Htw * Hfw.inverse();
-                Eigen::Vector3d kickTarget =
-                    (Htf * Eigen ::Vector4d(kickPlan.target.x(), kickPlan.target.y(), 0.0, 1.0)).head<3>();
-                float KickAngle = std::fabs(std::atan2(kickTarget.y(), kickTarget.x()));
+                Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+                Eigen::Vector3d kickTarget = Htf * Eigen ::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0.0);
+                float KickAngle            = std::fabs(std::atan2(kickTarget.y(), kickTarget.x()));
 
                 // log("KickPlan target global",kickPlan. target.transpose());
                 // log("Target of Kick", kickTarget.transpose());

--- a/module/behaviour/planning/KickPlanner/src/KickPlanner.cpp
+++ b/module/behaviour/planning/KickPlanner/src/KickPlanner.cpp
@@ -111,11 +111,11 @@ namespace module::behaviour::planning {
 
                 Eigen::Affine3d Htw(sensors.Htw);
                 Eigen::Vector3d ballPosition =
-                    (Htw * Eigen::Vector3d(ball.position.x(), ball.position.y(), fd.ball_radius));
+                    Htw * Eigen::Vector3d(ball.position.x(), ball.position.y(), fd.ball_radius);
 
                 // Transform target from field to torso space
                 Eigen::Affine3d Htf        = Htw * Hfw.inverse();
-                Eigen::Vector3d kickTarget = Htf * Eigen ::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0.0);
+                Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0.0);
                 float KickAngle            = std::fabs(std::atan2(kickTarget.y(), kickTarget.x()));
 
                 // log("KickPlan target global",kickPlan. target.transpose());

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -190,10 +190,9 @@ namespace module::behaviour::planning {
 
 
                 Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
-                rBWw                = timeSinceBallSeen < search_timeout ? rBWw_temp :  // Place last seen
+                rBWw     = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
                            Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
-                Eigen::Vector3d pos = (Htw * Eigen::Vector4d(rBWw.x(), rBWw.y(), rBWw.z(), 1.0)).head<3>();
-                position            = pos.head<2>();
+                position = (Htw * rBWw).head<2>();
 
                 // Hack Planner:
                 float headingChange = 0;
@@ -210,9 +209,8 @@ namespace module::behaviour::planning {
                                                      Eigen::Vector3d::UnitZ())
                                        .toRotationMatrix();
 
-                    Eigen::Affine3d Htf = Htw * Hfw.inverse();
-                    Eigen::Vector3d kickTarget =
-                        (Htf * Eigen::Vector4d(kickPlan.target.x(), kickPlan.target.y(), 0.0, 1.0)).head<3>();
+                    Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+                    Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
 
                     // //approach point:
                     Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();

--- a/module/localisation/BallLocalisation/src/BallModel.hpp
+++ b/module/localisation/BallLocalisation/src/BallModel.hpp
@@ -68,8 +68,8 @@ namespace module::localisation {
                                             const message::support::FieldDescription& field,
                                             const Eigen::Matrix<Scalar, 4, 4>& Hcw) const {
 
-            const Eigen::Matrix<Scalar, 4, 1> rBWw(state[PX], state[PY], field.ball_radius, 1.0);
-            const Eigen::Matrix<Scalar, 3, 1> rBCc_cart((Hcw * rBWw).template head<3>());
+            const Eigen::Matrix<Scalar, 3, 1> rBWw(state[PX], state[PY], field.ball_radius);
+            const Eigen::Matrix<Scalar, 3, 1> rBCc_cart(Eigen::Affine3d(Hcw) * rBWw);
             return cartesianToSpherical(rBCc_cart);
         }
 

--- a/module/localisation/RobotParticleLocalisation/src/RobotModel.hpp
+++ b/module/localisation/RobotParticleLocalisation/src/RobotModel.hpp
@@ -78,12 +78,11 @@ namespace module::localisation {
             return state;
         }
 
-        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> predict(
-            const StateVec& state,
-            const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& actual_position,
-            const Eigen::Matrix<Scalar, 4, 4>& Hcw,
-            const message::vision::Goal::MeasurementType& type,
-            const message::support::FieldDescription& fd) {
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> predict(const StateVec& state,
+                                                         const Eigen::Matrix<Scalar, 3, 1>& actual_position,
+                                                         const Eigen::Matrix<Scalar, 4, 4>& Hcw,
+                                                         const message::vision::Goal::MeasurementType& type,
+                                                         const message::support::FieldDescription& fd) {
 
             // Create a transform from the field state
             Eigen::Transform<Scalar, 3, Eigen::Affine> Hfw;
@@ -93,12 +92,7 @@ namespace module::localisation {
             const Eigen::Transform<Scalar, 3, Eigen::Affine> Hcf(Hcw * Hfw.inverse().matrix());
 
             if (type == Goal::MeasurementType::CENTRE) {
-                // rGCc = vector from camera to goal post expected position
-                const Eigen::Matrix<Scalar, 4, 1> rGCc_4(actual_position.x(),
-                                                         actual_position.y(),
-                                                         actual_position.z(),
-                                                         1);
-                const Eigen::Matrix<Scalar, 3, 1> rGCc((Hcf * rGCc_4).template head<3>());
+                const Eigen::Matrix<Scalar, 3, 1> rGCc(Hcf * actual_position);
                 return cartesianToSpherical(rGCc);
             }
 

--- a/module/motion/IKKick/src/IKKick.cpp
+++ b/module/motion/IKKick/src/IKKick.cpp
@@ -134,11 +134,8 @@ namespace module::motion {
 
                 Eigen::Affine3d Htg = Eigen::Affine3d(sensors.Hgt).inverse();
 
-                // Create the command target point object so we can transform it
-                Eigen::Vector4d commandTargetPoint(command.target.x(), command.target.y(), command.target.z(), 1);
-
                 // Put the ball position from vision into torso coordinates by transforming the command target point
-                Eigen::Vector3d targetTorso = (Htg * commandTargetPoint).head<3>();
+                Eigen::Vector3d targetTorso = Htg * commandTargetPoint;
 
                 // Put the ball position into support foot coordinates
                 Eigen::Vector3d targetSupportFoot = torsoPose * targetTorso;
@@ -146,7 +143,8 @@ namespace module::motion {
                 // Put the goal from vision into torso coordinates
                 Eigen::Vector3d directionTorso(Htg * command.direction);
 
-                // Put the goal into support foot coordinates
+                // Put the goal into support foot coordinates. Note that this transforms directionTorso as a vector,
+                // as opposed to transforming it as a point
                 Eigen::Vector3d directionSupportFoot = torsoPose.rotation() * directionTorso;
 
                 Eigen::Vector3d ballPosition = targetSupportFoot;


### PR DESCRIPTION
On reading the eigen docs ([see the "Affine transformations" heading on this page](https://eigen.tuxfamily.org/dox/group__TutorialGeometry.html)), I have realised that there's no need to append a `1` to transform 3D vectors as points with eigen's affine transforms. Doing that makes the code harder to read and follow, and does nothing.

This PR cleans up the instances where I did exactly that.