### PR TITLE
Adds NUsight's dependencies to the dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN install-package \
     ninja \
     cmake \
     meson \
-    nodejs \
+    nodejs-lts-fermium \
     npm \
     yarn \
     git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,9 @@ RUN install-package \
     ninja \
     cmake \
     meson \
+    nodejs \
+    npm \
+    yarn \
     git
 
 # Get python to look in /usr/local for packages


### PR DESCRIPTION
To run yarn and node stuff inside the container (as is done in `./b format`, for example), we need the node stuff