### PR TITLE
Revert arma purge

### DIFF
--- a/cmake/Modules/FindArmadillo.cmake
+++ b/cmake/Modules/FindArmadillo.cmake
@@ -1,0 +1,12 @@
+include(ToolchainLibraryFinder)
+
+# OpenBLAS for armadillo
+find_package(OpenBLAS REQUIRED)
+
+ToolchainLibraryFinder(
+  NAME Armadillo
+  HEADER armadillo
+  LIBRARY armadillo
+)
+
+target_link_libraries(Armadillo::Armadillo INTERFACE OpenBLAS::OpenBLAS)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -167,6 +167,14 @@ RUN install-package gcc-fortran
 COPY usr/local/package/openblas/${platform}.sh /usr/local/package/openblas.sh
 RUN /usr/local/package/openblas.sh https://github.com/xianyi/OpenBLAS/archive/v0.3.13.tar.gz
 
+# Armadillo
+COPY usr/local/package/armadillo/armadillo.sh /usr/local/package/armadillo.sh
+COPY usr/local/package/armadillo/config.hpp /usr/local/package/armadillo_config.hpp
+RUN /usr/local/package/armadillo.sh https://downloads.sourceforge.net/project/arma/armadillo-9.800.3.tar.xz \
+    /usr/local/package/armadillo_config.hpp \
+    -DDETECT_HDF5=OFF \
+    -DBUILD_SHARED_LIBS=ON
+
 # Eigen3
 COPY usr/local/package/eigen3/deprecated-copy.patch /usr/local/package/deprecated-copy.patch
 COPY usr/local/package/eigen3/cxx17-overalign.patch /usr/local/package/cxx17-overalign.patch

--- a/docker/usr/local/package/armadillo/armadillo.sh
+++ b/docker/usr/local/package/armadillo/armadillo.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Exit immediately on error
+set -e
+
+# Get our method as the name of this script and the url
+METHOD=$(basename "$0")
+URL="$1"
+shift
+CONFIG_PATH="$1"
+shift
+
+# Set installation prefix, default to /usr/local unless an external power says otherwise
+PREFIX=${PREFIX:-"/usr/local"}
+
+BUILD_FOLDER="/var/tmp/build"
+
+# Pull in the toolchain arguments
+. "${PREFIX}/toolchain.sh"
+
+# Setup the temporary build directories
+mkdir -p "${BUILD_FOLDER}"
+cd "${BUILD_FOLDER}"
+
+# Download the source code and extract it
+download-and-extract "${URL}"
+
+echo "Configuring using cmake"
+
+# Find the closest configure file to the root
+CMAKELISTS_FILE=$(find -type f -path "*${BUILD_FILE_DIR}/CMakeLists.txt" -printf '%d\t%P\n' | sort -nk1 | cut -f2- | head -n 1)
+cd $(dirname "${CMAKELISTS_FILE}")
+
+echo "Configuring using cmake file ${CMAKELISTS_FILE}"
+
+# Do an out of source build
+mkdir -p build
+cd build
+
+# Configure using cmake
+cmake .. -GNinja \
+    "$@" \
+    -DCMAKE_BUILD_TYPE="Release" \
+    -DCMAKE_TOOLCHAIN_FILE="${PREFIX}/toolchain.cmake" \
+    -Wno-dev
+
+# Copy our config file over the generated one
+# The generated config file doesn't enable LAPACK because it's "too hard" to determine if
+# OpenBLAS has included LAPACK or not
+cp "${CONFIG_PATH}" "tmp/include/armadillo_bits/config.hpp"
+
+# Run ninja
+ninja
+
+# Run ninja install
+ninja install
+
+# Make sure our config file makes it into the install location
+cp "${CONFIG_PATH}" "${PREFIX}/include/armadillo_bits/config.hpp"
+
+# Now that we have built, cleanup the build directory
+rm -rf "${BUILD_FOLDER}"

--- a/docker/usr/local/package/armadillo/config.hpp
+++ b/docker/usr/local/package/armadillo/config.hpp
@@ -1,0 +1,296 @@
+// Copyright 2008-2016 Conrad Sanderson (http://conradsanderson.id.au)
+// Copyright 2008-2016 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+
+#if !defined(ARMA_USE_LAPACK)
+    #define ARMA_USE_LAPACK
+//// Comment out the above line if you don't have LAPACK or a high-speed replacement for LAPACK,
+//// such as Intel MKL, AMD ACML, or the Accelerate framework.
+//// LAPACK is required for matrix decompositions (eg. SVD) and matrix inverse.
+#endif
+
+#if !defined(ARMA_USE_BLAS)
+    #define ARMA_USE_BLAS
+//// Comment out the above line if you don't have BLAS or a high-speed replacement for BLAS,
+//// such as OpenBLAS, GotoBLAS, Intel MKL, AMD ACML, or the Accelerate framework.
+//// BLAS is used for matrix multiplication.
+//// Without BLAS, matrix multiplication will still work, but might be slower.
+#endif
+
+#if !defined(ARMA_USE_NEWARP)
+    #define ARMA_USE_NEWARP
+//// Uncomment the above line to enable the built-in partial emulation of ARPACK.
+//// This is used for eigen decompositions of real (non-complex) sparse matrices, eg. eigs_sym(), svds()
+#endif
+
+#if !defined(ARMA_USE_ARPACK)
+/* #undef ARMA_USE_ARPACK */
+//// Uncomment the above line if you have ARPACK or a high-speed replacement for ARPACK.
+//// ARPACK is required for eigen decompositions of complex sparse matrices
+#endif
+
+#if !defined(ARMA_USE_SUPERLU)
+/* #undef ARMA_USE_SUPERLU */
+//// Uncomment the above line if you have SuperLU.
+//// SuperLU is used for solving sparse linear systems via spsolve()
+//// Caveat: only SuperLU version 5.2 can be used!
+#endif
+
+#if !defined(ARMA_SUPERLU_INCLUDE_DIR)
+    #define ARMA_SUPERLU_INCLUDE_DIR /
+//// If you're using SuperLU and want to explicitly include the SuperLU headers,
+//// uncomment the above define and specify the appropriate include directory.
+//// Make sure the directory has a trailing /
+#endif
+
+#define ARMA_USE_WRAPPER
+//// Comment out the above line if you're getting linking errors when compiling your programs,
+//// or if you prefer to directly link with LAPACK, BLAS + etc instead of the Armadillo runtime library.
+//// You will then need to link your programs directly with -llapack -lblas instead of -larmadillo
+
+// #define ARMA_BLAS_CAPITALS
+//// Uncomment the above line if your BLAS and LAPACK libraries have capitalised function names (eg. ACML on 64-bit
+/// Windows)
+
+#define ARMA_BLAS_UNDERSCORE
+//// Uncomment the above line if your BLAS and LAPACK libraries have function names with a trailing underscore.
+//// Conversely, comment it out if the function names don't have a trailing underscore.
+
+// #define ARMA_BLAS_LONG
+//// Uncomment the above line if your BLAS and LAPACK libraries use "long" instead of "int"
+
+// #define ARMA_BLAS_LONG_LONG
+//// Uncomment the above line if your BLAS and LAPACK libraries use "long long" instead of "int"
+
+#define ARMA_USE_FORTRAN_HIDDEN_ARGS
+//// Comment out the above line to call BLAS and LAPACK functions without using so-called "hidden" arguments.
+//// Fortran functions (compiled without a BIND(C) declaration) that have char arguments
+//// (like many BLAS and LAPACK functions) also have associated "hidden" arguments.
+//// For each char argument, the corresponding "hidden" argument specifies the number of characters.
+//// These "hidden" arguments are typically tacked onto the end of function definitions.
+
+// #define ARMA_USE_TBB_ALLOC
+//// Uncomment the above line if you want to use Intel TBB scalable_malloc() and scalable_free() instead of standard
+/// malloc() and free()
+
+// #define ARMA_USE_MKL_ALLOC
+//// Uncomment the above line if you want to use Intel MKL mkl_malloc() and mkl_free() instead of standard malloc() and
+/// free()
+
+/* #undef ARMA_USE_ATLAS */
+#define ARMA_ATLAS_INCLUDE_DIR /
+//// If you're using ATLAS and the compiler can't find cblas.h and/or clapack.h
+//// uncomment the above define and specify the appropriate include directory.
+//// Make sure the directory has a trailing /
+
+#if !defined(ARMA_USE_CXX11)
+    #define ARMA_USE_CXX11
+//// Uncomment the above line to forcefully enable use of C++11 features (eg. initialiser lists).
+//// Note that ARMA_USE_CXX11 is automatically enabled when a C++11 compiler is detected.
+#endif
+
+#if !defined(ARMA_USE_OPENMP)
+// #define ARMA_USE_OPENMP
+//// Uncomment the above line to forcefully enable use of OpenMP for parallelisation.
+//// Note that ARMA_USE_OPENMP is automatically enabled when a compiler supporting OpenMP 3.1 is detected.
+#endif
+
+#if !defined(ARMA_64BIT_WORD)
+// #define ARMA_64BIT_WORD
+//// Uncomment the above line if you require matrices/vectors capable of holding more than 4 billion elements.
+//// Your machine and compiler must have support for 64 bit integers (eg. via "long" or "long long").
+//// Note that ARMA_64BIT_WORD is automatically enabled when a C++11 compiler is detected.
+#endif
+
+#if !defined(ARMA_USE_HDF5)
+// #define ARMA_USE_HDF5
+//// Uncomment the above line to allow the ability to save and load matrices stored in HDF5 format;
+//// the hdf5.h header file must be available on your system,
+//// and you will need to link with the hdf5 library (eg. -lhdf5)
+#endif
+
+#if !defined(ARMA_OPTIMISE_SOLVE_BAND)
+    #define ARMA_OPTIMISE_SOLVE_BAND
+//// Comment out the above line if you don't want optimised handling of band matrices by solve()
+#endif
+
+#if !defined(ARMA_OPTIMISE_SOLVE_SYMPD)
+    #define ARMA_OPTIMISE_SOLVE_SYMPD
+//// Comment out the above line if you don't want optimised handling of symmetric/hermitian positive definite matrices
+/// by solve()
+#endif
+
+/* #undef ARMA_USE_HDF5_ALT */
+#if defined(ARMA_USE_HDF5_ALT) && defined(ARMA_USE_WRAPPER)
+    #undef ARMA_USE_HDF5
+    #define ARMA_USE_HDF5
+
+    #define ARMA_HDF5_INCLUDE_DIR /
+#endif
+
+#if !defined(ARMA_MAT_PREALLOC)
+    #define ARMA_MAT_PREALLOC 16
+#endif
+//// This is the number of preallocated elements used by matrices and vectors;
+//// it must be an integer that is at least 1.
+//// If you mainly use lots of very small vectors (eg. <= 4 elements),
+//// change the number to the size of your vectors.
+
+#if !defined(ARMA_OPENMP_THRESHOLD)
+    #define ARMA_OPENMP_THRESHOLD 240
+#endif
+//// The minimum number of elements in a matrix to allow OpenMP based parallelisation;
+//// it must be an integer that is at least 1.
+
+#if !defined(ARMA_OPENMP_THREADS)
+    #define ARMA_OPENMP_THREADS 10
+#endif
+//// The maximum number of threads to use for OpenMP based parallelisation;
+//// it must be an integer that is at least 1.
+
+// #define ARMA_NO_DEBUG
+//// Uncomment the above line if you want to disable all run-time checks.
+//// This will result in faster code, but you first need to make sure that your code runs correctly!
+//// We strongly recommend to have the run-time checks enabled during development,
+//// as this greatly aids in finding mistakes in your code, and hence speeds up development.
+//// We recommend that run-time checks be disabled _only_ for the shipped version of your program.
+
+// #define ARMA_EXTRA_DEBUG
+//// Uncomment the above line if you want to see the function traces of how Armadillo evaluates expressions.
+//// This is mainly useful for debugging of the library.
+
+
+#if defined(ARMA_DEFAULT_OSTREAM)
+    #pragma message("WARNING: support for ARMA_DEFAULT_OSTREAM is deprecated and will be removed;")
+    #pragma message("WARNING: use ARMA_COUT_STREAM and ARMA_CERR_STREAM instead")
+#endif
+
+
+#if !defined(ARMA_COUT_STREAM)
+    #if defined(ARMA_DEFAULT_OSTREAM)
+        // for compatibility with earlier versions of Armadillo
+        #define ARMA_COUT_STREAM ARMA_DEFAULT_OSTREAM
+    #else
+        #define ARMA_COUT_STREAM std::cout
+    #endif
+#endif
+
+#if !defined(ARMA_CERR_STREAM)
+    #if defined(ARMA_DEFAULT_OSTREAM)
+        // for compatibility with earlier versions of Armadillo
+        #define ARMA_CERR_STREAM ARMA_DEFAULT_OSTREAM
+    #else
+        #define ARMA_CERR_STREAM std::cerr
+    #endif
+#endif
+
+
+#if !defined(ARMA_PRINT_ERRORS)
+    #define ARMA_PRINT_ERRORS
+//// Comment out the above line if you don't want errors and warnings printed (eg. failed decompositions)
+#endif
+
+#if !defined(ARMA_PRINT_HDF5_ERRORS)
+// #define ARMA_PRINT_HDF5_ERRORS
+#endif
+
+#if defined(ARMA_DONT_USE_LAPACK)
+    #undef ARMA_USE_LAPACK
+#endif
+
+#if defined(ARMA_DONT_USE_BLAS)
+    #undef ARMA_USE_BLAS
+#endif
+
+#if defined(ARMA_DONT_USE_NEWARP) || !defined(ARMA_USE_LAPACK)
+    #undef ARMA_USE_NEWARP
+#endif
+
+#if defined(ARMA_DONT_USE_ARPACK)
+    #undef ARMA_USE_ARPACK
+#endif
+
+#if defined(ARMA_DONT_USE_SUPERLU)
+    #undef ARMA_USE_SUPERLU
+    #undef ARMA_SUPERLU_INCLUDE_DIR
+#endif
+
+#if defined(ARMA_DONT_USE_ATLAS)
+    #undef ARMA_USE_ATLAS
+    #undef ARMA_ATLAS_INCLUDE_DIR
+#endif
+
+#if defined(ARMA_DONT_USE_WRAPPER)
+    #undef ARMA_USE_WRAPPER
+    #undef ARMA_USE_HDF5_ALT
+#endif
+
+#if defined(ARMA_DONT_USE_FORTRAN_HIDDEN_ARGS)
+    #undef ARMA_USE_FORTRAN_HIDDEN_ARGS
+#endif
+
+#if defined(ARMA_DONT_USE_CXX11)
+    #undef ARMA_USE_CXX11
+    #undef ARMA_USE_EXTERN_CXX11_RNG
+#endif
+
+#if defined(ARMA_DONT_USE_OPENMP)
+    #undef ARMA_USE_OPENMP
+#endif
+
+#if defined(ARMA_USE_WRAPPER)
+    #if defined(ARMA_USE_CXX11)
+        #if !defined(ARMA_USE_EXTERN_CXX11_RNG)
+            #define ARMA_USE_EXTERN_CXX11_RNG
+        #endif
+    #endif
+#endif
+
+#if defined(ARMA_DONT_USE_EXTERN_CXX11_RNG)
+    #undef ARMA_USE_EXTERN_CXX11_RNG
+#endif
+
+#if defined(ARMA_32BIT_WORD)
+    #undef ARMA_64BIT_WORD
+#endif
+
+#if defined(ARMA_DONT_USE_HDF5)
+    #undef ARMA_USE_HDF5
+    #undef ARMA_USE_HDF5_ALT
+#endif
+
+#if defined(ARMA_DONT_OPTIMISE_SOLVE_BAND)
+    #undef ARMA_OPTIMISE_SOLVE_BAND
+#endif
+
+#if defined(ARMA_DONT_OPTIMISE_SOLVE_SYMPD)
+    #undef ARMA_OPTIMISE_SOLVE_SYMPD
+#endif
+
+#if defined(ARMA_DONT_PRINT_ERRORS)
+    #undef ARMA_PRINT_ERRORS
+#endif
+
+#if defined(ARMA_DONT_PRINT_HDF5_ERRORS)
+    #undef ARMA_PRINT_HDF5_ERRORS
+#endif
+
+
+// if Armadillo was installed on this system via CMake and ARMA_USE_WRAPPER is not defined,
+// ARMA_AUX_LIBS lists the libraries required by Armadillo on this system, and
+// ARMA_AUX_INCDIRS lists the include directories required by Armadillo on this system.
+// Do not use these unless you know what you are doing.
+#define ARMA_AUX_LIBS "/usr/local/lib/libopenblas.so"
+#define ARMA_AUX_INCDIRS

--- a/module/behaviour/planning/KickPlanner/src/KickPlanner.cpp
+++ b/module/behaviour/planning/KickPlanner/src/KickPlanner.cpp
@@ -63,6 +63,7 @@ namespace module::behaviour::planning {
     using LimbID = utility::input::LimbID;
     using utility::localisation::fieldStateToTransform3D;
     using utility::math::coordinates::sphericalToCartesian;
+    using utility::motion::kinematics::legPoseValid;
     using utility::nusight::graph;
 
     KickPlanner::KickPlanner(std::unique_ptr<NUClear::Environment> environment)

--- a/module/behaviour/skills/HeadBehaviourSoccer/src/HeadBehaviourSoccer.cpp
+++ b/module/behaviour/skills/HeadBehaviourSoccer/src/HeadBehaviourSoccer.cpp
@@ -546,7 +546,7 @@ namespace module::behaviour::skills {
             return scaledResults;
         }
 
-        Quad<double, 2, 1> boundingBox = getScreenAngularBoundingBox(fixationObjects);
+        Quad<Eigen::Vector2d> boundingBox = getScreenAngularBoundingBox(fixationObjects);
 
         std::vector<Eigen::Vector2d> viewPoints;
         if (lens.fov == 0) {
@@ -609,7 +609,7 @@ namespace module::behaviour::skills {
             return scaledResults;
         }
 
-        Quad<double, 2, 1> boundingBox = getScreenAngularBoundingBox(fixationObjects);
+        Quad<Eigen::Vector2d> boundingBox = getScreenAngularBoundingBox(fixationObjects);
 
         std::vector<Eigen::Vector2d> viewPoints;
         if (lens.fov == 0) {
@@ -649,14 +649,14 @@ namespace module::behaviour::skills {
                 "HeadBehaviourSoccer::combineVisionBalls - Attempted to combine zero vision objects into one.");
             return Ball();
         }
-        Quad<double, 2, 1> q = getScreenAngularBoundingBox(ob);
-        Ball v               = ob.balls.at(0);
-        v.screen_angular     = q.getCentre().cast<float>();
-        v.angular_size       = q.getSize().cast<float>();
+        Quad<Eigen::Vector2d> q = getScreenAngularBoundingBox(ob);
+        Ball v                  = ob.balls.at(0);
+        v.screen_angular        = q.getCentre().cast<float>();
+        v.angular_size          = q.getSize().cast<float>();
         return v;
     }
 
-    Quad<double, 2, 1> HeadBehaviourSoccer::getScreenAngularBoundingBox(const Balls& ob) {
+    Quad<Eigen::Vector2d> HeadBehaviourSoccer::getScreenAngularBoundingBox(const Balls& ob) {
         std::vector<Eigen::Vector2d> boundingPoints;
         for (uint i = 0; i < ob.balls.size(); i++) {
             boundingPoints.push_back(
@@ -664,7 +664,7 @@ namespace module::behaviour::skills {
             boundingPoints.push_back(
                 (ob.balls.at(i).screen_angular - ob.balls.at(i).angular_size * 0.5).cast<double>());
         }
-        return Quad<double, 2, 1>::getBoundingBox(boundingPoints);
+        return Quad<Eigen::Vector2d>::getBoundingBox(boundingPoints);
     }
 
 
@@ -678,7 +678,7 @@ namespace module::behaviour::skills {
         return ob.goals.at(0);
     }
 
-    Quad<double, 2, 1> HeadBehaviourSoccer::getScreenAngularBoundingBox(const Goals& ob) {
+    Quad<Eigen::Vector2d> HeadBehaviourSoccer::getScreenAngularBoundingBox(const Goals& ob) {
         std::vector<Eigen::Vector2d> boundingPoints;
         for (uint i = 0; i < ob.goals.size(); i++) {
             boundingPoints.push_back(
@@ -686,7 +686,7 @@ namespace module::behaviour::skills {
             boundingPoints.push_back(
                 (ob.goals.at(i).screen_angular - ob.goals.at(i).angular_size * 0.5).cast<double>());
         }
-        return Quad<double, 2, 1>::getBoundingBox(boundingPoints);
+        return Quad<Eigen::Vector2d>::getBoundingBox(boundingPoints);
     }
 
     bool HeadBehaviourSoccer::orientationHasChanged(const message::input::Sensors& sensors) {

--- a/module/behaviour/skills/HeadBehaviourSoccer/src/HeadBehaviourSoccer.hpp
+++ b/module/behaviour/skills/HeadBehaviourSoccer/src/HeadBehaviourSoccer.hpp
@@ -20,6 +20,7 @@
 #ifndef MODULES_BEHAVIOUR_REFLEX_HEADBEHAVIOURSOCCER_HPP
 #define MODULES_BEHAVIOUR_REFLEX_HEADBEHAVIOURSOCCER_HPP
 
+#include <armadillo>
 #include <nuclear>
 #include <set>
 
@@ -95,8 +96,8 @@ namespace module::behaviour::skills {
 
         /*! @brief Gets a bounding box in screen angular space of a set of vision objects
          */
-        utility::math::geometry::Quad<double, 2, 1> getScreenAngularBoundingBox(const message::vision::Balls& obs);
-        utility::math::geometry::Quad<double, 2, 1> getScreenAngularBoundingBox(const message::vision::Goals& obs);
+        utility::math::geometry::Quad<Eigen::Vector2d> getScreenAngularBoundingBox(const message::vision::Balls& obs);
+        utility::math::geometry::Quad<Eigen::Vector2d> getScreenAngularBoundingBox(const message::vision::Goals& obs);
 
         bool orientationHasChanged(const message::input::Sensors& sensors);
 

--- a/module/localisation/BallLocalisation/src/BallLocalisation.hpp
+++ b/module/localisation/BallLocalisation/src/BallLocalisation.hpp
@@ -5,8 +5,8 @@
 
 #include "BallModel.hpp"
 
-#include "utility/math/filter/ParticleFilter.hpp"
-#include "utility/math/filter/UKF.hpp"
+#include "utility/math/filter/eigen/ParticleFilter.hpp"
+#include "utility/math/filter/eigen/UKF.hpp"
 
 namespace module::localisation {
 

--- a/module/localisation/RobotParticleLocalisation/src/RobotParticleLocalisation.hpp
+++ b/module/localisation/RobotParticleLocalisation/src/RobotParticleLocalisation.hpp
@@ -10,7 +10,7 @@
 #include "message/support/FieldDescription.hpp"
 #include "message/vision/Goal.hpp"
 
-#include "utility/math/filter/ParticleFilter.hpp"
+#include "utility/math/filter/eigen/ParticleFilter.hpp"
 
 namespace module::localisation {
 

--- a/module/motion/QuinticWalk/src/QuinticWalk.cpp
+++ b/module/motion/QuinticWalk/src/QuinticWalk.cpp
@@ -12,6 +12,7 @@
 
 #include "utility/math/comparison.hpp"
 #include "utility/math/euler.hpp"
+#include "utility/math/matrix/Transform3D.hpp"
 #include "utility/motion/InverseKinematics.hpp"
 #include "utility/support/yaml_expression.hpp"
 
@@ -32,6 +33,7 @@ namespace module::motion {
     using utility::support::Expression;
 
     using utility::input::ServoID;
+    using utility::math::matrix::Transform3D;
     using utility::motion::kinematics::calculateLegJoints;
 
     QuinticWalk::QuinticWalk(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
@@ -251,9 +253,8 @@ namespace module::motion {
         Eigen::Matrix4d right_foot =
             walk_engine.getFootstep().isLeftSupport() ? Hft.matrix().cast<double>() : Hst.matrix().cast<double>();
 
-        auto joints = calculateLegJoints(kinematicsModel,
-                                         Eigen::Affine3f(left_foot.cast<float>()),
-                                         Eigen::Affine3f(right_foot.cast<float>()));
+        auto joints =
+            calculateLegJoints(kinematicsModel, Transform3D(convert(left_foot)), Transform3D(convert(right_foot)));
 
         auto waypoints = motionLegs(joints);
 

--- a/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
+++ b/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
@@ -34,6 +34,7 @@
 #include "utility/math/angle.hpp"
 #include "utility/nusight/NUhelpers.hpp"
 #include "utility/platform/darwin/DarwinSensors.hpp"
+#include "utility/support/eigen_armadillo.hpp"
 #include "utility/support/yaml_expression.hpp"
 
 namespace module::platform::darwin {

--- a/module/platform/darwin/SensorFilter/src/SensorFilter.cpp
+++ b/module/platform/darwin/SensorFilter/src/SensorFilter.cpp
@@ -27,6 +27,7 @@
 
 #include "utility/input/LimbID.hpp"
 #include "utility/input/ServoID.hpp"
+#include "utility/math/matrix/matrix.hpp"
 #include "utility/motion/ForwardKinematics.hpp"
 #include "utility/nusight/NUhelpers.hpp"
 #include "utility/platform/darwin/DarwinSensors.hpp"

--- a/module/platform/darwin/SensorFilter/src/SensorFilter.hpp
+++ b/module/platform/darwin/SensorFilter/src/SensorFilter.hpp
@@ -29,7 +29,7 @@
 
 #include "message/motion/KinematicsModel.hpp"
 
-#include "utility/math/filter/UKF.hpp"
+#include "utility/math/filter/eigen/UKF.hpp"
 
 
 namespace module::platform::darwin {

--- a/module/vision/BallDetector/src/BallDetector.cpp
+++ b/module/vision/BallDetector/src/BallDetector.cpp
@@ -21,7 +21,6 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
-#include <numeric>
 
 #include "extension/Configuration.hpp"
 

--- a/module/vision/GoalDetector/src/GoalDetector.cpp
+++ b/module/vision/GoalDetector/src/GoalDetector.cpp
@@ -22,7 +22,6 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <fmt/format.h>
-#include <numeric>
 
 #include "extension/Configuration.hpp"
 

--- a/shared/tests/utility/math/filter/TestFilters.cpp
+++ b/shared/tests/utility/math/filter/TestFilters.cpp
@@ -24,8 +24,8 @@
 
 #include "VanDerPolModel.hpp"
 
-#include "utility/math/filter/ParticleFilter.hpp"
-#include "utility/math/filter/UKF.hpp"
+#include "utility/math/filter/eigen/ParticleFilter.hpp"
+#include "utility/math/filter/eigen/UKF.hpp"
 
 static const std::array<Eigen::Vector2d, 101> true_state   = {Eigen::Vector2d(2.0, 0.0),
                                                             Eigen::Vector2d(1.99762085441568, -0.0928337297585024),

--- a/shared/utility/behaviour/MotionCommand.hpp
+++ b/shared/utility/behaviour/MotionCommand.hpp
@@ -40,8 +40,8 @@ namespace utility::behaviour {
 
     inline MotionCommand WalkToState(const Transform2D& goalState_) {
         MotionCommand cmd;
-        cmd.type      = MotionCommand::Type::Value::WalkToState;
-        cmd.goalState = convert(goalState_);
+        cmd.type       = MotionCommand::Type::Value::WALK_TO_STATE;
+        cmd.goal_state = convert(goalState_);
         return cmd;
     }
 
@@ -63,8 +63,8 @@ namespace utility::behaviour {
 
     inline MotionCommand DirectCommand(const Transform2D& walkCommand_) {
         MotionCommand cmd;
-        cmd.type        = MotionCommand::Type::Value::DirectCommand;
-        cmd.walkCommand = convert(walkCommand_);
+        cmd.type         = MotionCommand::Type::Value::DIRECT_COMMAND;
+        cmd.walk_command = convert(walkCommand_);
         return cmd;
     }
 

--- a/shared/utility/behaviour/MotionCommand.hpp
+++ b/shared/utility/behaviour/MotionCommand.hpp
@@ -24,13 +24,24 @@
 
 #include "message/behaviour/MotionCommand.hpp"
 
+#include "utility/math/matrix/Transform2D.hpp"
+#include "utility/support/eigen_armadillo.hpp"
+
 namespace utility::behaviour {
 
     using message::behaviour::MotionCommand;
+    using utility::math::matrix::Transform2D;
 
     inline MotionCommand StandStill() {
         MotionCommand cmd;
         cmd.type = MotionCommand::Type::Value::STAND_STILL;
+        return cmd;
+    }
+
+    inline MotionCommand WalkToState(const Transform2D& goalState_) {
+        MotionCommand cmd;
+        cmd.type      = MotionCommand::Type::Value::WalkToState;
+        cmd.goalState = convert(goalState_);
         return cmd;
     }
 
@@ -47,6 +58,13 @@ namespace utility::behaviour {
         MotionCommand cmd;
         cmd.type        = MotionCommand::Type::Value::BALL_APPROACH;
         cmd.kick_target = kickTarget_;
+        return cmd;
+    }
+
+    inline MotionCommand DirectCommand(const Transform2D& walkCommand_) {
+        MotionCommand cmd;
+        cmd.type        = MotionCommand::Type::Value::DirectCommand;
+        cmd.walkCommand = convert(walkCommand_);
         return cmd;
     }
 

--- a/shared/utility/libraries.cmake
+++ b/shared/utility/libraries.cmake
@@ -13,6 +13,9 @@ target_link_libraries(nuclear_utility PUBLIC fmt::fmt)
 find_package(Aravis REQUIRED)
 target_link_libraries(nuclear_utility PUBLIC Aravis::Aravis)
 
+find_package(Armadillo REQUIRED)
+target_link_libraries(nuclear_utility PUBLIC Armadillo::Armadillo)
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   find_package(libbacktrace REQUIRED)
   target_link_libraries(nuclear_utility PUBLIC libbacktrace::libbacktrace ${CMAKE_DL_LIBS})

--- a/shared/utility/localisation/transform.hpp
+++ b/shared/utility/localisation/transform.hpp
@@ -21,6 +21,11 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <armadillo>
+
+#include "utility/math/matrix/Transform2D.hpp"
+#include "utility/math/matrix/Transform3D.hpp"
+
 
 namespace utility::localisation {
 
@@ -29,6 +34,14 @@ namespace utility::localisation {
         Eigen::Affine3d Hfw;
         Hfw.translation() = Eigen::Vector3d(state.x(), state.y(), 0.0);
         Hfw.linear()      = Eigen::AngleAxisd(state.z(), Eigen::Vector3d::UnitZ()).toRotationMatrix();
+        return Hfw;
+    }
+
+    // Transforms the field state (x,y,theta) to the correct transform Hfw : World -> Field
+    inline utility::math::matrix::Transform3D fieldStateToTransform3D(const arma::vec3& state) {
+        utility::math::matrix::Transform3D Hfw;
+        Hfw.translation() = arma::vec3({state[0], state[1], 0});
+        Hfw               = Hfw.rotateZ(state[2]);
         return Hfw;
     }
 
@@ -62,6 +75,12 @@ namespace utility::localisation {
     // Transforms the transform
     inline Eigen::Affine2d transform3DToFieldState(const Eigen::Affine3d& m) {
         return projectTo2D(m, Eigen::Vector3d::UnitZ(), Eigen::Vector3d::UnitX());
+    }
+
+    // Transforms the transform
+    inline arma::vec3 transform3DToFieldState(const utility::math::matrix::Transform3D& m) {
+        utility::math::matrix::Transform2D ax = m.projectTo2D(arma::vec3({0, 0, 1}), arma::vec3({1, 0, 0}));
+        return arma::vec3({ax.x(), ax.y(), ax.angle()});
     }
 
 }  // namespace utility::localisation

--- a/shared/utility/math/angle.hpp
+++ b/shared/utility/math/angle.hpp
@@ -21,6 +21,7 @@
 #define UTILITY_MATH_ANGLE_HPP
 
 #include <Eigen/Core>
+#include <armadillo>
 #include <cmath>
 
 /**
@@ -129,8 +130,17 @@ namespace utility::math::angle {
         }
     }
 
+
+    inline double vectorToBearing(arma::vec2 dirVec) {
+        return std::atan2(dirVec(1), dirVec(0));
+    }
+
     inline double vectorToBearing(const Eigen::Vector2d& dirVec) {
         return std::atan2(dirVec.y(), dirVec.x());
+    }
+
+    inline arma::vec2 bearingToUnitVector(double angle) {
+        return arma::vec2({std::cos(angle), std::sin(angle)});
     }
 
     /*! @brief Solves for x in $a \sin(x) + b \cos(x) = c ; x \in [0,\pi]$

--- a/shared/utility/math/coordinates.hpp
+++ b/shared/utility/math/coordinates.hpp
@@ -21,6 +21,7 @@
 #define UTILITY_MATH_COORDINATES_HPP
 
 #include <Eigen/Core>
+#include <armadillo>
 #include <cmath>
 
 
@@ -32,6 +33,20 @@
  * @author Alex Biddulph
  */
 namespace utility::math::coordinates {
+    inline arma::vec3 sphericalToCartesian(const arma::vec3& sphericalCoordinates) {
+        double distance  = sphericalCoordinates[0];
+        double cos_theta = cos(sphericalCoordinates[1]);
+        double sin_theta = sin(sphericalCoordinates[1]);
+        double cos_phi   = cos(sphericalCoordinates[2]);
+        double sin_phi   = sin(sphericalCoordinates[2]);
+        arma::vec3 result;
+
+        result[0] = distance * cos_theta * sin_phi;
+        result[1] = distance * sin_theta * sin_phi;
+        result[2] = distance * cos_phi;
+
+        return result;
+    }
 
     template <typename T, typename U = typename T::Scalar>
     inline Eigen::Matrix<U, 3, 1> sphericalToCartesian(const Eigen::MatrixBase<T>& sphericalCoordinates) {
@@ -45,6 +60,24 @@ namespace utility::math::coordinates {
         result.x() = distance * cos_theta * cos_phi;
         result.y() = distance * sin_theta * cos_phi;
         result.z() = distance * sin_phi;
+
+        return result;
+    }
+
+    inline arma::vec3 cartesianToSpherical(const arma::vec3& cartesianCoordinates) {
+        double x = cartesianCoordinates[0];
+        double y = cartesianCoordinates[1];
+        double z = cartesianCoordinates[2];
+        arma::vec3 result;
+
+        result[0] = sqrt(x * x + y * y + z * z);  // r
+        result[1] = atan2(y, x);                  // theta
+        if (result[0] == 0) {
+            result[2] = 0;
+        }
+        else {
+            result[2] = asin(z / (result[0]));  // phi
+        }
 
         return result;
     }
@@ -68,6 +101,35 @@ namespace utility::math::coordinates {
         return result;
     }
 
+    inline arma::vec4 sphericalToCartesian4(const arma::vec3& sphericalCoordinates) {
+        arma::vec3 p = sphericalToCartesian(sphericalCoordinates);
+        return arma::vec4({p[0], p[1], p[2], 1});
+    }
+
+    inline arma::vec4 cartesianToSpherical4(const arma::vec3& cartesianCoordinates) {
+        arma::vec3 p = cartesianToSpherical(cartesianCoordinates);
+        return arma::vec4({p[0], p[1], p[2], 1});
+    }
+
+
+    inline arma::vec2 cartesianToRadial(const arma::vec2& cartesianCoordinates) {
+        double x = cartesianCoordinates[0];
+        double y = cartesianCoordinates[1];
+
+        return {sqrt(x * x + y * y), atan2(y, x)};
+    }
+
+    inline arma::vec2 spherical2Radial(const arma::vec3& sphericalCoordinates) {
+        double dist          = sphericalCoordinates(0);
+        double declination   = sphericalCoordinates(2);
+        double flat_distance = dist * std::cos(declination);
+
+        arma::vec2 result;
+        result[0] = flat_distance;
+        result[1] = sphericalCoordinates(1);
+
+        return result;
+    }
 }  // namespace utility::math::coordinates
 
 

--- a/shared/utility/math/filter/MMUKF.hpp
+++ b/shared/utility/math/filter/MMUKF.hpp
@@ -1,0 +1,170 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2016 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_MATH_FILTER_MMUKF_HPP
+#define UTILITY_MATH_FILTER_MMUKF_HPP
+
+#include <armadillo>
+#include <nuclear>
+
+#include "UKF.hpp"
+
+namespace utility::math::filter {
+
+    template <typename Model>
+    class MMUKF {
+    public:
+        struct Filter {
+
+            Filter(double weight = 1.0, UKF<Model> filter = UKF<Model>()) : weight(weight), filter(filter) {}
+
+            double weight;
+            UKF<Model> filter;
+
+            bool operator<(const Filter& other) {
+                // Sort from big to small
+                return weight > other.weight;
+            }
+        };
+
+        std::vector<Filter> filters;
+        size_t maxModels        = 2;
+        double mergeProbability = 0.9;
+
+        static double bhattacharyyaDistance(const UKF<Model>& a, const UKF<Model>& b) {
+            // Get our state difference
+            const arma::vec ud = a.model.observationDifference(a.get(), b.get());
+
+            // Get our 3 covariance matricies we need
+            const auto& s1 = a.getCovariance();
+            const auto& s2 = b.getCovariance();
+            arma::mat s    = (s1 + s2) * 0.5;
+
+            double d = arma::as_scalar((0.125 * ud).t() * arma::inv_sympd(s) * ud)
+                       + 0.5 * std::log(arma::det(s) / std::sqrt(arma::det(s1) * arma::det(s2)));
+            return d;
+        }
+
+        void renormalise() {
+
+            // Normalise our weights
+            double totalWeight = 0;
+            for (auto& filter : filters) {
+                totalWeight = std::min(filter.weight, totalWeight);
+            }
+            // totalWeight = 1.0 / totalWeight;
+            for (auto& filter : filters) {
+                filter.weight -= totalWeight;
+            }
+        }
+
+        void prune() {
+            // Sort so the most likely model is first
+            std::sort(std::begin(filters), std::end(filters));
+
+            // First we merge similar models
+            // Now we merge to the number of models we need
+            // We can do this because merging models that we are going
+            // to cut off later is pointless. We only need the first
+            // n most probable models
+            for (uint i = 0; i < std::min(maxModels, filters.size()); ++i) {
+
+                auto end = std::remove_if(filters.begin() + i + 1, filters.end(), [this, i](const Filter& f) {
+                    return mergeProbability < bhattacharyyaDistance(filters[i].filter, f.filter);
+                });
+
+                filters.erase(end, filters.end());
+            }
+
+            // Now we cut off the models we don't need
+            filters.resize(maxModels);
+
+            // Normalise our weights
+            renormalise();
+        }
+
+        template <typename... TArgs, size_t... I>
+        double applyMeasurement(Filter& filter, const std::tuple<TArgs...>& args, const std::index_sequence<I...>&) {
+            return filter.filter.measurementUpdate(std::get<I>(args)...);
+        }
+
+    public:
+        MMUKF(size_t maxModels = 2, double mergeProbability = 0.9)
+            : filters(), maxModels(maxModels), mergeProbability(mergeProbability) {}
+
+        template <typename... TAdditionalParameters>
+        void timeUpdate(double deltaT, const TAdditionalParameters&... additionalParameters) {
+
+            // Prune before time update
+            prune();
+
+            for (auto& filter : filters) {
+                filter.filter.timeUpdate(deltaT, additionalParameters...);
+            }
+        }
+
+        template <typename TMeasurement, typename... TMeasurementArgs>
+        void measurementUpdate(const TMeasurement& measurement,
+                               const arma::mat& measurementVariance,
+                               const TMeasurementArgs&... measurementArgs) {
+
+            for (auto& filter : filters) {
+                double weight = filter.filter.measurementUpdate(measurement, measurementVariance, measurementArgs...);
+                filter.weight += weight;
+            }
+        }
+
+        template <typename TMeasurement, typename... TMeasurementArgs>
+        void measurementUpdate(
+            const std::initializer_list<std::tuple<TMeasurement, arma::mat, TMeasurementArgs...>>& measurements) {
+
+            std::vector<Filter> newFilters;
+            for (auto& filter : filters) {
+
+                for (auto& measurement : measurements) {
+                    Filter split = filter;
+
+                    double weight = applyMeasurement(split,
+                                                     measurement,
+                                                     std::make_index_sequence<2 + sizeof...(TMeasurementArgs)>());
+                    split.weight += weight;
+                    // std::cerr << split.weight << std::endl;
+                    newFilters.push_back(split);
+                }
+            }
+
+            std::sort(newFilters.begin(), newFilters.end());
+
+            filters = std::move(newFilters);
+
+            // Normalise our weights
+            renormalise();
+        }
+
+        const typename UKF<Model>::StateVec& get() const {
+            return filters[0].filter.get();
+        }
+
+        const typename UKF<Model>::StateMat& getCovariance() const {
+            return filters[0].filter.getCovariance();
+        }
+    };
+}  // namespace utility::math::filter
+
+#endif  // UTILITY_MATH_FILTER_MMUKF_HPP

--- a/shared/utility/math/filter/ParticleFilter.hpp
+++ b/shared/utility/math/filter/ParticleFilter.hpp
@@ -16,164 +16,211 @@
  * You should have received a copy of the GNU General Public License
  * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright 2019 NUbots <nubots@nubots.net>
+ * Copyright 2013 NUBots <nubots@nubots.net>
  */
 
 #ifndef UTILITY_MATH_FILTER_PARTICLEFILTER_HPP
 #define UTILITY_MATH_FILTER_PARTICLEFILTER_HPP
 
-#include <Eigen/Dense>
+#include <armadillo>
+#include <iostream>
+#include <nuclear>
 #include <random>
 #include <vector>
 
 namespace utility::math::filter {
 
-    template <typename Scalar, template <typename> class FilterModel>
+    template <typename Model>  // model is is a template parameter that Kalman also inherits
     class ParticleFilter {
     public:
-        using Model = FilterModel<Scalar>;
         // The model
         Model model;
 
-        using StateVec = Eigen::Matrix<Scalar, Model::size, 1>;
-        using StateMat = Eigen::Matrix<Scalar, Model::size, Model::size>;
+        using StateVec = arma::vec::fixed<Model::size>;
+        using StateMat = arma::mat::fixed<Model::size, Model::size>;
 
     private:
-        // Our random number generator
-        std::mt19937 rng;
-        std::normal_distribution<Scalar> norm;
-
         // Dimension types for vectors and square matricies
-        using ParticleList = Eigen::Matrix<Scalar, Model::size, Eigen::Dynamic>;
+        using ParticleList = arma::mat;
 
-        ParticleList sample_particles(const StateVec& mean, const StateMat& covariance, const int& n_particles) {
-            // Sample single gaussian (represented by a gaussian mixture model of size 1)
+        /* particles.n_cols = number of particles
+           particle.col(i) = particle i
+        */
+        ParticleList particles;
 
-            // Implementation based on the work presented in
-            // Conrad Sanderson and Ryan Curtin.
-            // An Open Source C++ Implementation of Multi-Threaded Gaussian Mixture Models, k-Means and
-            // Expectation Maximisation. International Conference on Signal Processing and Communication
-            // Systems, 2017.
-
-            ParticleList new_particles =
-                ParticleList::NullaryExpr(Model::size, n_particles, [&]() { return norm(rng); });
-
-            const StateMat sqrt_covariance = covariance.cwiseSqrt();
-
-            for (int i = 0; i < n_particles; ++i) {
-                new_particles.col(i) = new_particles.col(i).cwiseProduct(sqrt_covariance.col(0)) + mean;
-            }
-
-            return new_particles;
-        }
-
-        ParticleList sample_particles(const StateVec& mean, const StateVec& covariance, const int& n_particles) {
-            // Sample single gaussian (represented by a gaussian mixture model of size 1)
-
-            // Implementation based on the work presented in
-            // Conrad Sanderson and Ryan Curtin.
-            // An Open Source C++ Implementation of Multi-Threaded Gaussian Mixture Models, k-Means and
-            // Expectation Maximisation. International Conference on Signal Processing and Communication
-            // Systems, 2017.
-
-            ParticleList new_particles =
-                ParticleList::NullaryExpr(Model::size, n_particles, [&]() { return norm(rng); });
-
-            const StateVec sqrt_covariance = covariance.cwiseSqrt();
-
-            for (int i = 0; i < n_particles; ++i) {
-                new_particles.col(i) = new_particles.col(i).cwiseProduct(sqrt_covariance) + mean;
-            }
-
-            return new_particles;
-        }
+        StateVec sigma_sq;
 
     public:
-        ParticleFilter(const StateVec& initial_mean      = StateVec::Zero(),
-                       const StateMat& initialCovariance = StateMat::Identity() * 0.1,
-                       const int& number_of_particles    = 100)
-            : rng(), norm() {
-            set_state(initial_mean, initialCovariance, number_of_particles);
+        ParticleFilter(StateVec initialMean       = arma::zeros(Model::size),
+                       StateMat initialCovariance = arma::eye(Model::size, Model::size) * 0.1,
+                       int number_of_particles_   = 100,
+                       StateVec sigma_sq_         = 0.1 * arma::ones(Model::size)) {
+            sigma_sq = arma::abs(sigma_sq_);
+            reset(initialMean, initialCovariance, number_of_particles_);
         }
 
-        void set_state(const StateVec& initial_mean,
-                       const StateMat& initialCovariance,
-                       const int& number_of_particles = 100) {
-            particles = sample_particles(initial_mean, initialCovariance, number_of_particles);
+        void reset(StateVec initialMean, StateMat initialCovariance, int number_of_particles_ = 100) {
+            particles = getParticles(initialMean, initialCovariance, number_of_particles_);
+        }
 
-            // Limit the state of each particle to ensure they are still valid
-            for (unsigned int i = 0; i < particles.cols(); i++) {
-                particles.col(i) = model.limit(particles.col(i));
+        void resetAmbiguous(const std::vector<StateVec>& initialMeans,
+                            const std::vector<StateMat>& initialCovariances,
+                            const int& number_of_particles_ = 100) {
+            if (initialMeans.size() != initialCovariances.size()) {
+                throw std::runtime_error(std::string(__FILE__) + " : " + std::to_string(__LINE__)
+                                         + " different number of means vs covariances provided.");
+            }
+            particles = arma::zeros(Model::size, number_of_particles_);
+            // Sample the same number of particles for each possibility
+            const int particlesPerInit = number_of_particles_ / initialMeans.size();
+            const int remainder        = number_of_particles_ % initialMeans.size();
+            // Generate remainder using first hypotheses
+            // Cols are accessed cols(first,last_inclusive)
+            if (remainder > 0) {
+                particles.cols(0, remainder - 1) = getParticles(initialMeans[0], initialCovariances[0], remainder);
+            }
+            // Generate the rest equally
+            for (unsigned int i = 0, currentStart = remainder; currentStart < particles.n_cols;
+                 ++i, currentStart += particlesPerInit) {
+                particles.cols(currentStart, currentStart + particlesPerInit - 1) =
+                    getParticles(initialMeans[i], initialCovariances[i], particlesPerInit);
             }
         }
 
-        template <typename... Args>
-        void time(const Scalar& dt, const Args&... params) {
-            // Time update our particles
-            for (unsigned int i = 0; i < particles.cols(); ++i) {
-                particles.col(i) = model.time(particles.col(i), dt, params...);
-            }
+        ParticleList getParticles(const StateVec& initialMean,
+                                  const StateMat& initialCovariance,
+                                  const int& n_particles) const {
+            // Sample single gaussian (represented by a gaussian mixture model of size 1)
+            ParticleList new_particles = arma::zeros(n_particles, Model::size);
 
-            // Perturb them by noise
-            particles += sample_particles(StateVec::Zero(), StateVec(model.noise(dt).diagonal()), particles.cols());
+            arma::gmm_diag gaussian;
+            gaussian.set_params(arma::mat(initialMean), arma::mat(initialCovariance.diag()), arma::ones(1));
 
-            // Limit the state of each particle to ensure they are still valid
-            for (unsigned int i = 0; i < particles.cols(); i++) {
-                particles.col(i) = model.limit(particles.col(i));
-            }
+            return gaussian.generate(n_particles);
         }
 
-        template <typename MeasurementScalar, int S, int... VArgs, int... MArgs, typename... Args>
-        MeasurementScalar measure(const Eigen::Matrix<MeasurementScalar, S, 1, VArgs...>& measurement,
-                                  const Eigen::Matrix<MeasurementScalar, S, S, MArgs...>& measurement_variance,
-                                  const Args&... params) {
 
-            ParticleList candidate_particles =
-                ParticleList::Zero(Model::size, particles.cols() + model.getRogueCount());
-            candidate_particles.leftCols(particles.cols()) = particles;
+        template <typename... TAdditionalParameters>
+        void timeUpdate(const double& deltaT, const TAdditionalParameters&... additionalParameters) {
+            // Sample single zero mean gaussian with process noise (represented by a gaussian mixture model of
+            // size 1)
+            arma::gmm_diag gaussian;
+            gaussian.set_params(arma::mat(arma::zeros(Model::size)),
+                                arma::mat(model.processNoise().diag() * deltaT),
+                                arma::ones(1));
 
+            for (unsigned int i = 0; i < particles.n_cols; ++i) {
+                particles.col(i) = model.timeUpdate(particles.col(i), deltaT, additionalParameters...);
+            }
+            particles += gaussian.generate(particles.n_cols);
+        }
+
+        template <typename TMeasurement, typename... TMeasurementType>
+        double measurementUpdate(const TMeasurement& measurement,
+                                 const arma::mat& measurement_variance,
+                                 const TMeasurementType&... measurementArgs) {
+            ParticleList candidateParticles =
+                arma::join_rows(particles, arma::zeros(Model::size, model.getRogueCount()));
             // Resample some rogues
-            for (int i = 0; i < model.getRogueCount(); ++i) {
-                candidate_particles.col(i + particles.cols()) =
-                    particles.col(i) + model.getRogueRange().cwiseProduct(StateVec::Random() * 0.5);
+            for (int i = 0; i < model.getRogueCount(); i++) {
+                candidateParticles.col(i + particles.n_cols) =
+                    particles.col(i) + (model.getRogueRange() % (0.5 - arma::randu(Model::size)));
             }
 
-            Eigen::Matrix<MeasurementScalar, S, Eigen::Dynamic> differences(S, particles.cols());
-            for (int i = 0; i < candidate_particles.cols(); ++i) {
-                differences.col(i) = model.difference(model.predict(particles.col(i), params...), measurement);
+            arma::mat observationDifferences = arma::mat(measurement.n_elem, candidateParticles.n_cols);
+            for (unsigned int i = 0; i < candidateParticles.n_cols; ++i) {
+                arma::vec predictedObservation =
+                    model.predictedObservation(candidateParticles.col(i), measurementArgs...);
+                observationDifferences.col(i) = model.observationDifference(predictedObservation, measurement);
             }
 
             // Calculate log probabilities
-            Eigen::Matrix<MeasurementScalar, Eigen::Dynamic, 1> logits =
-                -differences.cwiseProduct(measurement_variance.inverse() * differences).colwise().sum();
+            arma::vec logits =
+                (-arma::sum(observationDifferences % (measurement_variance.i() * observationDifferences), 0)).t();
 
             // Subtract the max log prob for numerical stability and then exponentiate
-            logits = Eigen::exp(logits.array() - logits.maxCoeff());
+            logits = arma::exp(logits - logits.max());
 
             // Resample
-            std::discrete_distribution<> multinomial(logits.data(), logits.data() + logits.size());
-            for (unsigned int i = 0; i < particles.cols(); i++) {
-                particles.col(i) = model.limit(candidate_particles.col(multinomial(rng)));
+            std::random_device rd;
+            std::mt19937 gen(rd());
+            std::discrete_distribution<> multinomial(logits.begin(),
+                                                     logits.end());  // class incorrectly named by cpp devs
+            for (unsigned int i = 0; i < particles.n_cols; i++) {
+                particles.col(i) = model.limitState(candidateParticles.col(multinomial(gen)));
             }
-            return logits.mean();
+            return arma::mean(logits);
         }
 
-        // Take the mean of all particles, pay no attention to the type of the data
+
+        template <typename TMeasurement, typename... TMeasurementType>
+        double ambiguousMeasurementUpdate(const TMeasurement& measurement,
+                                          const arma::mat& measurement_variance,
+                                          const std::vector<arma::vec>& possibilities,
+                                          const TMeasurementType&... measurementArgs) {
+            // Expand candidate particles with
+            ParticleList candidateParticles =
+                arma::join_rows(particles, arma::zeros(Model::size, model.getRogueCount()));
+            // Resample rogues
+            for (int i = 0; i < model.getRogueCount(); i++) {
+                candidateParticles.col(i + particles.n_cols) =
+                    particles.col(i) + (model.getRogueRange() % (0.5 - arma::randu(Model::size)));
+            }
+            // Repeat each particle for each possibility
+            ParticleList repCandidateParticles = arma::repmat(candidateParticles, 1, possibilities.size());
+
+            // Compute weights
+            arma::mat observationDifferences = arma::mat(measurement.n_elem, repCandidateParticles.n_cols);
+            for (unsigned int i = 0; i < repCandidateParticles.n_cols; ++i) {
+                arma::vec predictedObservation =
+                    model.predictedObservation(repCandidateParticles.col(i),
+                                               possibilities[i / candidateParticles.n_cols],
+                                               measurementArgs...);
+                observationDifferences.col(i) = model.observationDifference(predictedObservation, measurement);
+            }
+            arma::vec weights =
+                arma::exp(-arma::sum(observationDifferences % (measurement_variance.i() * observationDifferences), 0))
+                    .t();
+
+            // Resample
+            std::random_device rd;
+            std::mt19937 gen(rd());
+            std::discrete_distribution<> multinomial(weights.begin(),
+                                                     weights.end());  // class incorrectly named by cpp devs
+            // Only sample N particles
+            arma::vec new_weights = arma::zeros(particles.n_cols);
+            for (unsigned int i = 0; i < particles.n_cols; i++) {
+                int index        = multinomial(gen);
+                particles.col(i) = repCandidateParticles.col(index);
+                new_weights(i)   = weights(index);
+            }
+            // Sort particles by descending weight
+
+            arma::uvec sorted_index  = sort_index(new_weights, "decend");
+            arma::mat particles_temp = particles;
+            for (unsigned int i = 0; i < sorted_index.n_rows; i++) {
+                particles.col(i) = model.limitState(particles_temp.col(sorted_index[i]));
+            }
+
+            // Return mean weight
+            return new_weights[sorted_index[0]];
+        }
+
         StateVec get() const {
-            return particles.rowwise().mean();
+            return arma::mean(particles, 1);
+        }
+
+        StateVec getBest() const {
+            return particles.col(0);
         }
 
         StateMat getCovariance() const {
-            auto mean_centered = particles.transpose().rowwise() - particles.transpose().colwise().mean();
-            return (mean_centered.transpose() * mean_centered) / (particles.transpose().rows() - 1);
+            return arma::cov(particles.t());
         }
 
-        const ParticleList& getParticles() const {
+        ParticleList getParticles() const {
             return particles;
         }
-
-    private:
-        ParticleList particles;
     };
 }  // namespace utility::math::filter
 

--- a/shared/utility/math/filter/UKF.hpp
+++ b/shared/utility/math/filter/UKF.hpp
@@ -14,275 +14,220 @@
  * You should have received a copy of the GNU General Public License
  * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright 2019 NUbots <nubots@nubots.net>
+ * Copyright 2013 NUbots <nubots@nubots.net>
  */
 
 #ifndef UTILITY_MATH_FILTER_UKF_HPP
 #define UTILITY_MATH_FILTER_UKF_HPP
 
-#include <Eigen/Cholesky>
-#include <Eigen/Core>
+#include <armadillo>
+#include <nuclear>
 
 #include "utility/support/LazyEvaluation.hpp"
 
 namespace utility::math::filter {
 
-    template <typename Scalar, template <typename> class FilterModel>
+    template <typename Model>  // model is is a template parameter that Kalman also inherits
     class UKF {
-
     public:
         // The model
-        using Model = FilterModel<Scalar>;
         Model model;
 
-        // Dimension types for vectors and square matrices
-        using StateVec = Eigen::Matrix<Scalar, Model::size, 1>;
-        using StateMat = Eigen::Matrix<Scalar, Model::size, Model::size>;
+        // Dimension types for vectors and square matricies
+        using StateVec = arma::vec::fixed<Model::size>;
+        using StateMat = arma::mat::fixed<Model::size, Model::size>;
 
     private:
         // The number of sigma points
-        static constexpr unsigned int NUM_SIGMA_POINTS = (Model::size * 2) + 1;
+        static constexpr uint NUM_SIGMA_POINTS = (Model::size * 2) + 1;
 
-        using SigmaVec       = Eigen::Matrix<Scalar, NUM_SIGMA_POINTS, 1>;
-        using SigmaMat       = Eigen::Matrix<Scalar, Model::size, NUM_SIGMA_POINTS>;
-        using SigmaSquareMat = Eigen::Matrix<Scalar, NUM_SIGMA_POINTS, NUM_SIGMA_POINTS>;
+        using SigmaVec       = arma::vec::fixed<NUM_SIGMA_POINTS>;
+        using SigmaRowVec    = arma::rowvec::fixed<NUM_SIGMA_POINTS>;
+        using SigmaMat       = arma::mat::fixed<Model::size, NUM_SIGMA_POINTS>;
+        using SigmaSquareMat = arma::mat::fixed<NUM_SIGMA_POINTS, NUM_SIGMA_POINTS>;
 
         // Our estimate and covariance
         StateVec mean;
         StateMat covariance;
 
         // Our sigma points for UKF
-        StateVec sigma_mean;
-        SigmaMat sigma_points;
+        StateVec sigmaMean;
+        SigmaMat sigmaPoints;
 
-        SigmaMat centred_sigma_points;  // X in Steves kalman theory
+        SigmaMat centredSigmaPoints;  // X in Steves kalman theory
         SigmaVec d;
-        SigmaSquareMat covariance_update;  // C in Steves kalman theory
+        SigmaSquareMat covarianceUpdate;  // C in Steves kalman theory
+
+        SigmaSquareMat defaultCovarianceUpdate;
 
         // The mean and covariance weights
-        SigmaVec mean_weights;
-        SigmaVec covariance_weights;
+        SigmaVec meanWeights;
+        SigmaRowVec covarianceWeights;
 
     private:
         // UKF variables
-        Scalar covariance_sigma_weight;
+        double covarianceSigmaWeights;
 
-        /**
-         * @brief Generate new sigma points given our mean and covariance.
-         */
-        template <typename T, int S>
-        static Eigen::Matrix<T, S, NUM_SIGMA_POINTS> generate_sigma_points(const Eigen::Matrix<T, S, 1>& mean,
-                                                                           const Eigen::Matrix<T, S, S>& covariance,
-                                                                           const T& sigma_weight) {
-
-            Eigen::Matrix<T, S, NUM_SIGMA_POINTS> points;
+        void generateSigmaPoints(SigmaMat& points, const StateVec& mean, const StateMat& covariance) {
 
             // Our first row is always the mean
             points.col(0) = mean;
 
-            // Get our Cholesky decomposition
-            // Impose positive semi-definiteness on the covariance matrix
-            Eigen::LLT<StateMat> cholesky(sigma_weight
-                                          * covariance.unaryExpr([](const Scalar& c) { return std::abs(c); }));
-            if (cholesky.info() == Eigen::Success) {
-                // Put our values in either end of the matrix
-                StateMat chol = cholesky.matrixL().toDenseMatrix();
-                for (unsigned int i = 1; i < Model::size + 1; ++i) {
-                    points.col(i)               = (mean + chol.col(i - 1));
-                    points.col(i + Model::size) = (mean - chol.col(i - 1));
-                }
+            // Get our cholskey decomposition
+            arma::mat chol = arma::chol(covarianceSigmaWeights * covariance);
+
+            // Put our values in either end of the matrix
+            for (uint i = 1; i < Model::size + 1; ++i) {
+
+                auto deviation              = chol.col(i - 1);
+                points.col(i)               = (mean + deviation);
+                points.col(i + Model::size) = (mean - deviation);
             }
-            else {
-                switch (cholesky.info()) {
-                    case Eigen::NumericalIssue:
-                        throw std::runtime_error(
-                            "Cholesky decomposition failed. The provided data did not satisfy the "
-                            "prerequisites.");
-                    case Eigen::NoConvergence:
-                        throw std::runtime_error(
-                            "Cholesky decomposition failed. Iterative procedure did not converge.");
-                    case Eigen::InvalidInput:
-                        throw std::runtime_error(
-                            "Cholesky decomposition failed. The inputs are invalid, or the algorithm has been "
-                            "improperly called. When assertions are enabled, such errors trigger an assert.");
-                    default: throw std::runtime_error("Cholesky decomposition failed. Some other reason.");
-                }
-            }
-
-            return points;
         }
 
-        /**
-         * @brief Calculate the the mean given a set of sigma points.
-         *
-         * @param mean          the mean to set
-         * @param sigma_points  the sigma points to calculate the mean from
-         */
-        template <typename T1, typename T2, int S>
-        // model size, num sigma points
-        static Eigen::Matrix<T1, S, 1> mean_from_sigmas(const Eigen::Matrix<T1, S, NUM_SIGMA_POINTS>& sigma_points,
-                                                        const Eigen::Matrix<T2, NUM_SIGMA_POINTS, 1>& weights) {
-            return sigma_points * weights.template cast<T1>();
+        void meanFromSigmas(StateVec& mean, const SigmaMat& sigmaPoints) const {
+            mean = sigmaPoints * meanWeights;
         }
 
-        template <typename T1, typename T2, int S>
-        static Eigen::Matrix<T1, S, S> covariance_from_sigmas(
-            const Eigen::Matrix<T1, S, NUM_SIGMA_POINTS>& sigma_points,
-            const Eigen::Matrix<T1, S, 1>& mean,
-            const Eigen::Matrix<T2, NUM_SIGMA_POINTS, 1>& weights) {
+        void covarianceFromSigmas(StateMat& covariance, const SigmaMat& sigmaPoints, const StateVec& mean) const {
 
-            Eigen::Matrix<T1, S, NUM_SIGMA_POINTS> mean_centred = sigma_points.colwise() - mean;
-            return mean_centred * weights.template cast<T1>().asDiagonal() * mean_centred.transpose();
+            SigmaMat meanCentered = sigmaPoints - arma::repmat(mean, 1, NUM_SIGMA_POINTS);
+            covariance            = (arma::repmat(covarianceWeights, Model::size, 1) % meanCentered) * meanCentered.t();
         }
 
-        template <typename T1, typename T2, int S>
-        static Eigen::Matrix<T1, S, S> covariance_from_sigmas(
-            const Eigen::Matrix<T1, S, NUM_SIGMA_POINTS>& sigma_points,
-            const T1& mean,
-            const Eigen::Matrix<T2, NUM_SIGMA_POINTS, 1>& weights) {
+        void meanFromSigmas(arma::vec& mean, const arma::mat& sigmaPoints) const {
+            mean = sigmaPoints * meanWeights;
+        }
 
-            Eigen::Matrix<T1, S, NUM_SIGMA_POINTS> mean_centred = (sigma_points.array() - mean).matrix();
-            return mean_centred * weights.template cast<T1>().asDiagonal() * mean_centred.transpose();
+        void covarianceFromSigmas(arma::mat& covariance, const arma::mat& sigmaPoints, const arma::vec& mean) const {
+
+            arma::mat meanCentered = sigmaPoints - arma::repmat(mean, 1, NUM_SIGMA_POINTS);
+            covariance = (arma::repmat(covarianceWeights, mean.size(), 1) % meanCentered) * meanCentered.t();
         }
 
     public:
-        UKF(StateVec initial_mean       = StateVec::Zero(),
-            StateMat initial_covariance = StateMat::Identity() * 0.1,
-            Scalar alpha                = 0.1,
-            Scalar kappa                = 0.0,
-            Scalar beta                 = 2.0)
+        UKF(StateVec initialMean       = arma::zeros(Model::size),
+            StateMat initialCovariance = arma::eye(Model::size, Model::size) * 0.1,
+            double alpha               = 1e-1,
+            double kappa               = 0.f,
+            double beta                = 2.f)
             : model()
-            , mean(initial_mean)
-            , covariance(initial_covariance)
-            , sigma_mean(StateVec::Zero())
-            , sigma_points(SigmaMat::Zero())
-            , centred_sigma_points(SigmaMat::Zero())
-            , d(SigmaVec::Zero())
-            , covariance_update(SigmaSquareMat::Identity())
-            , mean_weights(SigmaVec::Zero())
-            , covariance_weights(SigmaVec::Zero())
-            , covariance_sigma_weight(0.0) {
+            , mean(arma::fill::zeros)
+            , covariance(arma::fill::eye)
+            , sigmaMean(arma::fill::zeros)
+            , sigmaPoints(arma::fill::zeros)
+            , centredSigmaPoints(arma::fill::zeros)
+            , d(arma::fill::zeros)
+            , covarianceUpdate(arma::fill::eye)
+            , defaultCovarianceUpdate(arma::fill::eye)
+            , meanWeights(arma::fill::zeros)
+            , covarianceWeights(arma::fill::zeros)
+            , covarianceSigmaWeights(0.0) {
 
-            reset(initial_mean, initial_covariance, alpha, kappa, beta);
+            reset(initialMean, initialCovariance, alpha, kappa, beta);
         }
 
-        void reset(StateVec initial_mean, StateMat initial_covariance, Scalar alpha, Scalar kappa, Scalar beta) {
-            Scalar lambda = alpha * alpha * (Model::size + kappa) - Model::size;
+        void reset(StateVec initialMean, StateMat initialCovariance, double alpha, double kappa, double beta) {
+            double lambda = pow(alpha, 2) * (Model::size + kappa) - Model::size;
 
-            covariance_sigma_weight = Model::size + lambda;
+            covarianceSigmaWeights = Model::size + lambda;
 
-            mean_weights.fill(1.0 / (2.0 * covariance_sigma_weight));
-            mean_weights[0] = lambda / covariance_sigma_weight;
+            meanWeights.fill(1.0 / (2.0 * (Model::size + lambda)));
+            meanWeights[0] = lambda / (Model::size + lambda);
 
-            covariance_weights.fill(1.0 / (2.0 * covariance_sigma_weight));
-            covariance_weights[0] = lambda / covariance_sigma_weight + (1.0 - (alpha * alpha) + beta);
+            covarianceWeights.fill(1.0 / (2.0 * (Model::size + lambda)));
+            covarianceWeights[0] = lambda / (Model::size + lambda) + (1.0 - pow(alpha, 2) + beta);
 
-            set_state(initial_mean, initial_covariance);
+            defaultCovarianceUpdate = arma::diagmat(covarianceWeights);
+
+            setState(initialMean, initialCovariance);
         }
 
-        void set_state(StateVec initial_mean, StateMat initial_covariance) {
-            mean       = initial_mean;
-            covariance = initial_covariance;
+        void setState(StateVec initialMean, StateMat initialCovariance) {
+            mean       = initialMean;
+            covariance = initialCovariance;
 
             // Calculate our sigma points
-            sigma_mean   = mean;
-            sigma_points = generate_sigma_points(mean, covariance, covariance_sigma_weight);
+            sigmaMean = mean;
+            generateSigmaPoints(sigmaPoints, mean, covariance);
 
             // Reset our state for more measurements
-            covariance_update = covariance_weights.asDiagonal();
-            d.setZero();
-            centred_sigma_points = sigma_points.colwise() - sigma_mean;
+            covarianceUpdate = defaultCovarianceUpdate;
+            d.zeros();
+            centredSigmaPoints = sigmaPoints - arma::repmat(sigmaMean, 1, NUM_SIGMA_POINTS);
         }
 
-        template <typename... Args>
-        void time(const Scalar& dt, const Args&... params) {
+        template <typename... TAdditionalParameters>
+        void timeUpdate(double deltaT, const TAdditionalParameters&... additionalParameters) {
             // Generate our sigma points
-            sigma_points = generate_sigma_points(mean, covariance, covariance_sigma_weight);
+            generateSigmaPoints(sigmaPoints, mean, covariance);
 
             // Write the propagated version of the sigma point
-            for (unsigned int i = 0; i < NUM_SIGMA_POINTS; ++i) {
-                sigma_points.col(i) = model.time(sigma_points.col(i), dt, params...);
+            for (uint i = 0; i < NUM_SIGMA_POINTS; ++i) {
+                sigmaPoints.col(i) = model.timeUpdate(sigmaPoints.col(i), deltaT, additionalParameters...);
             }
 
             // Calculate the new mean and covariance values.
-            mean       = mean_from_sigmas(sigma_points, mean_weights);
-            mean       = model.limit(mean);
-            covariance = covariance_from_sigmas(sigma_points, mean, covariance_weights);
-            covariance += model.noise(dt);
+            meanFromSigmas(mean, sigmaPoints);
+            mean = model.limitState(mean);
+            covarianceFromSigmas(covariance, sigmaPoints, mean);
+            covariance += model.processNoise();
 
             // Re calculate our sigma points
-            sigma_mean   = mean;
-            sigma_points = generate_sigma_points(mean, covariance, covariance_sigma_weight);
+            sigmaMean = mean;
+            generateSigmaPoints(sigmaPoints, mean, covariance);
 
             // Reset our state for more measurements
-            covariance_update = covariance_weights.asDiagonal();
-            d.setZero();
-            centred_sigma_points = sigma_points.colwise() - sigma_mean;
+            covarianceUpdate = defaultCovarianceUpdate;
+            d.zeros();
+            centredSigmaPoints = sigmaPoints - arma::repmat(sigmaMean, 1, NUM_SIGMA_POINTS);
         }
 
-
-        /**
-         * Perform a measurement update using the given measurement and covariance
-         */
-        template <typename MeasurementScalar, int S, int... VArgs, int... MArgs, typename... Args>
-        utility::support::LazyEvaluation<MeasurementScalar> measure(
-            const Eigen::Matrix<MeasurementScalar, S, 1, VArgs...>& measurement,
-            const Eigen::Matrix<MeasurementScalar, S, S, MArgs...>& measurement_variance,
-            const Args&... params) {
+        template <typename TMeasurement, typename... TMeasurementArgs>
+        utility::support::LazyEvaluation<double> measurementUpdate(const TMeasurement& measurement,
+                                                                   const arma::mat& measurementVariance,
+                                                                   const TMeasurementArgs&... measurementArgs) {
 
             // Allocate room for our predictions
-            Eigen::Matrix<MeasurementScalar, S, NUM_SIGMA_POINTS> predictions;
+            arma::mat predictedObservations(measurement.n_elem, NUM_SIGMA_POINTS);
 
-            // First step is to calculate the predicted measurement for each sigma point.
-            for (unsigned int i = 0; i < NUM_SIGMA_POINTS; ++i) {
-                predictions.col(i) = model.predict(sigma_points.col(i), params...);
+            // First step is to calculate the expected measurement for each sigma point.
+            for (uint i = 0; i < NUM_SIGMA_POINTS; ++i) {
+                predictedObservations.col(i) = model.predictedObservation(sigmaPoints.col(i), measurementArgs...);
             }
 
             // Now calculate the mean of these measurement sigmas.
-            Eigen::Matrix<MeasurementScalar, S, 1> predicted_mean         = mean_from_sigmas(predictions, mean_weights);
-            Eigen::Matrix<MeasurementScalar, S, NUM_SIGMA_POINTS> centred = predictions.colwise() - predicted_mean;
+            arma::vec predictedMean;
+            meanFromSigmas(predictedMean, predictedObservations);
+            auto centredObservations = predictedObservations - arma::repmat(predictedMean, 1, NUM_SIGMA_POINTS);
 
-            // Create a state update in our measurement units
-            Eigen::Matrix<MeasurementScalar, NUM_SIGMA_POINTS, NUM_SIGMA_POINTS> update =
-                covariance_update.template cast<MeasurementScalar>();
-            update = update.transpose() * centred.transpose()
-                     * (measurement_variance + centred * update * centred.transpose())
-                           .llt()
-                           .solve(Eigen::Matrix<MeasurementScalar, S, S>::Identity())
-                     * centred * update;
-            covariance_update -= update.template cast<Scalar>();
+            // Update our state
+            covarianceUpdate -= covarianceUpdate.t() * centredObservations.t()
+                                * arma::inv_sympd(measurementVariance
+                                                  + centredObservations * covarianceUpdate * centredObservations.t())
+                                * centredObservations * covarianceUpdate;
 
-            Eigen::Matrix<MeasurementScalar, S, 1> innovation = model.difference(measurement, predicted_mean);
-            d += (centred.transpose()
-                  * measurement_variance.llt().solve(Eigen::Matrix<MeasurementScalar, S, S>::Identity()) * innovation)
-                     .template cast<Scalar>();
+            const arma::mat innovation = model.observationDifference(measurement, predictedMean);
+            d += (centredObservations.t()) * measurementVariance.i() * innovation;
 
             // Update our mean and covariance
-            mean       = sigma_mean + centred_sigma_points * covariance_update * d;
-            mean       = model.limit(mean);
-            covariance = centred_sigma_points * covariance_update * centred_sigma_points.transpose();
+            mean       = sigmaMean + centredSigmaPoints * covarianceUpdate * d;
+            mean       = model.limitState(mean);
+            covariance = centredSigmaPoints * covarianceUpdate * centredSigmaPoints.t();
 
-            // Calculate and return the likelihood of the prior mean and covariance given the new measurement
-            // (i.e. the prior probability density of the measurement):
-            return utility::support::LazyEvaluation<MeasurementScalar>(
-                [predictions, predicted_mean, measurement_variance, innovation, cw = this->covariance_weights] {
-                    Eigen::Matrix<MeasurementScalar, S, S> predicted_covariance =
-                        covariance_from_sigmas(predictions, predicted_mean, cw);
-
-                    Eigen::Matrix<MeasurementScalar, S, S> innovation_variance =
-                        predicted_covariance + measurement_variance;
-
-                    MeasurementScalar likelihood_exponent =
-                        (innovation.transpose()
-                         * innovation_variance.llt().solve(Eigen::Matrix<MeasurementScalar, S, S>::Identity())
-                         * innovation)
-                            .x();
-
-                    MeasurementScalar loglikelihood =
+            // Calculate and return the likelihood of the prior mean
+            // and covariance given the new measurement (i.e. the
+            // prior probability density of the measurement):
+            return utility::support::LazyEvaluation<double>(
+                [this, predictedObservations, predictedMean, measurementVariance, innovation] {
+                    arma::mat predictedCovariance;
+                    covarianceFromSigmas(predictedCovariance, predictedObservations, predictedMean);
+                    arma::mat innovationVariance       = predictedCovariance + measurementVariance;
+                    arma::mat scalarlikelihoodExponent = ((innovation.t() * innovationVariance.i()) * innovation);
+                    double loglikelihood =
                         0.5
-                        * (std::log(innovation_variance.determinant()) + std::abs(likelihood_exponent)
-                           + innovation.size() * std::log(2 * M_PI));
-
+                        * (std::log(arma::det(innovationVariance)) + std::abs(scalarlikelihoodExponent[0])
+                           + innovation.n_elem * std::log(2 * M_PI));
                     return -loglikelihood;
                 });
         }

--- a/shared/utility/math/filter/eigen/ParticleFilter.hpp
+++ b/shared/utility/math/filter/eigen/ParticleFilter.hpp
@@ -1,0 +1,181 @@
+/*
+ * Particle filter substitute for UKF
+ *
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2019 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_MATH_FILTER_PARTICLEFILTER_HPP
+#define UTILITY_MATH_FILTER_PARTICLEFILTER_HPP
+
+#include <Eigen/Dense>
+#include <random>
+#include <vector>
+
+namespace utility::math::filter {
+
+    template <typename Scalar, template <typename> class FilterModel>
+    class ParticleFilter {
+    public:
+        using Model = FilterModel<Scalar>;
+        // The model
+        Model model;
+
+        using StateVec = Eigen::Matrix<Scalar, Model::size, 1>;
+        using StateMat = Eigen::Matrix<Scalar, Model::size, Model::size>;
+
+    private:
+        // Our random number generator
+        std::mt19937 rng;
+        std::normal_distribution<Scalar> norm;
+
+        // Dimension types for vectors and square matricies
+        using ParticleList = Eigen::Matrix<Scalar, Model::size, Eigen::Dynamic>;
+
+        ParticleList sample_particles(const StateVec& mean, const StateMat& covariance, const int& n_particles) {
+            // Sample single gaussian (represented by a gaussian mixture model of size 1)
+
+            // Implementation based on the work presented in
+            // Conrad Sanderson and Ryan Curtin.
+            // An Open Source C++ Implementation of Multi-Threaded Gaussian Mixture Models, k-Means and
+            // Expectation Maximisation. International Conference on Signal Processing and Communication
+            // Systems, 2017.
+
+            ParticleList new_particles =
+                ParticleList::NullaryExpr(Model::size, n_particles, [&]() { return norm(rng); });
+
+            const StateMat sqrt_covariance = covariance.cwiseSqrt();
+
+            for (int i = 0; i < n_particles; ++i) {
+                new_particles.col(i) = new_particles.col(i).cwiseProduct(sqrt_covariance.col(0)) + mean;
+            }
+
+            return new_particles;
+        }
+
+        ParticleList sample_particles(const StateVec& mean, const StateVec& covariance, const int& n_particles) {
+            // Sample single gaussian (represented by a gaussian mixture model of size 1)
+
+            // Implementation based on the work presented in
+            // Conrad Sanderson and Ryan Curtin.
+            // An Open Source C++ Implementation of Multi-Threaded Gaussian Mixture Models, k-Means and
+            // Expectation Maximisation. International Conference on Signal Processing and Communication
+            // Systems, 2017.
+
+            ParticleList new_particles =
+                ParticleList::NullaryExpr(Model::size, n_particles, [&]() { return norm(rng); });
+
+            const StateVec sqrt_covariance = covariance.cwiseSqrt();
+
+            for (int i = 0; i < n_particles; ++i) {
+                new_particles.col(i) = new_particles.col(i).cwiseProduct(sqrt_covariance) + mean;
+            }
+
+            return new_particles;
+        }
+
+    public:
+        ParticleFilter(const StateVec& initial_mean      = StateVec::Zero(),
+                       const StateMat& initialCovariance = StateMat::Identity() * 0.1,
+                       const int& number_of_particles    = 100)
+            : rng(), norm() {
+            set_state(initial_mean, initialCovariance, number_of_particles);
+        }
+
+        void set_state(const StateVec& initial_mean,
+                       const StateMat& initialCovariance,
+                       const int& number_of_particles = 100) {
+            particles = sample_particles(initial_mean, initialCovariance, number_of_particles);
+
+            // Limit the state of each particle to ensure they are still valid
+            for (unsigned int i = 0; i < particles.cols(); i++) {
+                particles.col(i) = model.limit(particles.col(i));
+            }
+        }
+
+        template <typename... Args>
+        void time(const Scalar& dt, const Args&... params) {
+            // Time update our particles
+            for (unsigned int i = 0; i < particles.cols(); ++i) {
+                particles.col(i) = model.time(particles.col(i), dt, params...);
+            }
+
+            // Perturb them by noise
+            particles += sample_particles(StateVec::Zero(), StateVec(model.noise(dt).diagonal()), particles.cols());
+
+            // Limit the state of each particle to ensure they are still valid
+            for (unsigned int i = 0; i < particles.cols(); i++) {
+                particles.col(i) = model.limit(particles.col(i));
+            }
+        }
+
+        template <typename MeasurementScalar, int S, int... VArgs, int... MArgs, typename... Args>
+        MeasurementScalar measure(const Eigen::Matrix<MeasurementScalar, S, 1, VArgs...>& measurement,
+                                  const Eigen::Matrix<MeasurementScalar, S, S, MArgs...>& measurement_variance,
+                                  const Args&... params) {
+
+            ParticleList candidate_particles =
+                ParticleList::Zero(Model::size, particles.cols() + model.getRogueCount());
+            candidate_particles.leftCols(particles.cols()) = particles;
+
+            // Resample some rogues
+            for (int i = 0; i < model.getRogueCount(); ++i) {
+                candidate_particles.col(i + particles.cols()) =
+                    particles.col(i) + model.getRogueRange().cwiseProduct(StateVec::Random() * 0.5);
+            }
+
+            Eigen::Matrix<MeasurementScalar, S, Eigen::Dynamic> differences(S, particles.cols());
+            for (int i = 0; i < candidate_particles.cols(); ++i) {
+                differences.col(i) = model.difference(model.predict(particles.col(i), params...), measurement);
+            }
+
+            // Calculate log probabilities
+            Eigen::Matrix<MeasurementScalar, Eigen::Dynamic, 1> logits =
+                -differences.cwiseProduct(measurement_variance.inverse() * differences).colwise().sum();
+
+            // Subtract the max log prob for numerical stability and then exponentiate
+            logits = Eigen::exp(logits.array() - logits.maxCoeff());
+
+            // Resample
+            std::discrete_distribution<> multinomial(logits.data(), logits.data() + logits.size());
+            for (unsigned int i = 0; i < particles.cols(); i++) {
+                particles.col(i) = model.limit(candidate_particles.col(multinomial(rng)));
+            }
+            return logits.mean();
+        }
+
+        // Take the mean of all particles, pay no attention to the type of the data
+        StateVec get() const {
+            return particles.rowwise().mean();
+        }
+
+        StateMat getCovariance() const {
+            auto mean_centered = particles.transpose().rowwise() - particles.transpose().colwise().mean();
+            return (mean_centered.transpose() * mean_centered) / (particles.transpose().rows() - 1);
+        }
+
+        const ParticleList& getParticles() const {
+            return particles;
+        }
+
+    private:
+        ParticleList particles;
+    };
+}  // namespace utility::math::filter
+
+
+#endif

--- a/shared/utility/math/filter/eigen/UKF.hpp
+++ b/shared/utility/math/filter/eigen/UKF.hpp
@@ -1,0 +1,301 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2019 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_MATH_FILTER_UKF_HPP
+#define UTILITY_MATH_FILTER_UKF_HPP
+
+#include <Eigen/Cholesky>
+#include <Eigen/Core>
+
+#include "utility/support/LazyEvaluation.hpp"
+
+namespace utility::math::filter {
+
+    template <typename Scalar, template <typename> class FilterModel>
+    class UKF {
+
+    public:
+        // The model
+        using Model = FilterModel<Scalar>;
+        Model model;
+
+        // Dimension types for vectors and square matrices
+        using StateVec = Eigen::Matrix<Scalar, Model::size, 1>;
+        using StateMat = Eigen::Matrix<Scalar, Model::size, Model::size>;
+
+    private:
+        // The number of sigma points
+        static constexpr unsigned int NUM_SIGMA_POINTS = (Model::size * 2) + 1;
+
+        using SigmaVec       = Eigen::Matrix<Scalar, NUM_SIGMA_POINTS, 1>;
+        using SigmaMat       = Eigen::Matrix<Scalar, Model::size, NUM_SIGMA_POINTS>;
+        using SigmaSquareMat = Eigen::Matrix<Scalar, NUM_SIGMA_POINTS, NUM_SIGMA_POINTS>;
+
+        // Our estimate and covariance
+        StateVec mean;
+        StateMat covariance;
+
+        // Our sigma points for UKF
+        StateVec sigma_mean;
+        SigmaMat sigma_points;
+
+        SigmaMat centred_sigma_points;  // X in Steves kalman theory
+        SigmaVec d;
+        SigmaSquareMat covariance_update;  // C in Steves kalman theory
+
+        // The mean and covariance weights
+        SigmaVec mean_weights;
+        SigmaVec covariance_weights;
+
+    private:
+        // UKF variables
+        Scalar covariance_sigma_weight;
+
+        /**
+         * @brief Generate new sigma points given our mean and covariance.
+         */
+        template <typename T, int S>
+        static Eigen::Matrix<T, S, NUM_SIGMA_POINTS> generate_sigma_points(const Eigen::Matrix<T, S, 1>& mean,
+                                                                           const Eigen::Matrix<T, S, S>& covariance,
+                                                                           const T& sigma_weight) {
+
+            Eigen::Matrix<T, S, NUM_SIGMA_POINTS> points;
+
+            // Our first row is always the mean
+            points.col(0) = mean;
+
+            // Get our Cholesky decomposition
+            // Impose positive semi-definiteness on the covariance matrix
+            Eigen::LLT<StateMat> cholesky(sigma_weight
+                                          * covariance.unaryExpr([](const Scalar& c) { return std::abs(c); }));
+            if (cholesky.info() == Eigen::Success) {
+                // Put our values in either end of the matrix
+                StateMat chol = cholesky.matrixL().toDenseMatrix();
+                for (unsigned int i = 1; i < Model::size + 1; ++i) {
+                    points.col(i)               = (mean + chol.col(i - 1));
+                    points.col(i + Model::size) = (mean - chol.col(i - 1));
+                }
+            }
+            else {
+                switch (cholesky.info()) {
+                    case Eigen::NumericalIssue:
+                        throw std::runtime_error(
+                            "Cholesky decomposition failed. The provided data did not satisfy the "
+                            "prerequisites.");
+                    case Eigen::NoConvergence:
+                        throw std::runtime_error(
+                            "Cholesky decomposition failed. Iterative procedure did not converge.");
+                    case Eigen::InvalidInput:
+                        throw std::runtime_error(
+                            "Cholesky decomposition failed. The inputs are invalid, or the algorithm has been "
+                            "improperly called. When assertions are enabled, such errors trigger an assert.");
+                    default: throw std::runtime_error("Cholesky decomposition failed. Some other reason.");
+                }
+            }
+
+            return points;
+        }
+
+        /**
+         * @brief Calculate the the mean given a set of sigma points.
+         *
+         * @param mean          the mean to set
+         * @param sigma_points  the sigma points to calculate the mean from
+         */
+        template <typename T1, typename T2, int S>
+        // model size, num sigma points
+        static Eigen::Matrix<T1, S, 1> mean_from_sigmas(const Eigen::Matrix<T1, S, NUM_SIGMA_POINTS>& sigma_points,
+                                                        const Eigen::Matrix<T2, NUM_SIGMA_POINTS, 1>& weights) {
+            return sigma_points * weights.template cast<T1>();
+        }
+
+        template <typename T1, typename T2, int S>
+        static Eigen::Matrix<T1, S, S> covariance_from_sigmas(
+            const Eigen::Matrix<T1, S, NUM_SIGMA_POINTS>& sigma_points,
+            const Eigen::Matrix<T1, S, 1>& mean,
+            const Eigen::Matrix<T2, NUM_SIGMA_POINTS, 1>& weights) {
+
+            Eigen::Matrix<T1, S, NUM_SIGMA_POINTS> mean_centred = sigma_points.colwise() - mean;
+            return mean_centred * weights.template cast<T1>().asDiagonal() * mean_centred.transpose();
+        }
+
+        template <typename T1, typename T2, int S>
+        static Eigen::Matrix<T1, S, S> covariance_from_sigmas(
+            const Eigen::Matrix<T1, S, NUM_SIGMA_POINTS>& sigma_points,
+            const T1& mean,
+            const Eigen::Matrix<T2, NUM_SIGMA_POINTS, 1>& weights) {
+
+            Eigen::Matrix<T1, S, NUM_SIGMA_POINTS> mean_centred = (sigma_points.array() - mean).matrix();
+            return mean_centred * weights.template cast<T1>().asDiagonal() * mean_centred.transpose();
+        }
+
+    public:
+        UKF(StateVec initial_mean       = StateVec::Zero(),
+            StateMat initial_covariance = StateMat::Identity() * 0.1,
+            Scalar alpha                = 0.1,
+            Scalar kappa                = 0.0,
+            Scalar beta                 = 2.0)
+            : model()
+            , mean(initial_mean)
+            , covariance(initial_covariance)
+            , sigma_mean(StateVec::Zero())
+            , sigma_points(SigmaMat::Zero())
+            , centred_sigma_points(SigmaMat::Zero())
+            , d(SigmaVec::Zero())
+            , covariance_update(SigmaSquareMat::Identity())
+            , mean_weights(SigmaVec::Zero())
+            , covariance_weights(SigmaVec::Zero())
+            , covariance_sigma_weight(0.0) {
+
+            reset(initial_mean, initial_covariance, alpha, kappa, beta);
+        }
+
+        void reset(StateVec initial_mean, StateMat initial_covariance, Scalar alpha, Scalar kappa, Scalar beta) {
+            Scalar lambda = alpha * alpha * (Model::size + kappa) - Model::size;
+
+            covariance_sigma_weight = Model::size + lambda;
+
+            mean_weights.fill(1.0 / (2.0 * covariance_sigma_weight));
+            mean_weights[0] = lambda / covariance_sigma_weight;
+
+            covariance_weights.fill(1.0 / (2.0 * covariance_sigma_weight));
+            covariance_weights[0] = lambda / covariance_sigma_weight + (1.0 - (alpha * alpha) + beta);
+
+            set_state(initial_mean, initial_covariance);
+        }
+
+        void set_state(StateVec initial_mean, StateMat initial_covariance) {
+            mean       = initial_mean;
+            covariance = initial_covariance;
+
+            // Calculate our sigma points
+            sigma_mean   = mean;
+            sigma_points = generate_sigma_points(mean, covariance, covariance_sigma_weight);
+
+            // Reset our state for more measurements
+            covariance_update = covariance_weights.asDiagonal();
+            d.setZero();
+            centred_sigma_points = sigma_points.colwise() - sigma_mean;
+        }
+
+        template <typename... Args>
+        void time(const Scalar& dt, const Args&... params) {
+            // Generate our sigma points
+            sigma_points = generate_sigma_points(mean, covariance, covariance_sigma_weight);
+
+            // Write the propagated version of the sigma point
+            for (unsigned int i = 0; i < NUM_SIGMA_POINTS; ++i) {
+                sigma_points.col(i) = model.time(sigma_points.col(i), dt, params...);
+            }
+
+            // Calculate the new mean and covariance values.
+            mean       = mean_from_sigmas(sigma_points, mean_weights);
+            mean       = model.limit(mean);
+            covariance = covariance_from_sigmas(sigma_points, mean, covariance_weights);
+            covariance += model.noise(dt);
+
+            // Re calculate our sigma points
+            sigma_mean   = mean;
+            sigma_points = generate_sigma_points(mean, covariance, covariance_sigma_weight);
+
+            // Reset our state for more measurements
+            covariance_update = covariance_weights.asDiagonal();
+            d.setZero();
+            centred_sigma_points = sigma_points.colwise() - sigma_mean;
+        }
+
+
+        /**
+         * Perform a measurement update using the given measurement and covariance
+         */
+        template <typename MeasurementScalar, int S, int... VArgs, int... MArgs, typename... Args>
+        utility::support::LazyEvaluation<MeasurementScalar> measure(
+            const Eigen::Matrix<MeasurementScalar, S, 1, VArgs...>& measurement,
+            const Eigen::Matrix<MeasurementScalar, S, S, MArgs...>& measurement_variance,
+            const Args&... params) {
+
+            // Allocate room for our predictions
+            Eigen::Matrix<MeasurementScalar, S, NUM_SIGMA_POINTS> predictions;
+
+            // First step is to calculate the predicted measurement for each sigma point.
+            for (unsigned int i = 0; i < NUM_SIGMA_POINTS; ++i) {
+                predictions.col(i) = model.predict(sigma_points.col(i), params...);
+            }
+
+            // Now calculate the mean of these measurement sigmas.
+            Eigen::Matrix<MeasurementScalar, S, 1> predicted_mean         = mean_from_sigmas(predictions, mean_weights);
+            Eigen::Matrix<MeasurementScalar, S, NUM_SIGMA_POINTS> centred = predictions.colwise() - predicted_mean;
+
+            // Create a state update in our measurement units
+            Eigen::Matrix<MeasurementScalar, NUM_SIGMA_POINTS, NUM_SIGMA_POINTS> update =
+                covariance_update.template cast<MeasurementScalar>();
+            update = update.transpose() * centred.transpose()
+                     * (measurement_variance + centred * update * centred.transpose())
+                           .llt()
+                           .solve(Eigen::Matrix<MeasurementScalar, S, S>::Identity())
+                     * centred * update;
+            covariance_update -= update.template cast<Scalar>();
+
+            Eigen::Matrix<MeasurementScalar, S, 1> innovation = model.difference(measurement, predicted_mean);
+            d += (centred.transpose()
+                  * measurement_variance.llt().solve(Eigen::Matrix<MeasurementScalar, S, S>::Identity()) * innovation)
+                     .template cast<Scalar>();
+
+            // Update our mean and covariance
+            mean       = sigma_mean + centred_sigma_points * covariance_update * d;
+            mean       = model.limit(mean);
+            covariance = centred_sigma_points * covariance_update * centred_sigma_points.transpose();
+
+            // Calculate and return the likelihood of the prior mean and covariance given the new measurement
+            // (i.e. the prior probability density of the measurement):
+            return utility::support::LazyEvaluation<MeasurementScalar>(
+                [predictions, predicted_mean, measurement_variance, innovation, cw = this->covariance_weights] {
+                    Eigen::Matrix<MeasurementScalar, S, S> predicted_covariance =
+                        covariance_from_sigmas(predictions, predicted_mean, cw);
+
+                    Eigen::Matrix<MeasurementScalar, S, S> innovation_variance =
+                        predicted_covariance + measurement_variance;
+
+                    MeasurementScalar likelihood_exponent =
+                        (innovation.transpose()
+                         * innovation_variance.llt().solve(Eigen::Matrix<MeasurementScalar, S, S>::Identity())
+                         * innovation)
+                            .x();
+
+                    MeasurementScalar loglikelihood =
+                        0.5
+                        * (std::log(innovation_variance.determinant()) + std::abs(likelihood_exponent)
+                           + innovation.size() * std::log(2 * M_PI));
+
+                    return -loglikelihood;
+                });
+        }
+
+        const StateVec& get() const {
+            return mean;
+        }
+
+        const StateMat& getCovariance() const {
+            return covariance;
+        }
+    };
+}  // namespace utility::math::filter
+
+
+#endif

--- a/shared/utility/math/geometry/UnitQuaternion.cpp
+++ b/shared/utility/math/geometry/UnitQuaternion.cpp
@@ -1,0 +1,216 @@
+/*
+ * This file is part of the Autocalibration Codebase.
+ *
+ * The Autocalibration Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Autocalibration Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Autocalibration Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#include "UnitQuaternion.hpp"
+
+#include "utility/math/angle.hpp"
+
+namespace utility::math::geometry {
+
+    using matrix::Rotation3D;
+
+    UnitQuaternion::UnitQuaternion() {
+        real() = 1;
+        imaginary().zeros();
+    }
+
+    UnitQuaternion::UnitQuaternion(const Rotation3D& rotation) {
+        real()      = std::sqrt(1.0 + rotation(0, 0) + rotation(1, 1) + rotation(2, 2)) / 2;
+        double w4   = 4.0 * real();
+        imaginary() = arma::vec3({(rotation(2, 1) - rotation(1, 2)) / w4,
+                                  (rotation(0, 2) - rotation(2, 0)) / w4,
+                                  (rotation(1, 0) - rotation(0, 1)) / w4});
+    }
+
+    UnitQuaternion::UnitQuaternion(double realPart, const arma::vec3& imaginaryPart) {
+        real()      = realPart;
+        imaginary() = imaginaryPart;
+    }
+
+    UnitQuaternion::UnitQuaternion(const arma::vec3& v) {
+        real()      = 0;
+        imaginary() = v;
+    }
+
+    UnitQuaternion::UnitQuaternion(const arma::vec3& axis, double angle) {
+        real()      = std::cos(angle / 2.0);
+        imaginary() = std::sin(angle / 2.0) * arma::normalise(axis);
+    }
+
+    UnitQuaternion::UnitQuaternion(double W, double X, double Y, double Z) {
+        real()      = W;
+        imaginary() = arma::vec3({X, Y, Z});
+    }
+
+    UnitQuaternion::UnitQuaternion(const arma::vec3& vec1, const arma::vec3& vec2) {
+        double norm     = arma::norm(vec1) * arma::norm(vec2);
+        double half_cos = std::sqrt(0.5 + arma::dot(vec1, vec2) / (2.0 * norm));
+
+        real()      = half_cos;
+        imaginary() = arma::cross(vec1, vec2) / (2.0 * half_cos * norm);
+
+        this->normalise();
+    }
+
+    void UnitQuaternion::rectify() {
+        if (kW() < 0) {
+            *this = -*this;
+        }
+    }
+
+    UnitQuaternion UnitQuaternion::i() const {
+        UnitQuaternion qi = *this;
+        // take the congugate, as it is equal to the inverse when a unit vector
+        qi.imaginary() *= -1;
+        return qi;
+    }
+
+    arma::vec3 UnitQuaternion::rotateVector(const arma::vec3& v) const {
+        // Do the math
+        const arma::vec3 t = 2 * arma::cross(imaginary(), v);
+        return v + real() * t + arma::cross(imaginary(), t);
+    }
+
+    arma::vec3 UnitQuaternion::getAxis() const {
+        double angle         = getAngle();
+        double sinThetaOnTwo = std::sin(angle / 2.0);
+        return imaginary() / sinThetaOnTwo;
+    }
+
+    double UnitQuaternion::getAngle() const {
+        // Max and min prevent nand error, presumably due to computational limitations
+        return 2 * utility::math::angle::acos_clamped(std::fmin(1, std::fmax(real(), -1)));
+    }
+
+    void UnitQuaternion::setAngle(double angle) {
+        real()      = std::cos(angle / 2.0);
+        imaginary() = std::sin(angle / 2.0) * arma::normalise(imaginary());
+    }
+
+    void UnitQuaternion::scaleAngle(double scale) {
+        setAngle(getAngle() * scale);
+    }
+
+    void UnitQuaternion::normalise() {
+        *this = arma::normalise(*this);
+    }
+
+    arma::mat44 UnitQuaternion::getLeftQuatMultMatrix() const {
+        arma::mat44 Q;
+        Q << kW() << -kX() << -kY() << -kZ() << arma::endr << kX() << kW() << -kZ() << kY() << arma::endr << kY()
+          << kZ() << kW() << -kX() << arma::endr << kZ() << -kY() << kX() << kW() << arma::endr;
+        return Q;
+    }
+
+    arma::mat44 UnitQuaternion::getRightQuatMultMatrix() const {
+        arma::mat44 W;
+        W << kW() << -kX() << -kY() << -kZ() << arma::endr << kX() << kW() << kZ() << -kY() << arma::endr << kY()
+          << -kZ() << kW() << kX() << arma::endr << kZ() << kY() << -kX() << kW() << arma::endr;
+        return W;
+    }
+
+
+    float UnitQuaternion::random(float a, float b) {
+        float alpha = rand() / float(RAND_MAX);
+        return a * alpha + b * (1 - alpha);
+    }
+
+    UnitQuaternion UnitQuaternion::getRandomU(float max_angle) {
+        // Get angle:
+        float angle = random(0, max_angle);
+
+        // Get axis:
+        float phi      = random(0, 2 * M_PI);
+        float costheta = random(-1, 1);
+
+        float theta = std::acos(costheta);
+        float r     = 1;
+
+        float x         = r * sin(theta) * cos(phi);
+        float y         = r * sin(theta) * sin(phi);
+        float z         = r * cos(theta);
+        arma::vec3 axis = {x, y, z};
+
+        return UnitQuaternion(axis, angle);
+    }
+
+    UnitQuaternion UnitQuaternion::getRandomN(float stddev) {
+        // Get angle:
+        float angle = stddev * arma::randn(1)[0];
+
+        // Get axis:
+        float phi      = random(0, 2 * M_PI);
+        float costheta = random(-1, 1);
+
+        float theta = std::acos(costheta);
+        float r     = 1;
+
+        float x         = r * sin(theta) * cos(phi);
+        float y         = r * sin(theta) * sin(phi);
+        float z         = r * cos(theta);
+        arma::vec3 axis = {x, y, z};
+
+        return UnitQuaternion(axis, angle);
+    }
+
+    double UnitQuaternion::norm() {
+        return kW() * kW() + kX() * kX() + kY() * kY() + kZ() * kZ();
+    }
+
+    UnitQuaternion UnitQuaternion::operator-(const UnitQuaternion& p) const {
+        return *this * p.i();
+    }
+
+    UnitQuaternion UnitQuaternion::operator*(const UnitQuaternion& p) const {
+        // From http://en.wikipedia.org/wiki/Quaternion#Quaternions_and_the_geometry_of_R3
+        double realPart = real() * p.real() - arma::dot(imaginary(), p.imaginary());
+
+        arma::vec3 imaginaryPart =
+            arma::cross(imaginary(), p.imaginary()) + p.real() * imaginary() + real() * p.imaginary();
+
+        return UnitQuaternion(realPart, imaginaryPart);
+    }
+
+    UnitQuaternion UnitQuaternion::slerp(const UnitQuaternion& p, const double& t) {
+        // See http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/
+        // Where qa = *this and qb = p
+
+        double cosHalfTheta = kW() * p.kW() + kX() * p.kX() + kY() * p.kY() + kZ() * p.kZ();
+
+        // If qa=qb or qa=-qb then theta = 0 and we can return qa
+        if (std::abs(cosHalfTheta) >= 1.0) {
+            return *this;
+        }
+
+        double halfTheta    = utility::math::angle::acos_clamped(cosHalfTheta);
+        double sinHalfTheta = sqrt(1.0 - cosHalfTheta * cosHalfTheta);
+
+        // If theta = 180 degrees then result is not fully defined
+        // We could rotate around any axis normal to qa or qb
+        if (std::abs(sinHalfTheta) < 0.001) {
+            return *this * 0.5 + p * 0.5;
+        }
+
+        // Interpolate
+        double ratioA = std::sin((1 - t) * halfTheta) / sinHalfTheta;
+        double ratioB = std::sin(t * halfTheta) / sinHalfTheta;
+
+        return *this * ratioA + p * ratioB;
+    }
+}  // namespace utility::math::geometry

--- a/shared/utility/math/geometry/UnitQuaternion.hpp
+++ b/shared/utility/math/geometry/UnitQuaternion.hpp
@@ -1,0 +1,148 @@
+/*
+ * This file is part of the Autocalibration Codebase.
+ *
+ * The Autocalibration Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Autocalibration Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Autocalibration Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_MATH_GEOMETRY_UNITQUATERNION_HPP
+#define UTILITY_MATH_GEOMETRY_UNITQUATERNION_HPP
+
+#include <armadillo>
+
+#include "utility/math/matrix/Rotation3D.hpp"
+
+namespace utility::math {
+    namespace matrix {
+        template <int Dimensions>
+        class Rotation;
+        using Rotation3D = Rotation<3>;
+    }  // namespace matrix
+    namespace geometry {
+
+        class UnitQuaternion : public arma::vec4 {
+            using arma::vec4::vec4;  // inherit constructors
+
+        private:
+            /* @brief Constructor for non-unit quaternion for purpose of point representation
+             */
+            UnitQuaternion(const arma::vec3& v);
+
+        public:
+            UnitQuaternion();
+
+            UnitQuaternion(const matrix::Rotation3D& rotation);
+
+            UnitQuaternion(double W, double X, double Y, double Z);
+
+            UnitQuaternion(const arma::vec3& vec1, const arma::vec3& vec2);
+
+            UnitQuaternion operator-(const UnitQuaternion& p) const;
+
+            UnitQuaternion operator*(const UnitQuaternion& p) const;
+
+            UnitQuaternion(double realPart, const arma::vec3& imaginaryPart);
+
+            /*! @brief Creates quaternion which rotates about 3D axis by angle radians
+             */
+            UnitQuaternion(const arma::vec3& axis, double angle);
+
+            /*! @brief Swaps quat to -quat if kW < 0
+             */
+            void rectify();
+
+            /*! @brief Gets the inverse of the quaternion
+             */
+            UnitQuaternion i() const;
+
+            arma::vec3 rotateVector(const arma::vec3& v) const;
+
+            arma::vec3 getAxis() const;
+
+            double getAngle() const;
+
+            void setAngle(double angle);
+
+            void scaleAngle(double scale);
+
+            void normalise();
+
+            /* @return Matrix Q(q) such that given another quaternion q', then
+             * Q(q) * q' = q * q'
+             */
+            arma::mat44 getLeftQuatMultMatrix() const;
+
+            /* @return Matrix W(q) such that given another quaternion q', then
+             * W(q) * q' = q' * q
+             */
+            arma::mat44 getRightQuatMultMatrix() const;
+
+            static float random(float a, float b);
+            static UnitQuaternion getRandomU(float max_angle);
+            static UnitQuaternion getRandomN(float stddev);
+
+            double norm();
+
+            // real part
+            inline double kW() const {
+                return at(0);
+            };
+            inline double& kW() {
+                return at(0);
+            };
+
+            inline double kX() const {
+                return at(1);
+            };
+            inline double& kX() {
+                return at(1);
+            };
+
+            inline double kY() const {
+                return at(2);
+            };
+            inline double& kY() {
+                return at(2);
+            };
+
+            inline double kZ() const {
+                return at(3);
+            };
+            inline double& kZ() {
+                return at(3);
+            };
+
+            inline double real() const {
+                return at(0);
+            };
+            inline double& real() {
+                return at(0);
+            };
+
+            inline const arma::subview_col<double> imaginary() const {
+                return rows(1, 3);
+            }
+            inline arma::subview_col<double> imaginary() {
+                return rows(1, 3);
+            }
+
+            UnitQuaternion slerp(const UnitQuaternion& p, const double& t);
+            static inline UnitQuaternion Identity() {
+                return (arma::vec4({1.0, 0.0, 0.0, 0.0}));
+            }
+        };
+    }  // namespace geometry
+}  // namespace utility::math
+#endif

--- a/shared/utility/math/matrix/Rotation2D.cpp
+++ b/shared/utility/math/matrix/Rotation2D.cpp
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#include "Rotation2D.hpp"
+
+namespace utility::math::matrix {
+
+    Rotation2D::Rotation() {
+        eye();  // identity matrix by default
+    }
+
+    Rotation2D Rotation2D::rotate(double radians) const {
+        return *this * createRotation(radians);
+    }
+
+    Rotation2D Rotation2D::i() const {
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Multiplication
+        // The inverse of a rotation matrix is its transpose, which is also a rotation matrix.
+        return t();
+    }
+
+    Rotation2D Rotation2D::createRotation(double radians) {
+        double c = cos(radians);
+        double s = sin(radians);
+        Rotation2D rotation;
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations
+        rotation << c << -s << arma::endr << s << c;
+        return rotation;
+    }
+}  // namespace utility::math::matrix

--- a/shared/utility/math/matrix/Rotation2D.hpp
+++ b/shared/utility/math/matrix/Rotation2D.hpp
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_MATH_MATRIX_ROTATION2D_HPP
+#define UTILITY_MATH_MATRIX_ROTATION2D_HPP
+
+#include <armadillo>
+
+namespace utility::math::matrix {
+
+    template <int Dimensions>
+    class Rotation;
+
+    using Rotation2D = Rotation<2>;
+
+    template <>
+    class Rotation<2> : public arma::mat22 {
+        using arma::mat22::mat22;  // inherit constructors
+
+    public:
+        /**
+         * @brief Default constructor creates an identity matrix
+         */
+        Rotation();
+
+        /**
+         * @brief Rotates matrix around the local Z axis
+         *
+         * @param radians The amount to radians to rotate by
+         * @return The rotation matrix
+         */
+        Rotation2D rotate(double radians) const;
+
+        /**
+         * @brief Performs an inverse and returns a new copy
+         * Note: Assumes current transform is orthonormal and invertible (which it should be given normal use)
+         *
+         * @return The inverse transform
+         */
+        Rotation2D i() const;
+
+        /**
+         * @brief Creates a rotation matrix around the Z axis by the given radians
+         *
+         * @param radians The amount to radians to rotate by
+         * @return The rotation matrix
+         */
+        static Rotation2D createRotation(double radians);
+    };
+
+}  // namespace utility::math::matrix
+
+#endif  // UTILITY_MATH_MATRIX_ROTATION2D_HPP

--- a/shared/utility/math/matrix/Rotation3D.cpp
+++ b/shared/utility/math/matrix/Rotation3D.cpp
@@ -1,0 +1,239 @@
+/*
+ * This file is part of the Autocalibration Codebase.
+ *
+ * The Autocalibration Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Autocalibration Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Autocalibration Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#include "Rotation3D.hpp"
+
+#include "matrix.hpp"
+
+#include "utility/math/angle.hpp"
+#include "utility/math/comparison.hpp"
+
+
+namespace utility::math::matrix {
+
+    using geometry::UnitQuaternion;
+    using utility::math::almost_equal;
+
+    Rotation3D::Rotation() {
+        eye();  // identity matrix by default
+    }
+
+    Rotation3D::Rotation(const arma::mat& m) {
+        *this = m.submat(0, 0, 2, 2);
+        *this = this->orthogonalise();
+    }
+
+    Rotation3D::Rotation(const UnitQuaternion& q) {
+        // quaternion to rotation conversion
+        // http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToMatrix/
+        // http://en.wikipedia.org/wiki/Rotation_group_SO(3)#Quaternions_of_unit_norm
+        *this << 1 - 2 * q.kY() * q.kY() - 2 * q.kZ() * q.kZ() << 2 * q.kX() * q.kY() - 2 * q.kZ() * q.kW()
+              << 2 * q.kX() * q.kZ() + 2 * q.kY() * q.kW() << arma::endr << 2 * q.kX() * q.kY() + 2 * q.kZ() * q.kW()
+              << 1 - 2 * q.kX() * q.kX() - 2 * q.kZ() * q.kZ() << 2 * q.kY() * q.kZ() - 2 * q.kX() * q.kW()
+              << arma::endr << 2 * q.kX() * q.kZ() - 2 * q.kY() * q.kW() << 2 * q.kY() * q.kZ() + 2 * q.kX() * q.kW()
+              << 1 - 2 * q.kX() * q.kX() - 2 * q.kY() * q.kY();
+    }
+
+    Rotation3D::Rotation(const arma::vec3& axis) {
+        double normAxis = arma::norm(axis, 2);
+
+        if (normAxis == 0) {
+            // Axis has zero length
+            std::cout << "utility::math::matrix::Rotation3D: WARNING Zero rotation axis given" << std::endl;
+            eye();
+            return;
+        }
+
+        // Construct an othonormal basis
+        col(0) = axis / normAxis;              // x axis
+        col(1) = orthonormal(col(0));          // arbitary orthonormal vector
+        col(2) = arma::cross(col(0), col(1));  // third othogonal vector
+    }
+
+    Rotation3D::Rotation(const arma::vec3& axis, double angle) : Rotation(axis) {
+        // Rotate by angle
+
+        *this *= Rotation3D::createRotationX(angle) * i();
+    }
+
+    Rotation3D Rotation3D::orthogonalise() const {
+        Rotation3D R;
+        R.x() = this->x();
+        R.z() = arma::cross(this->x(), this->y());
+        R.y() = arma::cross(R.z(), R.x());
+        return R;
+    }
+
+    Rotation3D Rotation3D::rotateX(double radians) const {
+        return *this * createRotationX(radians);
+    }
+
+    Rotation3D Rotation3D::rotateY(double radians) const {
+        return *this * createRotationY(radians);
+    }
+
+    Rotation3D Rotation3D::rotateZ(double radians) const {
+        return *this * createRotationZ(radians);
+    }
+
+    Rotation3D Rotation3D::worldToLocal(const Rotation3D& reference) const {
+        // http://en.wikipedia.org/wiki/Change_of_basis
+        return reference.i() * (*this);
+    }
+
+    Rotation3D Rotation3D::localToWorld(const Rotation3D& reference) const {
+        // http://en.wikipedia.org/wiki/Change_of_basis
+        return reference * (*this);
+    }
+
+    Rotation3D Rotation3D::i() const {
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Multiplication
+        // The inverse of a rotation matrix is its transpose, which is also a rotation matrix.
+        return t();
+    }
+
+    AxisAngle Rotation3D::axisAngle() const {
+        AxisAngle result;
+        arma::cx_vec eigValues;
+        arma::cx_mat eigVectors;
+        arma::eig_gen(eigValues, eigVectors, *this);
+
+        Axis axis;
+        bool axisFound = false;
+        for (size_t i = 0; i < eigValues.size(); i++) {
+            if (almost_equal(std::real(eigValues[i]), 1.0, 4)) {  // account for numeric imprecision
+                axis      = arma::real(eigVectors.col(i));        // Axis of rotation
+                axisFound = true;
+            }
+        }
+
+        if (arma::norm(axis, 2) == 0 || !axisFound) {
+            throw std::domain_error("utility::math::matrix::Rotation3D::axisAngle: No rotation found");
+        }
+
+        // Construct an ONB
+        arma::vec3 s = orthonormal(axis);
+        arma::vec3 t = arma::cross(axis, s);
+        // Rotate s to calculate angle of rotation
+        arma::vec3 rs = *this * s;
+
+        return {
+            axis,
+            std::atan2(arma::dot(rs, t), arma::dot(rs, s))  // Angle of rotation
+        };
+    }
+
+    arma::vec3 Rotation3D::eulerAngles() const {
+        // See: http://staff.city.ac.uk/~sbbh653/publications/euler.pdf
+        // Computing Euler angles from a rotation matrix
+        // Gregory G. Slabaugh
+        double roll, pitch, yaw;  // psi, theta, phi
+        if (!almost_equal(std::abs(at(2, 0)), 1.0, 4)) {
+            pitch           = -utility::math::angle::asin_clamped(at(2, 0));
+            double cosPitch = std::cos(pitch);
+            roll            = std::atan2(at(2, 1) / cosPitch, at(2, 2) / cosPitch);
+            yaw             = std::atan2(at(1, 0) / cosPitch, at(0, 0) / cosPitch);
+        }
+        else {
+            roll = std::atan2(at(0, 1), at(0, 2));
+            yaw  = 0;
+            if (almost_equal(at(2, 0), -1.0, 4)) {
+                pitch = M_PI_2;
+            }
+            else {
+                pitch = -M_PI_2;
+            }
+        }
+        return {roll, pitch, yaw};
+    }
+
+    float Rotation3D::norm(Rotation3D T) {
+        UnitQuaternion q = UnitQuaternion(T);
+        // Get angle between -2Pi and 2pi
+        float angle = q.getAngle();
+        // Just want magnitude
+        float theta = std::fabs(angle);
+        // But rotating more that Pi in one direction is equivalent to a rotation in the other direction
+        return std::fmin(2 * M_PI - theta, theta);
+    }
+
+
+    Rotation3D Rotation3D::createRotationX(double radians) {
+        double c = cos(radians);
+        double s = sin(radians);
+        Rotation rotation;
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations
+        rotation << 1 << 0 << 0 << arma::endr << 0 << c << -s << arma::endr << 0 << s << c;
+        return rotation;
+    }
+
+    Rotation3D Rotation3D::createRotationXJacobian(double radians) {
+        double c = -sin(radians);
+        double s = cos(radians);
+        Rotation rotation;
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations
+        rotation << 1 << 0 << 0 << arma::endr << 0 << c << -s << arma::endr << 0 << s << c;
+        return rotation;
+    }
+
+    Rotation3D Rotation3D::createRotationY(double radians) {
+        double c = cos(radians);
+        double s = sin(radians);
+        Rotation rotation;
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations
+        rotation << c << 0 << s << arma::endr << 0 << 1 << 0 << arma::endr << -s << 0 << c;
+        return rotation;
+    }
+
+    Rotation3D Rotation3D::createRotationYJacobian(double radians) {
+        double c = -sin(radians);
+        double s = cos(radians);
+        Rotation rotation;
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations
+        rotation << c << 0 << s << arma::endr << 0 << 1 << 0 << arma::endr << -s << 0 << c;
+        return rotation;
+    }
+
+    Rotation3D Rotation3D::createRotationZ(double radians) {
+        double c = cos(radians);
+        double s = sin(radians);
+        Rotation rotation;
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations
+        rotation << c << -s << 0 << arma::endr << s << c << 0 << arma::endr << 0 << 0 << 1;
+        return rotation;
+    }
+
+    Rotation3D Rotation3D::createRotationZJacobian(double radians) {
+        double c = -sin(radians);
+        double s = cos(radians);
+        Rotation rotation;
+        // http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations
+        rotation << c << -s << 0 << arma::endr << s << c << 0 << arma::endr << 0 << 0 << 1;
+        return rotation;
+    }
+
+
+    Rotation3D Rotation3D::createFromEulerAngles(const arma::vec3& a) {
+        // double roll = a[0];
+        // double pitch = a[1];
+        // double yaw = a[2];
+        return Rotation3D::createRotationZ(a[2]) * Rotation3D::createRotationY(a[1])
+               * Rotation3D::createRotationX(a[0]);
+    }
+}  // namespace utility::math::matrix

--- a/shared/utility/math/matrix/Rotation3D.hpp
+++ b/shared/utility/math/matrix/Rotation3D.hpp
@@ -1,0 +1,223 @@
+/*
+ * This file is part of the Autocalibration Codebase.
+ *
+ * The Autocalibration Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Autocalibration Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Autocalibration Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_MATH_MATRIX_ROTATION3D_HPP
+#define UTILITY_MATH_MATRIX_ROTATION3D_HPP
+
+#include <armadillo>
+
+#include "utility/math/geometry/UnitQuaternion.hpp"
+
+namespace utility::math {
+    namespace geometry {
+        class UnitQuaternion;
+    }
+    namespace matrix {
+
+        template <int Dimensions>
+        class Transform;
+
+        using Transform3D = Transform<3>;
+
+        template <int Dimensions>
+        class Rotation;
+
+        using Rotation3D = Rotation<3>;
+        using Axis       = arma::vec3;
+        using AxisAngle  = std::pair<Axis, double>;
+
+        template <>
+        class Rotation<3> : public arma::mat33 {
+            using arma::mat33::mat33;  // inherit constructors
+        public:
+            /**
+             * @brief Default constructor creates an identity matrix
+             */
+            Rotation();
+
+            Rotation(const arma::mat& m);
+            /**
+             * @brief Convert from a quaternions vec4
+             */
+            Rotation(const geometry::UnitQuaternion& q);
+
+            /**
+             * @brief Construct an ONB using a vec3 as the X axis
+             */
+            Rotation(const arma::vec3& axis);
+
+            Rotation(const Transform3D&) = delete;
+
+            /**
+             * @brief Create a rotation matrix based on a vec3 as the X axis and an angle
+             */
+            Rotation(const arma::vec3& axis, double angle);
+
+            /**
+             * @brief Rotates matrix around the local X axis
+             *
+             * @param radians The amount to radians to rotate by
+             * @return The rotation matrix
+             */
+            Rotation3D rotateX(double radians) const;
+
+            /**
+             * @brief Rotates matrix around the local Y axis
+             *
+             * @param radians The amount to radians to rotate by
+             * @return The rotation matrix
+             */
+            Rotation3D rotateY(double radians) const;
+
+            /**
+             * @brief Rotates matrix around the local Z axis
+             *
+             * @param radians The amount to radians to rotate by
+             * @return The rotation matrix
+             */
+            Rotation3D rotateZ(double radians) const;
+
+            /**
+             * @brief Transforms current rotation from world coordinates (i.e. standard basis) to be local to
+             * 'reference'
+             *
+             * @param reference A rotation matrix to become relatively local to
+             * @return The transformed rotation matrix
+             */
+            Rotation3D worldToLocal(const Rotation3D& reference) const;
+
+            /**
+             * @brief Rotations current rotation from local coordinates relative to 'reference', to world
+             * coordinates (i.e. standard rotation)
+             *
+             * @param reference The rotation matrix that the current rotation is relative to
+             * @return The transformed rotation matrix
+             */
+            Rotation3D localToWorld(const Rotation3D& reference) const;
+
+            /**
+             * @brief Performs an inverse and returns a new copy
+             * Note: Assumes current transform is orthonormal and invertible (which it should be given normal use)
+             *
+             * @return The inverse transform
+             */
+            Rotation3D i() const;
+
+            /**
+             * @return Pair containing the axis of the rotation as a unit vector followed by the rotation angle.
+             */
+            AxisAngle axisAngle() const;
+
+            /**
+             * @return Retrieve the euler angles (xyz) from the matrix
+             */
+            arma::vec3 eulerAngles() const;
+
+            Rotation3D orthogonalise() const;
+
+            inline const arma::vec3 x() const {
+                return submat(0, 0, 2, 0);
+            }
+            inline arma::subview<double> x() {
+                return submat(0, 0, 2, 0);
+            }
+
+            inline const arma::vec3 y() const {
+                return submat(0, 1, 2, 1);
+            }
+            inline arma::subview<double> y() {
+                return submat(0, 1, 2, 1);
+            }
+
+            inline const arma::vec3 z() const {
+                return submat(0, 2, 2, 2);
+            }
+            inline arma::subview<double> z() {
+                return submat(0, 2, 2, 2);
+            }
+
+
+            /**
+             * @brief Computes 'size' of the transform T
+             *
+             */
+            static float norm(Rotation3D T);
+
+            /**
+             * @return The roll (x-axis) of the rotation matrix
+             */
+            inline double roll() const {
+                return eulerAngles()[0];
+            }
+
+            /**
+             * @return The pitch (y-axis) of the rotation matrix
+             */
+            inline double pitch() const {
+                return eulerAngles()[1];
+            }
+
+            /**
+             * @return The yaw (z-axis) of the rotation matrix
+             */
+            inline double yaw() const {
+                return eulerAngles()[2];
+            }
+
+            /**
+             * @brief Creates a rotation matrix around the X axis by the given radians
+             *
+             * @param radians The amount to radians to rotate by
+             * @return The rotation matrix
+             */
+            static Rotation3D createRotationX(double radians);
+            static Rotation3D createRotationXJacobian(double radians);
+
+            /**
+             * @brief Creates a rotation matrix around the Y axis by the given radians
+             *
+             * @param radians The amount to radians to rotate by
+             * @return The rotation matrix
+             */
+            static Rotation3D createRotationY(double radians);
+            static Rotation3D createRotationYJacobian(double radians);
+
+            /**
+             * @brief Creates a rotation matrix around the Z axis by the given radians
+             *
+             * @param radians The amount to radians to rotate by
+             * @return The rotation matrix
+             */
+            static Rotation3D createRotationZ(double radians);
+            static Rotation3D createRotationZJacobian(double radians);
+
+            /**
+             * @brief Create a rotation matrix from euler angles
+                See: http://staff.city.ac.uk/~sbbh653/publications/euler.pdf
+                Computing Euler angles from a rotation matrix
+                Gregory G. Slabaugh
+                double roll, pitch, yaw; // psi, theta, phi
+             */
+            static Rotation3D createFromEulerAngles(const arma::vec3& a);
+        };
+
+    }  // namespace matrix
+}  // namespace utility::math
+
+#endif  // UTILITY_MATH_MATRIX_ROTATION3D_HPP

--- a/shared/utility/math/matrix/Transform2D.cpp
+++ b/shared/utility/math/matrix/Transform2D.cpp
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the Autocalibration Codebase.
+ *
+ * The Autocalibration Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Autocalibration Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Autocalibration Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#include "Transform2D.hpp"
+
+#include "Rotation2D.hpp"
+
+#include "utility/math/angle.hpp"
+
+namespace utility::math::matrix {
+
+    using utility::math::angle::normalizeAngle;
+    using utility::math::angle::vectorToBearing;
+    using utility::math::matrix::Rotation2D;
+
+    Transform2D::Transform() {
+        zeros();
+    }
+
+    Transform2D::Transform(const arma::vec2 xy_, double angle_) {
+        xy()    = xy_;
+        angle() = angle_;
+    }
+
+    Transform2D Transform2D::lookAt(const arma::vec2 from, arma::vec2 to) {
+        arma::vec2 vecHeading = to - from;
+        double angle          = vectorToBearing(vecHeading);
+        return {from, angle};
+    }
+
+
+    Transform2D Transform2D::localToWorld(const Transform2D& reference) const {
+        // translates to this + rotZ(this.angle) * reference
+        Rotation2D R      = Rotation2D::createRotation(angle());
+        arma::vec2 newPos = R * reference.xy();
+        return {
+            x() + newPos[0],
+            y() + newPos[1],
+            angle() + reference.angle()  // do not use normalizeAngle here, causes bad things when turning!
+                                         // TODO: unsure on cause
+        };
+    }
+
+    Transform2D Transform2D::worldToLocal(const Transform2D& reference) const {
+        double cosAngle  = std::cos(angle());
+        double sinAngle  = std::sin(angle());
+        Transform2D diff = reference - *this;
+        // translates to rotZ(this.angle) * (reference - this)
+        return {cosAngle * diff.x() + sinAngle * diff.y(),
+                -sinAngle * diff.x() + cosAngle * diff.y(),
+                normalizeAngle(diff.angle())};
+    }
+
+    Transform2D Transform2D::interpolate(double t, const Transform2D& target) const {
+        Transform2D result = *this + t * (target - *this);
+        result.angle()     = normalizeAngle(result.angle());
+        return result;
+    }
+
+    Transform2D Transform2D::i() const {
+        arma::vec2 newDisplacement = -Rotation2D::createRotation(angle()).i() * xy();
+        return Transform2D(newDisplacement, -this->angle());
+    }
+}  // namespace utility::math::matrix

--- a/shared/utility/math/matrix/Transform2D.hpp
+++ b/shared/utility/math/matrix/Transform2D.hpp
@@ -1,0 +1,128 @@
+/*
+ * This file is part of the Autocalibration Codebase.
+ *
+ * The Autocalibration Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Autocalibration Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Autocalibration Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_MATH_MATRIX_TRANSFORM2D_HPP
+#define UTILITY_MATH_MATRIX_TRANSFORM2D_HPP
+
+#include <armadillo>
+
+#include "Rotation2D.hpp"
+
+namespace utility::math::matrix {
+
+    template <int Dimensions>
+    class Transform;
+
+    using Transform2D = Transform<2>;
+
+    /**
+     * Represents a 2D point including its rotation. Uses a vec3 of the form {x, y, angle}.
+     *
+     * See: Special Euclidean group SE(2).
+     * http://en.wikipedia.org/wiki/Euclidean_group
+     *
+     * @author Brendan Annable
+     */
+    template <>
+    class Transform<2> : public arma::vec3 {
+        using arma::vec3::vec3;  // inherit constructors
+
+    public:
+        /**
+         * @brief Default constructor initialises values to zero
+         */
+        Transform();
+
+        /**
+         * @brief Construct transform from a position and an angle.
+         */
+        Transform(const arma::vec2 xy_, double angle_);
+
+        /**
+         * Construct a transform that represents the position and
+         * orientation of a camera positioned at 'from' and facing toward
+         * 'to'.
+         */
+        static Transform2D lookAt(const arma::vec2 from, arma::vec2 to);
+
+        /**
+         * @brief Transforms position from local coordinates relative to 'reference', to world coordinates
+         *
+         * @param reference A position to become relatively local to
+         * @return The new position
+         */
+        Transform2D localToWorld(const Transform2D& reference) const;
+
+        /**
+         * @brief Transforms position from world coordinates to be local to 'reference'
+         *
+         * @param reference The position that the current position is relative to
+         * @return The new position
+         */
+        Transform2D worldToLocal(const Transform2D& reference) const;
+
+
+        /**
+         * Interpolate between itself and given target vector
+         *
+         * @param t A value between 0-1 to interpolate between the two,
+         * outside these bounds will extrapolate
+         * @param target The target vector
+         * @return The interpolated vector
+         */
+        Transform2D interpolate(double t, const Transform2D& target) const;
+
+        Transform2D i() const;
+
+        inline double x() const {
+            return at(0);
+        }
+        inline double& x() {
+            return at(0);
+        }
+
+        inline double y() const {
+            return at(1);
+        }
+        inline double& y() {
+            return at(1);
+        }
+
+        inline double angle() const {
+            return at(2);
+        }
+        inline double& angle() {
+            return at(2);
+        }
+
+        inline Rotation2D rotation() {
+            return Rotation2D::createRotation(angle());
+        }
+
+        inline const arma::subview_col<double> xy() const {
+            return rows(0, 1);
+        }
+        inline arma::subview_col<double> xy() {
+            return rows(0, 1);
+        }
+    };
+
+}  // namespace utility::math::matrix
+
+#endif  // UTILITY_MATH_MATRIX_TRANSFORM2D_HPP

--- a/shared/utility/math/matrix/Transform3D.cpp
+++ b/shared/utility/math/matrix/Transform3D.cpp
@@ -1,0 +1,252 @@
+/*
+ * This file is part of the Autocalibration Codebase.
+ *
+ * The Autocalibration Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Autocalibration Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Autocalibration Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#include "Transform3D.hpp"
+
+namespace utility::math::matrix {
+
+    using geometry::UnitQuaternion;
+
+    Transform3D::Transform() {
+        eye();  // identity matrix by default
+    }
+
+    Transform3D::Transform(const UnitQuaternion& q) : Transform(Rotation3D(q)) {}
+
+    Transform3D::Transform(const Rotation3D& rotation) : Transform() {
+        submat(0, 0, 2, 2) = rotation;
+    }
+
+    Transform3D::Transform(const Rotation3D& rotation, const arma::vec3& translation) : Transform() {
+        submat(0, 0, 2, 2)  = rotation;
+        this->translation() = translation;
+    }
+
+    Transform3D::Transform(const Transform2D& transform)
+        : Transform(Transform3D().translate({transform.x(), transform.y(), 0}).rotateZ(transform.angle())) {}
+
+    Transform3D::Transform(const arma::vec6& in)
+        : Transform(Transform3D().translate(in.rows(0, 2)).rotateZ(in[5]).rotateY(in[4]).rotateX(in[3])) {}
+
+    Transform3D::Transform(const arma::vec3& in) : Transform(Transform3D().translate(in)) {}
+
+    Transform3D Transform3D::translate(const arma::vec3& translation) const {
+        return *this * createTranslation(translation);
+    }
+
+    Transform3D Transform3D::translateX(double translation) const {
+        return translate({translation, 0, 0});
+    }
+
+    Transform3D Transform3D::translateY(double translation) const {
+        return translate({0, translation, 0});
+    }
+
+    Transform3D Transform3D::translateZ(double translation) const {
+        return translate({0, 0, translation});
+    }
+
+    Transform3D Transform3D::rotateX(double radians) const {
+        return *this * createRotationX(radians);
+    }
+
+    Transform3D Transform3D::rotateY(double radians) const {
+        return *this * createRotationY(radians);
+    }
+
+    Transform3D Transform3D::rotateZ(double radians) const {
+        return *this * createRotationZ(radians);
+    }
+
+    Transform3D Transform3D::scale(const arma::vec3& v) const {
+        return *this * createScale(v);
+    }
+
+    Transform3D Transform3D::rotateLocal(const Rotation3D& rotation, const Transform3D& local) const {
+        return Transform3D(Transform3D(rotation) * worldToLocal(local)).localToWorld(local);
+    }
+
+    Transform3D Transform3D::rotateXLocal(double radians, const Transform3D& local) const {
+        return Transform3D(createRotationX(radians) * worldToLocal(local)).localToWorld(local);
+    }
+
+    Transform3D Transform3D::rotateYLocal(double radians, const Transform3D& local) const {
+        return Transform3D(createRotationY(radians) * worldToLocal(local)).localToWorld(local);
+    }
+
+    Transform3D Transform3D::rotateZLocal(double radians, const Transform3D& local) const {
+        return Transform3D(createRotationZ(radians) * worldToLocal(local)).localToWorld(local);
+    }
+
+    Transform3D Transform3D::worldToLocal(const Transform3D& reference) const {
+        // http://en.wikipedia.org/wiki/Change_of_basis
+        return reference.i() * (*this);
+    }
+
+    Transform3D Transform3D::localToWorld(const Transform3D& reference) const {
+        // http://en.wikipedia.org/wiki/Change_of_basis
+        return reference * (*this);
+    }
+
+
+    arma::vec3 Transform3D::transformPoint(const arma::vec3& p) const {
+        arma::vec4 p4      = arma::join_cols(p, arma::vec({1}));
+        arma::vec4 result4 = *this * p4;
+        return result4.rows(0, 2);
+    }
+
+    arma::vec3 Transform3D::transformVector(const arma::vec3& p) const {
+        arma::vec4 p4      = arma::join_cols(p, arma::vec({0}));
+        arma::vec4 result4 = *this * p4;
+        return result4.rows(0, 2);
+    }
+
+
+    Transform3D Transform3D::i() const {
+        // Create a new transform
+        Transform3D inverseTransform3D;
+        // Transpose the rotation submatrix (top-left 3x3), this is equivalent to taking the inverse of the
+        // rotation matrix
+        inverseTransform3D.submat(0, 0, 2, 2) = submat(0, 0, 2, 2).t();
+        // Multiply translation vector (top-right column vector) by the negated inverse rotation matrix
+
+        inverseTransform3D.submat(0, 3, 2, 3) = -inverseTransform3D.submat(0, 0, 2, 2) * submat(0, 3, 2, 3);
+        /*if (arma::norm(inverseTransform3D * (*this) - arma::eye(4,4)) > 1e-10){
+            NUClear::log<NUClear::WARN>("Inverse failed! Matrix is singular");
+        }*/
+        return inverseTransform3D;
+    }
+
+    float Transform3D::norm(Transform3D T) {
+        float pos_norm = arma::norm(T.translation());
+        // return Rotation3D::norm(T.rotation());
+        // TODO: how to weight these two?
+        return pos_norm + Rotation3D::norm(T.rotation());
+    }
+
+    float Transform3D::random(float a, float b) {
+        float alpha = rand() / float(RAND_MAX);
+        return a * alpha + b * (1 - alpha);
+    }
+
+    Transform3D Transform3D::getRandomU(float max_angle, float max_displacement) {
+        UnitQuaternion q = UnitQuaternion::getRandomU(max_angle);
+        Rotation3D R(q);
+
+        // Get displacement:
+
+        float phi      = random(0, 2 * M_PI);
+        float costheta = random(-1, 1);
+        float u        = random(0, 1);
+
+        float theta = std::acos(costheta);
+        float r     = max_displacement * std::pow(u, 1 / 3.0);
+
+        float x = r * sin(theta) * cos(phi);
+        float y = r * sin(theta) * sin(phi);
+        float z = r * cos(theta);
+
+        return Transform3D(R, arma::vec3({x, y, z}));
+    }
+
+    Transform3D Transform3D::getRandomN(float stddev_angle, float stddev_disp) {
+        UnitQuaternion q = UnitQuaternion::getRandomN(stddev_angle);
+        Rotation3D R(q);
+
+        // Get displacement:
+        arma::vec3 displacement = stddev_disp * arma::randn(3);
+
+        return Transform3D(R, displacement);
+    }
+
+    Transform3D Transform3D::createTranslation(const arma::vec3& translation) {
+        Transform3D transform;
+        transform.col(3).rows(0, 2) = translation;
+        return transform;
+    }
+
+    Transform3D Transform3D::createRotationX(double radians) {
+        Transform3D transform;
+        transform.submat(0, 0, 2, 2) = Rotation3D::createRotationX(radians);
+        return transform;
+    }
+
+    Transform3D Transform3D::createRotationY(double radians) {
+        Transform3D transform;
+        transform.submat(0, 0, 2, 2) = Rotation3D::createRotationY(radians);
+        return transform;
+    }
+
+    Transform3D Transform3D::createRotationZ(double radians) {
+        Transform3D transform;
+        transform.submat(0, 0, 2, 2) = Rotation3D::createRotationZ(radians);
+        return transform;
+    }
+
+    Transform3D Transform3D::createScale(const arma::vec3& v) {
+        Transform3D transform;
+        transform.rotation() = arma::diagmat(v);
+        return transform;
+    }
+
+    Transform3D Transform3D::interpolate(Transform3D T1, Transform3D T2, float alpha) {
+        Rotation3D r1     = T1.rotation();
+        UnitQuaternion q1 = UnitQuaternion(r1);
+        Rotation3D r2     = T2.rotation();
+        UnitQuaternion q2 = UnitQuaternion(r2);
+
+        arma::vec3 t1 = T1.translation();
+        arma::vec3 t2 = T2.translation();
+
+        UnitQuaternion qResult = q1.slerp(q2, alpha);
+        arma::vec3 tResult     = alpha * (t2 - t1) + t1;
+
+        Transform3D TResult   = Transform3D(Rotation3D(qResult));
+        TResult.translation() = tResult;
+
+        return TResult;
+    }
+
+
+    Transform2D Transform3D::projectTo2D(const arma::vec3& yawAxis, const arma::vec3& forwardAxis) const {
+        Transform2D result;
+
+        // Translation
+        arma::vec3 orthoForwardAxis = arma::normalise(arma::cross(yawAxis, arma::cross(forwardAxis, yawAxis)));
+        arma::vec3 r                = translation();
+        Rotation3D newSpaceToWorld;
+        newSpaceToWorld.x()        = orthoForwardAxis;
+        newSpaceToWorld.y()        = arma::cross(yawAxis, orthoForwardAxis);
+        newSpaceToWorld.z()        = yawAxis;
+        Rotation3D worldToNewSpace = newSpaceToWorld.i();
+        arma::vec3 rNewSpace       = worldToNewSpace * r;
+        result.xy()                = rNewSpace.rows(0, 1);
+
+        // Rotation
+        Rotation3D rot       = rotation();
+        arma::vec3 x         = rot.x();
+        arma::vec3 xNew      = worldToNewSpace * x;
+        float theta_x_from_f = std::atan2(xNew[1], xNew[0]);  // sin/cos
+        result.angle()       = theta_x_from_f;
+
+        // std::cerr << "in = \n" << *this << std::endl;
+        // std::cerr << "out = \n" << result << std::endl;
+        return result;
+    }
+}  // namespace utility::math::matrix

--- a/shared/utility/math/matrix/Transform3D.hpp
+++ b/shared/utility/math/matrix/Transform3D.hpp
@@ -1,0 +1,305 @@
+/*
+ * This file is part of the Autocalibration Codebase.
+ *
+ * The Autocalibration Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Autocalibration Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Autocalibration Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_MATH_MATRIX_TRANSFORM3D_HPP
+#define UTILITY_MATH_MATRIX_TRANSFORM3D_HPP
+
+#include <armadillo>
+
+#include "utility/math/geometry/UnitQuaternion.hpp"
+#include "utility/math/matrix/Rotation3D.hpp"
+#include "utility/math/matrix/Transform2D.hpp"
+
+namespace utility::math::matrix {
+
+    template <int Dimensions>
+    class Transform;
+
+    using Transform3D = Transform<3>;
+
+    /**
+     * @brief A 4x4 homogeneous orthonormal basis matrix class for representing 3D transformations
+     *
+     * See:
+     * http://en.wikipedia.org/wiki/Transformation_matrix
+     * http://en.wikipedia.org/wiki/Rotation_group_SO(3)
+     * http://en.wikipedia.org/wiki/Orthogonal_matrix
+     * http://en.wikipedia.org/wiki/Orthonormal_basis
+     *
+     * @author Brendan Annable
+     */
+    template <>
+    class Transform<3> : public arma::mat44 {
+        using arma::mat44::mat44;  // inherit constructors
+
+    public:
+        /**
+         * @brief Default constructor creates an identity matrix
+         */
+        Transform();
+
+        /**
+         * @brief Convert from a quaternions vec4
+         */
+        Transform(const geometry::UnitQuaternion& q);
+
+        /**
+         * @brief Convert from a Transform2D matrix
+         */
+        Transform(const Transform2D& transform);
+
+        /**
+         * @brief Convert from a Rotation3D matrix
+         */
+
+        Transform(const Rotation3D& rotation);
+
+        /**
+         * @brief Convert from a Rotation3D matrix
+         */
+        Transform(const Rotation3D& rotation, const arma::vec3& translation);
+
+        /**
+         * @brief Convert from a vec6 representing [position_x, position_y, position_z, rotation_x, rotation_y,
+         * rotation_z]
+         */
+        Transform(const arma::vec6& in);
+        /**
+         * @brief Convert from a vec3 representing [..., ..., ...]
+         */
+        Transform(const arma::vec3& in);
+
+        /**
+         * @brief Translate the current basis by the given 3D vector in local space
+         *
+         * @param translation The 3D translation vector to translate by
+         * @return The transformed basis matrix
+         */
+        Transform3D translate(const arma::vec3& translation) const;
+
+        /*
+         * @brief Translate the current basis along the local X axis
+         *
+         * This translates along the column vector submatrix(0,0,2,0)
+         *
+         * @param translation The amount to translate by
+         * @return The transformed basis matrix
+         */
+        Transform3D translateX(double translation) const;
+
+        /**
+         * @brief Translate the current basis along the local Y axis
+         *
+         * This translates along the column vector submatrix(0,1,2,1)
+         *
+         * @param translation The amount to translate by
+         * @return The transformed basis matrix
+         */
+        Transform3D translateY(double translation) const;
+
+        /**
+         * @brief Translate the current basis along the local Z axis
+         *
+         * This translates along the column vector submatrix(0,2,2,2)
+         *
+         * @param translation The amount to translate by
+         * @return The transformed basis matrix
+         */
+        Transform3D translateZ(double translation) const;
+
+        /**
+         * @brief Rotates basis matrix around the local X axis
+         *
+         * @param radians The amount to radians to rotate by
+         * @return The transformed basis matrix
+         */
+        Transform3D rotateX(double radians) const;
+
+        /**
+         * @brief Rotates basis matrix around the local Y axis
+         *
+         * @param radians The amount to radians to rotate by
+         * @return The transformed basis matrix
+         */
+        Transform3D rotateY(double radians) const;
+
+        /**
+         * @brief Rotates basis matrix around the local Z axis
+         *
+         * @param radians The amount to radians to rotate by
+         * @return The transformed basis matrix
+         */
+        Transform3D rotateZ(double radians) const;
+
+        Transform3D scale(const arma::vec3& v) const;
+
+        Transform3D rotateLocal(const Rotation3D& rotation, const Transform3D& local) const;
+        Transform3D rotateXLocal(double radians, const Transform3D& local) const;
+        Transform3D rotateYLocal(double radians, const Transform3D& local) const;
+        Transform3D rotateZLocal(double radians, const Transform3D& local) const;
+
+        /**
+         * @brief Transforms current basis from world coordinates (i.e. standard basis) to be local to
+         * 'reference'
+         *
+         * @param reference A basis matrix to become relatively local to
+         * @return The transformed basis matrix
+         */
+        Transform3D worldToLocal(const Transform3D& reference) const;
+
+        /**
+         * @brief Transforms current basis from local coordinates relative to 'reference', to world coordinates
+         * (i.e. standard basis)
+         *
+         * @param reference The basis matrix that the current basis is relative to
+         * @return The transformed basis matrix
+         */
+        Transform3D localToWorld(const Transform3D& reference) const;
+
+        arma::vec3 transformPoint(const arma::vec3& p) const;
+        arma::vec3 transformVector(const arma::vec3& p) const;
+
+        /**
+         * @brief Performs an orthonormal inverse and returns a new copy
+         * Note: Assumes current transform is orthonormal and invertible (which it should be given normal use)
+         * Note: Unlike most methods this returns a new transform and does not modify the current transform
+         *
+         * @return The inverse transform
+         */
+        Transform3D i() const;
+
+        /**
+         * @return The 3x3 rotation matrix
+         */
+        inline const Rotation3D rotation() const {
+            return submat(0, 0, 2, 2);
+        }
+        inline arma::subview<double> rotation() {
+            return submat(0, 0, 2, 2);
+        }
+
+        inline const arma::vec3 translation() const {
+            return submat(0, 3, 2, 3);
+        }
+        inline arma::subview<double> translation() {
+            return submat(0, 3, 2, 3);
+        }
+
+        inline const arma::vec3 x() const {
+            return submat(0, 0, 2, 0);
+        }
+        inline arma::subview<double> x() {
+            return submat(0, 0, 2, 0);
+        }
+
+        inline const arma::vec3 y() const {
+            return submat(0, 1, 2, 1);
+        }
+        inline arma::subview<double> y() {
+            return submat(0, 1, 2, 1);
+        }
+
+        inline const arma::vec3 z() const {
+            return submat(0, 2, 2, 2);
+        }
+        inline arma::subview<double> z() {
+            return submat(0, 2, 2, 2);
+        }
+
+        arma::vec3 eulerAngles() const {
+            return rotation().eulerAngles();
+        }
+
+        inline const arma::mat44 raw() const {
+            return *this;
+        }
+        inline arma::mat44 raw() {
+            return *this;
+        }
+
+        /**
+         * @brief Computes 'size' of the transform T
+         *
+         */
+        static float norm(Transform3D T);
+
+        static float random(float a, float b);
+        /**
+         * @brief Gets a random transform
+         * U for uniform
+         * N for normal
+         *
+         */
+        static Transform3D getRandomU(float max_angle, float max_displacement);
+        static Transform3D getRandomN(float stddev_angle, float stddev_disp);
+
+
+        /**
+         * @brief Creates a translation transform by the given 3D vector
+         *
+         * @param translation The 3D translation vector to translate by
+         * @return The translation transform
+         */
+        static Transform3D createTranslation(const arma::vec3& translation);
+
+        /**
+         * @brief Creates a rotation transform around the X axis by the given radians
+         *
+         * @param radians The amount to radians to rotate by
+         * @return The rotation transform
+         */
+        static Transform3D createRotationX(double radians);
+
+        /**
+         * @brief Creates a rotation transform around the Y axis by the given radians
+         *
+         * @param radians The amount to radians to rotate by
+         * @return The rotation transform
+         */
+        static Transform3D createRotationY(double radians);
+
+        /**
+         * @brief Creates a rotation transform around the Z axis by the given radians
+         *
+         * @param radians The amount to radians to rotate by
+         * @return The rotation transform
+         */
+        static Transform3D createRotationZ(double radians);
+
+        static Transform3D createScale(const arma::vec3& v);
+
+        /**
+         * @brief Interpolates between two transforms
+         *
+         * @param alpha
+         * @return  alpha * (T2 - T1) + T1;
+         */
+        static Transform3D interpolate(Transform3D T1, Transform3D T2, float alpha);
+
+        /**
+         * @brief Construct transform from a transform 3D assuming the angle is around the yawAxis
+         * and the translation is projected onto the plane normal to yawAxis
+         */
+        Transform2D projectTo2D(const arma::vec3& yawAxis     = arma::vec3({0, 0, 1}),
+                                const arma::vec3& forwardAxis = arma::vec3({1, 0, 0})) const;
+    };
+
+}  // namespace utility::math::matrix
+
+#endif  // UTILITY_MATH_MATRIX_TRANSFORM3D_HPP

--- a/shared/utility/math/matrix/matrix.hpp
+++ b/shared/utility/math/matrix/matrix.hpp
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2013 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_MATH_MATRIX_HPP
+#define UTILITY_MATH_MATRIX_HPP
+
+#include <armadillo>
+
+/**
+ * Matrix related helper methods
+ *
+ * @author Brendan Annable
+ */
+
+namespace utility::math::matrix {
+
+
+    /**
+     * @brief Returns an orthogonal vec3 to a given vec3
+     * See: http://a.pomf.se/egicug.pdf
+     * Efficient Construction of Perpendicular Vectors without Branching
+     * Michael M. Stark
+     */
+    inline arma::vec3 orthogonal(const arma::vec3& v) {
+        const unsigned int uyx = static_cast<unsigned int>(std::signbit(std::abs(v[0]) - std::abs(v[1])));
+        const unsigned int uzx = static_cast<unsigned int>(std::signbit(std::abs(v[0]) - std::abs(v[2])));
+        const unsigned int uzy = static_cast<unsigned int>(std::signbit(std::abs(v[1]) - std::abs(v[2])));
+        const unsigned int xm  = uyx & uzx;
+        const unsigned int ym  = (1 ^ xm) & uzy;
+        const unsigned int zm  = 1 ^ (xm & ym);
+        return {zm * v[1] - ym * v[2], xm * v[2] - zm * v[0], ym * v[0] - xm * v[1]};
+    }
+
+    /**
+     * @brief An alternative method for returning a orthogonal vec3 to a given vec3
+     * See: http://lolengine.net/blog/2013/09/21/picking-orthogonal-vector-combing-coconuts
+     */
+    inline arma::vec3 orthogonal2(const arma::vec3& v) {
+        return std::abs(v[0]) > std::abs(v[2]) ? arma::vec3({-v[1], v[0], 0}) : arma::vec3({0, -v[2], v[1]});
+    }
+
+    /**
+     * @brief Returns an arbitary orthonormal vec3 to the given vec3
+     */
+    inline arma::vec3 orthonormal(const arma::vec3& v) {
+        auto u = orthogonal(v);
+        return arma::normalise(u);
+    }
+}  // namespace utility::math::matrix
+#endif  // UTILITY_MATH_MATRIX_HPP

--- a/shared/utility/motion/Balance.cpp
+++ b/shared/utility/motion/Balance.cpp
@@ -92,6 +92,9 @@ namespace utility::motion {
         // TODO: LEARN HOW TO COMPUTE THE INTEGRAL TERM CORRECTLY
         // footGoalErrorSum = footGoalErrorSum.slerp(goalQuaternion * footGoalErrorSum, 1.0/90.0);
 
+        // emit(graph("pid", Rotation3D(goalQuaternion).pitch(), Rotation3D(footGoalErrorSum).pitch(),
+        // Rotation3D(error).pitch()));
+
         // Apply the PID gains
         Eigen::AngleAxisf ankleRotation =
             Eigen::AngleAxisf(Eigen::Quaternion<float>::Identity().slerp(rotationPGain, errorQuaternion)
@@ -166,6 +169,11 @@ namespace utility::motion {
                 translationPGainY * sensors.Htw(2, 3) * roll + translationDGainY * sensors.Htw(2, 3) * dRoll,
                 -translationPGainZ * total - translationDGainY * dTotal)
                 .cast<float>();
+
+        // //Rotate from world space to torso space
+        // Rotation3D yawLessOrientation =
+        // Rotation3D::createRotationZ(-Transform3D(convert(sensors.Htw)).rotation()).yaw()) *
+        // Transform3D(convert(sensors.Htw)).rotation();
 
         // Apply opposite translation to the foot position
         footToTorso = footToTorso.translate(-torsoAdjustment_world);

--- a/shared/utility/motion/ForwardKinematics.hpp
+++ b/shared/utility/motion/ForwardKinematics.hpp
@@ -21,6 +21,7 @@
 #define UTILITY_MOTION_FORWARDKINEMATICS_HPP
 
 #include <Eigen/Geometry>
+#include <armadillo>
 #include <cmath>
 #include <nuclear>
 #include <vector>
@@ -32,6 +33,9 @@
 #include "utility/input/LimbID.hpp"
 #include "utility/input/ServoID.hpp"
 #include "utility/math/angle.hpp"
+#include "utility/math/matrix/Rotation3D.hpp"
+#include "utility/math/matrix/Transform3D.hpp"
+#include "utility/support/eigen_armadillo.hpp"
 
 namespace utility::motion::kinematics {
 
@@ -466,6 +470,47 @@ namespace utility::motion::kinematics {
         return inertia_tensor;
     }  // namespace kinematics
 
+
+    inline utility::math::matrix::Transform3D calculateBodyToGround(arma::vec3 groundNormal_body, double bodyHeight) {
+        arma::vec3 X            = arma::vec{1, 0, 0};
+        double projectXOnNormal = groundNormal_body[0];
+
+        arma::vec3 groundMatrixX;
+        arma::vec3 groundMatrixY;
+
+        if (std::fabs(projectXOnNormal) == 1) {
+            // Then x is parallel to the ground normal and we need to use projection onto +/-z instead
+            // If x parallel to normal, then use -z, if x antiparallel use z
+            arma::vec3 Z            = arma::vec3{0, 0, (projectXOnNormal > 0 ? -1.0 : 1.0)};
+            double projectZOnNormal = arma::dot(Z, groundNormal_body);
+            groundMatrixX           = arma::normalise(Z - projectZOnNormal * groundNormal_body);
+            groundMatrixY           = arma::cross(groundNormal_body, groundMatrixX);
+        }
+        else {
+            groundMatrixX = arma::normalise(X - projectXOnNormal * groundNormal_body);
+            groundMatrixY = arma::cross(groundNormal_body, groundMatrixX);
+        }
+
+        utility::math::matrix::Transform3D groundToBody;
+        groundToBody.submat(0, 0, 2, 0) = groundMatrixX;
+        groundToBody.submat(0, 1, 2, 1) = groundMatrixY;
+        groundToBody.submat(0, 2, 2, 2) = groundNormal_body;
+        groundToBody.submat(0, 3, 2, 3) = arma::vec{0, 0, -bodyHeight};
+        return groundToBody.i();
+    }
+
+    inline arma::mat22 calculateRobotToIMU(math::matrix::Rotation3D orientation) {
+        arma::vec3 xRobotImu  = orientation.i().col(0);
+        arma::vec2 projXRobot = arma::normalise(xRobotImu.rows(0, 1));
+        arma::vec2 projYRobot = arma::vec2({-projXRobot(1), projXRobot(0)});
+
+        arma::mat22 robotToImu;
+        robotToImu.col(0) = projXRobot;
+        robotToImu.col(1) = projYRobot;
+
+        return robotToImu;
+    }
+
     inline Eigen::Matrix2d calculateRobotToIMU(const Eigen::Affine3d& orientation) {
         Eigen::Vector3d xRobotImu  = orientation.rotation().topRows<1>();
         Eigen::Vector2d projXRobot = xRobotImu.head<2>().normalized();
@@ -475,6 +520,69 @@ namespace utility::motion::kinematics {
         robotToImu << projXRobot, projYRobot;
 
         return robotToImu;
+    }
+
+    /*! @return matrix J such that \overdot{X} = J * \overdot{theta}
+     */
+    inline arma::mat33 calculateArmJacobian(const KinematicsModel& model, const arma::vec3& a, bool isLeft) {
+        int negativeIfRight = isLeft ? 1 : -1;
+
+        const arma::vec3 t1 = {model.arm.SHOULDER_LENGTH,
+                               negativeIfRight * model.arm.SHOULDER_WIDTH,
+                               -model.arm.SHOULDER_HEIGHT};
+        const arma::vec3 t2 = {model.arm.UPPER_ARM_X_OFFSET,
+                               negativeIfRight * model.arm.UPPER_ARM_Y_OFFSET,
+                               -model.arm.UPPER_ARM_LENGTH};
+        const arma::vec3 t3 = {model.arm.LOWER_ARM_LENGTH,
+                               negativeIfRight * model.arm.LOWER_ARM_Y_OFFSET,
+                               -model.arm.LOWER_ARM_Z_OFFSET};
+
+        arma::mat33 jRY1 = utility::math::matrix::Rotation3D::createRotationYJacobian(a[0] - M_PI_2);
+        arma::mat33 jRX2 = utility::math::matrix::Rotation3D::createRotationXJacobian(a[1]);
+        arma::mat33 jRY3 = utility::math::matrix::Rotation3D::createRotationXJacobian(a[2]);
+
+        arma::mat33 RY1 = utility::math::matrix::Rotation3D::createRotationY(a[0] - M_PI_2);
+        arma::mat33 RX2 = utility::math::matrix::Rotation3D::createRotationX(a[1]);
+        arma::mat33 RY3 = utility::math::matrix::Rotation3D::createRotationY(a[2]);
+
+        arma::mat33 RY_PI_2 = utility::math::matrix::Rotation3D::createRotationY(M_PI_2);
+
+        arma::vec3 col1 = jRY1 * RX2 * RY_PI_2 * RY3 * t3 + jRY1 * RX2 * t2 + jRY1 * t1;
+
+        arma::vec3 col2 = RY1 * jRX2 * RY_PI_2 * RY3 * t3 + RY1 * jRX2 * t2;
+
+        arma::vec3 col3 = RY1 * RX2 * RY_PI_2 * jRY3 * t3;
+
+        return arma::join_rows(col1, arma::join_rows(col2, col3));
+    }
+    /*! @return matrix J such that \overdot{X} = J * \overdot{theta}
+     */
+    inline arma::vec3 calculateArmPosition(const KinematicsModel& model, const arma::vec3& a, bool isLeft) {
+        int negativeIfRight = isLeft ? 1 : -1;
+
+        const arma::vec3 t0 = {model.arm.SHOULDER_X_OFFSET,
+                               negativeIfRight * model.arm.DISTANCE_BETWEEN_SHOULDERS / 2.0,
+                               model.arm.SHOULDER_Z_OFFSET};
+
+        const arma::vec3 t1 = {model.arm.SHOULDER_LENGTH,
+                               negativeIfRight * model.arm.SHOULDER_WIDTH,
+                               -model.arm.SHOULDER_HEIGHT};
+        const arma::vec3 t2 = {model.arm.UPPER_ARM_X_OFFSET,
+                               negativeIfRight * model.arm.UPPER_ARM_Y_OFFSET,
+                               -model.arm.UPPER_ARM_LENGTH};
+        const arma::vec3 t3 = {model.arm.LOWER_ARM_LENGTH,
+                               negativeIfRight * model.arm.LOWER_ARM_Y_OFFSET,
+                               -model.arm.LOWER_ARM_Z_OFFSET};
+
+        arma::mat33 RY_PI_2 = utility::math::matrix::Rotation3D::createRotationY(M_PI_2);
+
+        arma::mat33 RY1 = utility::math::matrix::Rotation3D::createRotationY(a[0] - M_PI_2);
+        arma::mat33 RX2 = utility::math::matrix::Rotation3D::createRotationX(a[1]);
+        arma::mat33 RY3 = utility::math::matrix::Rotation3D::createRotationY(a[2]);
+
+        arma::vec3 pos = RY1 * RX2 * RY_PI_2 * RY3 * t3 + RY1 * RX2 * t2 + RY1 * t1 + t0;
+
+        return pos;
     }
 
     template <typename T, typename Scalar = typename T::Scalar, typename MatrixType = typename T::LinearMatrixType>

--- a/shared/utility/motion/InverseKinematics.cpp
+++ b/shared/utility/motion/InverseKinematics.cpp
@@ -36,6 +36,187 @@ namespace utility::motion::kinematics {
         @param isLeft Request for left leg motors or right leg motors?
         @param RobotKinematicsModel The class containing the leg model of the robot.
     */
+
+    bool legPoseValid(const KinematicsModel& model, utility::math::matrix::Transform3D target, LimbID limb) {
+        const float HIP_OFFSET_Y     = model.leg.HIP_OFFSET_Y;
+        const float HIP_OFFSET_Z     = model.leg.HIP_OFFSET_Z;
+        const float HIP_OFFSET_X     = model.leg.HIP_OFFSET_X;
+        const float UPPER_LEG_LENGTH = model.leg.UPPER_LEG_LENGTH;
+        const float LOWER_LEG_LENGTH = model.leg.LOWER_LEG_LENGTH;
+
+        // Translate up foot
+        auto targetLeg = target.translate(arma::vec3({0, 0, model.leg.FOOT_HEIGHT}));
+
+        // Remove hip offset
+        int negativeIfRight  = (limb == LimbID::RIGHT_LEG) ? -1 : 1;
+        arma::vec3 hipOffset = {HIP_OFFSET_X, negativeIfRight * HIP_OFFSET_Y, -HIP_OFFSET_Z};
+        targetLeg.translation() -= hipOffset;
+
+        float length       = arma::norm(targetLeg.translation());
+        float maxLegLength = UPPER_LEG_LENGTH + LOWER_LEG_LENGTH;
+        return (length < maxLegLength);
+    }
+
+    std::vector<std::pair<ServoID, float>> calculateLegJoints(const KinematicsModel& model,
+                                                              utility::math::matrix::Transform3D target,
+                                                              LimbID limb) {
+        const float LENGTH_BETWEEN_LEGS             = model.leg.LENGTH_BETWEEN_LEGS;
+        const float DISTANCE_FROM_BODY_TO_HIP_JOINT = model.leg.HIP_OFFSET_Z;
+        const float HIP_OFFSET_X                    = model.leg.HIP_OFFSET_X;
+        const float UPPER_LEG_LENGTH                = model.leg.UPPER_LEG_LENGTH;
+        const float LOWER_LEG_LENGTH                = model.leg.LOWER_LEG_LENGTH;
+
+        std::vector<std::pair<ServoID, float>> positions;
+
+        float hipYaw     = 0;
+        float hipRoll    = 0;
+        float hipPitch   = 0;
+        float knee       = 0;
+        float anklePitch = 0;
+        float ankleRoll  = 0;
+
+        // Correct for input referencing the bottom of the foot
+        target = target.translate(arma::vec3({0, 0, model.leg.FOOT_HEIGHT}));
+
+        // TODO remove this. It was due to wrong convention use
+        utility::math::matrix::Transform3D inputCoordinatesToCalcCoordinates;
+        // clang-format off
+            inputCoordinatesToCalcCoordinates << 0 << 1 <<  0 << 0 << arma::endr
+                                              << 1 << 0 <<  0 << 0 << arma::endr
+                                              << 0 << 0 << -1 << 0 << arma::endr
+                                              << 0 << 0 <<  0 << 1;
+        // clang-format on
+        // Rotate input position from standard robot coords to foot coords
+        // NUClear::log<NUClear::DEBUG>("Target Original\n", target);
+        arma::vec3 fourthColumn = target.col(3).head(3);
+        fourthColumn            = inputCoordinatesToCalcCoordinates.transformPoint(fourthColumn);
+        target                  = inputCoordinatesToCalcCoordinates * target * inputCoordinatesToCalcCoordinates.t();
+        target.col(3).head(3)   = fourthColumn;
+        // NUClear::log<NUClear::DEBUG>("Target Final\n", target);
+
+        // swap legs if needed
+        if (limb != LimbID::LEFT_LEG) {
+            target.submat(0, 0, 2, 2) = arma::mat33{-1, 0, 0, 0, 1, 0, 0, 0, 1} * target.submat(0, 0, 2, 2);
+            target.submat(0, 0, 2, 0) *= -1;
+            target(0, 3) *= -1;
+        }
+
+        arma::vec3 ankleX = target.submat(0, 0, 2, 0);
+        arma::vec3 ankleY = target.submat(0, 1, 2, 1);
+        arma::vec3 ankleZ = target.submat(0, 2, 2, 2);
+
+        arma::vec3 anklePos = target.submat(0, 3, 2, 3);
+
+        arma::vec3 hipOffset = {LENGTH_BETWEEN_LEGS / 2.0, HIP_OFFSET_X, DISTANCE_FROM_BODY_TO_HIP_JOINT};
+
+        arma::vec3 targetLeg = anklePos - hipOffset;
+
+        float length       = arma::norm(targetLeg);
+        float maxLegLength = UPPER_LEG_LENGTH + LOWER_LEG_LENGTH;
+        if (length > maxLegLength) {
+            // NUClear::log<NUClear::WARN>("InverseKinematics::calculateLegJoints : !!! WARNING !!! Requested
+            // position beyond leg reach.\n Scaling back requested vector from length ",length, " to ",
+            // maxLegLength);
+            targetLeg = targetLeg * (maxLegLength) / length;
+            length    = arma::norm(targetLeg);
+        }
+        // NUClear::log<NUClear::DEBUG>("Length: ", length);
+        float sqrLength   = length * length;
+        float sqrUpperLeg = UPPER_LEG_LENGTH * UPPER_LEG_LENGTH;
+        float sqrLowerLeg = LOWER_LEG_LENGTH * LOWER_LEG_LENGTH;
+
+        float cosKnee = (sqrUpperLeg + sqrLowerLeg - sqrLength) / (2 * UPPER_LEG_LENGTH * LOWER_LEG_LENGTH);
+        // NUClear::log<NUClear::DEBUG>("Cos Knee: ", cosKnee);
+        // TODO: check if cosKnee is between 1 and -1
+        knee = std::acos(std::fmax(std::fmin(cosKnee, 1), -1));
+        // NUClear::log<NUClear::DEBUG>("Knee: ", knee);
+
+        float cosLowerLeg = (sqrLowerLeg + sqrLength - sqrUpperLeg) / (2 * LOWER_LEG_LENGTH * length);
+        // TODO: check if cosLowerLeg is between 1 and -1
+        float lowerLeg = acos(cosLowerLeg);
+
+        float phi2 = acos(arma::dot(targetLeg, ankleY) / length);
+
+        anklePitch = lowerLeg + phi2 - M_PI_2;
+
+        arma::vec3 unitTargetLeg = targetLeg / length;
+
+        arma::vec3 hipX  = arma::cross(ankleY, unitTargetLeg);
+        float hipXLength = arma::norm(hipX, 2);
+        if (hipXLength > 0) {
+            hipX /= hipXLength;
+        }
+        else {
+            NUClear::log<NUClear::DEBUG>(
+                "InverseKinematics::calculateLegJoints : targetLeg and ankleY parallel. This is unhandled at "
+                "the "
+                "moment. requested pose = \n",
+                target);
+            return positions;
+        }
+        arma::vec3 legPlaneTangent = arma::cross(ankleY, hipX);  // Will be unit as ankleY and hipX are normal and unit
+
+        ankleRoll = atan2(arma::dot(ankleX, legPlaneTangent), arma::dot(ankleX, hipX));
+
+        arma::vec3 globalX = {1, 0, 0};
+        arma::vec3 globalY = {0, 1, 0};
+        arma::vec3 globalZ = {0, 0, 1};
+
+        bool isAnkleAboveWaist = arma::dot(unitTargetLeg, globalZ) < 0;
+
+        float cosZandHipX           = arma::dot(globalZ, hipX);
+        bool hipRollPositive        = cosZandHipX <= 0;
+        arma::vec3 legPlaneGlobalZ  = (isAnkleAboveWaist ? -1 : 1) * (globalZ - (cosZandHipX * hipX));
+        float legPlaneGlobalZLength = arma::norm(legPlaneGlobalZ, 2);
+        if (legPlaneGlobalZLength > 0) {
+            legPlaneGlobalZ /= legPlaneGlobalZLength;
+        }
+
+        float cosHipRoll = arma::dot(legPlaneGlobalZ, globalZ);
+        // TODO: check if cosHipRoll is between 1 and -1
+        hipRoll = (hipRollPositive ? 1 : -1) * acos(cosHipRoll);
+
+
+        float phi4 = M_PI - knee - lowerLeg;
+        // Superposition values:
+        float sinPIminusPhi2 = std::sin(M_PI - phi2);
+        arma::vec3 unitUpperLeg =
+            unitTargetLeg * (std::sin(phi2 - phi4) / sinPIminusPhi2) + ankleY * (std::sin(phi4) / sinPIminusPhi2);
+        bool isHipPitchPositive = dot(hipX, cross(unitUpperLeg, legPlaneGlobalZ)) >= 0;
+
+        hipPitch = (isHipPitchPositive ? 1 : -1) * acos(arma::dot(legPlaneGlobalZ, unitUpperLeg));
+
+        arma::vec3 hipXProjected =
+            (isAnkleAboveWaist ? -1 : 1)
+            * hipX;  // If leg is above waist then hipX is pointing in the wrong direction in the xy plane
+        hipXProjected[2] = 0;
+        hipXProjected /= arma::norm(hipXProjected, 2);
+        bool isHipYawPositive = arma::dot(hipXProjected, globalY) >= 0;
+
+        hipYaw = (isHipYawPositive ? 1 : -1) * acos(arma::dot(hipXProjected, globalX));
+
+        if (limb == LimbID::LEFT_LEG) {
+            positions.push_back(std::make_pair(ServoID::L_HIP_YAW, -hipYaw));
+            positions.push_back(std::make_pair(ServoID::L_HIP_ROLL, hipRoll));
+            positions.push_back(std::make_pair(ServoID::L_HIP_PITCH, -hipPitch));
+            positions.push_back(std::make_pair(ServoID::L_KNEE, M_PI - knee));
+            positions.push_back(std::make_pair(ServoID::L_ANKLE_PITCH, -anklePitch));
+            positions.push_back(std::make_pair(ServoID::L_ANKLE_ROLL, ankleRoll));
+        }
+        else {
+            positions.push_back(std::make_pair(ServoID::R_HIP_YAW, (model.leg.LEFT_TO_RIGHT_HIP_YAW) * -hipYaw));
+            positions.push_back(std::make_pair(ServoID::R_HIP_ROLL, (model.leg.LEFT_TO_RIGHT_HIP_ROLL) * hipRoll));
+            positions.push_back(std::make_pair(ServoID::R_HIP_PITCH, (model.leg.LEFT_TO_RIGHT_HIP_PITCH) * -hipPitch));
+            positions.push_back(std::make_pair(ServoID::R_KNEE, (model.leg.LEFT_TO_RIGHT_KNEE) * (M_PI - knee)));
+            positions.push_back(
+                std::make_pair(ServoID::R_ANKLE_PITCH, (model.leg.LEFT_TO_RIGHT_ANKLE_PITCH) * -anklePitch));
+            positions.push_back(
+                std::make_pair(ServoID::R_ANKLE_ROLL, (model.leg.LEFT_TO_RIGHT_ANKLE_ROLL) * ankleRoll));
+        }
+
+        return positions;
+    }
+
     std::vector<std::pair<ServoID, double>> calculateLegJoints(const KinematicsModel& model,
                                                                const Eigen::Affine3d& target_,
                                                                const LimbID& limb) {
@@ -330,6 +511,15 @@ namespace utility::motion::kinematics {
         return positions;
     }
 
+    std::vector<std::pair<ServoID, float>> calculateLegJoints(const KinematicsModel& model,
+                                                              utility::math::matrix::Transform3D leftTarget,
+                                                              utility::math::matrix::Transform3D rightTarget) {
+        auto joints  = calculateLegJoints(model, leftTarget, LimbID::LEFT_LEG);
+        auto joints2 = calculateLegJoints(model, rightTarget, LimbID::RIGHT_LEG);
+        joints.insert(joints.end(), joints2.begin(), joints2.end());
+        return joints;
+    }
+
     std::vector<std::pair<ServoID, float>> calculateLegJoints(const message::motion::KinematicsModel& model,
                                                               const Eigen::Affine3f& leftTarget,
                                                               const Eigen::Affine3f& rightTarget) {
@@ -337,6 +527,17 @@ namespace utility::motion::kinematics {
         auto joints2 = calculateLegJoints(model, rightTarget, LimbID::RIGHT_LEG);
         joints.insert(joints.end(), joints2.begin(), joints2.end());
         return joints;
+    }
+
+    std::vector<std::pair<ServoID, float>> calculateCameraLookJoints(const KinematicsModel& model,
+                                                                     arma::vec3 cameraUnitVector) {
+        std::vector<std::pair<ServoID, float>> positions;
+        positions.push_back(std::make_pair(ServoID::HEAD_YAW, atan2(cameraUnitVector[1], cameraUnitVector[0])));
+        positions.push_back(std::make_pair(
+            ServoID::HEAD_PITCH,
+            atan2(-cameraUnitVector[2],
+                  std::sqrt(cameraUnitVector[0] * cameraUnitVector[0] + cameraUnitVector[1] * cameraUnitVector[1]))));
+        return positions;
     }
 
     std::vector<std::pair<ServoID, double>> calculateCameraLookJoints(const KinematicsModel& model,
@@ -350,6 +551,16 @@ namespace utility::motion::kinematics {
         return positions;
     }
 
+    std::vector<std::pair<ServoID, float>> calculateHeadJoints(arma::vec3 cameraUnitVector) {
+        std::vector<std::pair<ServoID, float>> positions;
+        positions.push_back(std::make_pair(ServoID::HEAD_YAW, atan2(cameraUnitVector[1], cameraUnitVector[0])));
+        positions.push_back(std::make_pair(
+            ServoID::HEAD_PITCH,
+            atan2(-cameraUnitVector[2],
+                  std::sqrt(cameraUnitVector[0] * cameraUnitVector[0] + cameraUnitVector[1] * cameraUnitVector[1]))));
+        return positions;
+    }
+
     std::vector<std::pair<ServoID, float>> calculateHeadJoints(Eigen::Vector3f cameraUnitVector) {
         std::vector<std::pair<ServoID, float>> positions;
         positions.push_back(std::make_pair(ServoID::HEAD_YAW, atan2(cameraUnitVector[1], cameraUnitVector[0])));
@@ -359,5 +570,188 @@ namespace utility::motion::kinematics {
                   std::sqrt(cameraUnitVector[0] * cameraUnitVector[0] + cameraUnitVector[1] * cameraUnitVector[1]))));
         return positions;
     }
+
+    arma::vec2 calculateHeadJointsToLookAt(arma::vec3 groundPoint,
+                                           const utility::math::matrix::Transform3D& Hgc,
+                                           const utility::math::matrix::Transform3D& Hgt) {
+        // TODO: Find point that is invariant under head position.
+        arma::vec3 cameraPosition        = Hgc.submat(0, 3, 2, 3);
+        arma::vec3 groundSpaceLookVector = groundPoint - cameraPosition;
+        arma::vec3 lookVector            = Hgt.submat(0, 0, 2, 2).t() * groundSpaceLookVector;
+        arma::vec3 lookVectorSpherical   = utility::math::coordinates::cartesianToSpherical(lookVector);
+
+        return lookVectorSpherical.rows(1, 2);
+    }
+
+    arma::vec2 headAnglesToSeeGroundPoint(const arma::vec2& gpos, const message::input::Sensors& sensors) {
+        arma::vec3 groundPos_ground = {gpos[0], gpos[1], 0};
+        return calculateHeadJointsToLookAt(groundPos_ground, convert(sensors.Hgc), convert(sensors.Hgt));
+    }
+
+    std::vector<std::pair<ServoID, float>> setHeadPoseFromFeet(const KinematicsModel& model,
+                                                               const utility::math::matrix::Transform3D& cameraToFeet,
+                                                               const float& footSeparation) {
+        // Get camera pose relative to body
+        // arma::vec3 euler = cameraToFeet.rotation().eulerAngles();
+        // float headPitch = euler[1] - bodyAngle;
+        // float headYaw = euler[2];
+        arma::vec3 gaze = cameraToFeet.rotation().col(0);
+        auto headJoints = utility::motion::kinematics::calculateCameraLookJoints(model, gaze);
+        float headPitch = std::numeric_limits<float>::quiet_NaN();
+        float headYaw   = std::numeric_limits<float>::quiet_NaN();
+        for (auto joint : headJoints) {
+            switch (joint.first.value) {
+                case ServoID::HEAD_PITCH: headPitch = joint.second; break;
+                case ServoID::HEAD_YAW: headYaw = joint.second; break;
+                default:
+                    NUClear::log<NUClear::ERROR>(__FILE__, __LINE__, "Joints for head returned unexpected values");
+                    throw std::exception();
+            }
+        }
+        if (std::isnan(headPitch * headPitch)) {
+            NUClear::log<NUClear::ERROR>(__FILE__, __LINE__, "Joints for head missing values!!!");
+            throw std::exception();
+        }
+
+        auto headPoses =
+            utility::motion::kinematics::calculateHeadJointPosition(model, headPitch, headYaw, ServoID::HEAD_PITCH);
+        auto cameraToBody = headPoses[ServoID::HEAD_PITCH];
+
+        // Compute foot poses
+        utility::math::matrix::Transform3D F_c = convert(Eigen::Matrix4d(cameraToBody.matrix())) * cameraToFeet.i();
+        utility::math::matrix::Transform3D F_l = F_c.translateY(footSeparation * 0.5);
+        utility::math::matrix::Transform3D F_r = F_c.translateY(-footSeparation * 0.5);
+
+        // Get associated joint angles
+        auto joints  = calculateLegJoints(model, F_l, LimbID::LEFT_LEG);
+        auto joints2 = calculateLegJoints(model, F_r, LimbID::RIGHT_LEG);
+        joints.insert(joints.end(), joints2.begin(), joints2.end());
+        joints.insert(joints.end(), headJoints.begin(), headJoints.end());
+
+        // return joints;
+        return headJoints;
+    }
+
+    std::vector<std::pair<ServoID, float>> setArm(const KinematicsModel& model,
+                                                  const arma::vec3& pos,
+                                                  bool left,
+                                                  int number_of_iterations,
+                                                  arma::vec3 angleHint) {
+        ServoID SHOULDER_PITCH, SHOULDER_ROLL, ELBOW;
+        // int negativeIfRight;
+
+        if (static_cast<bool>(left)) {
+            SHOULDER_PITCH = ServoID::L_SHOULDER_PITCH;
+            SHOULDER_ROLL  = ServoID::L_SHOULDER_ROLL;
+            ELBOW          = ServoID::L_ELBOW;
+            // negativeIfRight = 1;
+        }
+        else {
+            SHOULDER_PITCH = ServoID::R_SHOULDER_PITCH;
+            SHOULDER_ROLL  = ServoID::R_SHOULDER_ROLL;
+            ELBOW          = ServoID::R_ELBOW;
+            // negativeIfRight = -1;
+        }
+
+        auto start_compute = NUClear::clock::now();
+
+        // Initial guess for angles
+        arma::vec3 angles = angleHint;
+        arma::vec3 X      = {0, 0, 0};
+        int i             = 0;
+        for (; i < number_of_iterations; i++) {
+            X             = calculateArmPosition(model, angles, left);
+            arma::vec3 dX = pos - X;
+
+            arma::mat33 J = calculateArmJacobian(model, angles, left);
+            // std::cout << "pos = " << pos.t() << std::endl;
+            // std::cout << "X = " << X.t() << std::endl;
+            // std::cout << "dX = " << dX.t() << std::endl;
+            // std::cout << "angles = " << angles.t() << std::endl;
+            // std::cout << "error = " << arma::norm(dX) << std::endl;
+            if (arma::norm(dX) < 0.001) {
+                break;
+            }
+            arma::vec3 dAngles = J.t() * dX;  // * std::max((100 - i),1);
+            angles             = dAngles + angles;
+        }
+        auto end_compute = NUClear::clock::now();
+        std::cout << "Computation Time (ms) = "
+                  << std::chrono::duration_cast<std::chrono::microseconds>(end_compute - start_compute).count() * 1e-3
+                  << std::endl;
+        // std::cout << "Final angles = " << angles.t() << std::endl;
+        // std::cout << "Final position = " << X.t() << std::endl;
+        // std::cout << "Goal position = " << pos.t() << std::endl;
+        std::cout << "Final error = " << arma::norm(pos - X) << std::endl;
+        // std::cout << "Iterations = " << i << std::endl;
+
+
+        std::vector<std::pair<ServoID, float>> joints;
+        joints.push_back(std::make_pair(SHOULDER_PITCH, utility::math::angle::normalizeAngle(angles[0])));
+        joints.push_back(std::make_pair(SHOULDER_ROLL, utility::math::angle::normalizeAngle(angles[1])));
+        joints.push_back(std::make_pair(ELBOW, utility::math::angle::normalizeAngle(angles[2])));
+        return joints;
+    }
+
+    std::vector<std::pair<ServoID, float>> setArmApprox(const KinematicsModel& model,
+                                                        const arma::vec3& pos,
+                                                        bool left) {
+        // Setup variables
+        ServoID SHOULDER_PITCH, SHOULDER_ROLL, ELBOW;
+        int negativeIfRight = 1;
+        if (left) {
+            SHOULDER_PITCH = ServoID::L_SHOULDER_PITCH;
+            SHOULDER_ROLL  = ServoID::L_SHOULDER_ROLL;
+            ELBOW          = ServoID::L_ELBOW;
+        }
+        else {
+            SHOULDER_PITCH  = ServoID::R_SHOULDER_PITCH;
+            SHOULDER_ROLL   = ServoID::R_SHOULDER_ROLL;
+            ELBOW           = ServoID::R_ELBOW;
+            negativeIfRight = -1;
+        }
+        // Compute Angles
+        float pitch, roll, elbow = 0;
+
+        arma::vec3 shoulderPos = {model.arm.SHOULDER_X_OFFSET,
+                                  negativeIfRight * model.arm.DISTANCE_BETWEEN_SHOULDERS / 2,
+                                  model.arm.SHOULDER_Z_OFFSET};
+
+        arma::vec3 handFromShoulder = pos - shoulderPos;
+        // std::cout << (left ? "left" : "right" ) << " shoulderPos = " << shoulderPos.t();
+        // std::cout << (left ? "right" : "left" ) << " pos = " << pos.t();
+        // std::cout << (left ? "left" : "right" ) << " handFromShoulder = " << handFromShoulder.t();
+
+        // ELBOW
+        float extensionLength    = arma::norm(handFromShoulder);
+        float upperArmLength     = model.arm.UPPER_ARM_LENGTH;
+        float lowerArmLength     = model.arm.LOWER_ARM_LENGTH;
+        float sqrUpperArmLength  = upperArmLength * upperArmLength;
+        float sqrLowerArmLength  = lowerArmLength * lowerArmLength;
+        float sqrExtensionLength = extensionLength * extensionLength;
+        float cosElbow =
+            (sqrUpperArmLength + sqrLowerArmLength - sqrExtensionLength) / (2 * upperArmLength * lowerArmLength);
+        elbow = -M_PI + std::acos(std::fmax(std::fmin(cosElbow, 1), -1));
+
+        // SHOULDER PITCH
+        float cosPitAngle =
+            (sqrUpperArmLength + sqrExtensionLength - sqrLowerArmLength) / (2 * upperArmLength * extensionLength);
+        pitch =
+            std::acos(std::fmax(std::fmin(cosPitAngle, 1), -1)) + std::atan2(-handFromShoulder[2], handFromShoulder[0]);
+        // SHOULDER ROLL
+        arma::vec3 pitchlessHandFromShoulder =
+            utility::math::matrix::Rotation3D::createRotationY(-pitch) * handFromShoulder;
+        roll = std::atan2(pitchlessHandFromShoulder[1], pitchlessHandFromShoulder[0]);
+
+        // Write to servo list
+        std::vector<std::pair<ServoID, float>> joints;
+        joints.push_back(std::make_pair(SHOULDER_PITCH, utility::math::angle::normalizeAngle(pitch)));
+        joints.push_back(std::make_pair(SHOULDER_ROLL, utility::math::angle::normalizeAngle(roll)));
+        joints.push_back(std::make_pair(ELBOW, utility::math::angle::normalizeAngle(elbow)));
+        // std::cout << (left ? "left" : "right" ) << " roll,pitch,elbow (deg) = " << 180 * roll / M_PI << ", "
+        // << 180 * pitch / M_PI << ", " << 180 * elbow / M_PI << std::endl;
+        return joints;
+    }
+
 
 }  // namespace utility::motion::kinematics

--- a/shared/utility/motion/InverseKinematics.hpp
+++ b/shared/utility/motion/InverseKinematics.hpp
@@ -22,6 +22,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <armadillo>
 #include <chrono>
 #include <cmath>
 #include <limits>
@@ -36,6 +37,7 @@
 #include "utility/input/ServoID.hpp"
 #include "utility/math/angle.hpp"
 #include "utility/math/coordinates.hpp"
+#include "utility/math/matrix/Transform3D.hpp"
 #include "utility/motion/ForwardKinematics.hpp"
 
 namespace utility::motion::kinematics {
@@ -53,6 +55,14 @@ namespace utility::motion::kinematics {
         @param RobotKinematicsModel The class containing the leg model of the robot.
     */
 
+    bool legPoseValid(const message::motion::KinematicsModel& model,
+                      utility::math::matrix::Transform3D target,
+                      LimbID limb);
+
+    std::vector<std::pair<ServoID, float>> calculateLegJoints(const message::motion::KinematicsModel& model,
+                                                              utility::math::matrix::Transform3D target,
+                                                              LimbID limb);
+
     std::vector<std::pair<ServoID, double>> calculateLegJoints(const message::motion::KinematicsModel& model,
                                                                const Eigen::Affine3d& target,
                                                                const LimbID& limb);
@@ -62,13 +72,43 @@ namespace utility::motion::kinematics {
                                                               const LimbID& limb);
 
     std::vector<std::pair<ServoID, float>> calculateLegJoints(const message::motion::KinematicsModel& model,
+                                                              utility::math::matrix::Transform3D leftTarget,
+                                                              utility::math::matrix::Transform3D rightTarget);
+
+    std::vector<std::pair<ServoID, float>> calculateLegJoints(const message::motion::KinematicsModel& model,
                                                               const Eigen::Affine3f& leftTarget,
                                                               const Eigen::Affine3f& rightTarget);
+
+    std::vector<std::pair<ServoID, float>> calculateCameraLookJoints(const message::motion::KinematicsModel& model,
+                                                                     arma::vec3 cameraUnitVector);
 
     std::vector<std::pair<ServoID, double>> calculateCameraLookJoints(const KinematicsModel& model,
                                                                       const Eigen::Vector3d& cameraUnitVector);
 
+    std::vector<std::pair<ServoID, float>> calculateHeadJoints(arma::vec3 cameraUnitVector);
+
     std::vector<std::pair<ServoID, float>> calculateHeadJoints(Eigen::Vector3f cameraUnitVector);
+
+    arma::vec2 calculateHeadJointsToLookAt(arma::vec3 groundPoint,
+                                           const utility::math::matrix::Transform3D& camToGround,
+                                           const utility::math::matrix::Transform3D& bodyToGround);
+
+    arma::vec2 headAnglesToSeeGroundPoint(const arma::vec2& gpos, const message::input::Sensors& sensors);
+
+    std::vector<std::pair<ServoID, float>> setHeadPoseFromFeet(const message::motion::KinematicsModel& model,
+                                                               const utility::math::matrix::Transform3D& cameraToFeet,
+                                                               const float& footSeparation);
+
+    std::vector<std::pair<ServoID, float>> setArm(const message::motion::KinematicsModel& model,
+                                                  const arma::vec3& pos,
+                                                  bool left,
+                                                  int number_of_iterations = 300,
+                                                  arma::vec3 angleHint     = arma::zeros(3));
+
+    std::vector<std::pair<ServoID, float>> setArmApprox(const message::motion::KinematicsModel& model,
+                                                        const arma::vec3& pos,
+                                                        bool left);
+
 
 }  // namespace utility::motion::kinematics
 

--- a/shared/utility/nusight/NUhelpers.hpp
+++ b/shared/utility/nusight/NUhelpers.hpp
@@ -20,6 +20,7 @@
 #ifndef NUHELPERS_HPP
 #define NUHELPERS_HPP
 
+#include <armadillo>
 #include <nuclear>
 #include <utility>
 

--- a/shared/utility/support/eigen_armadillo.hpp
+++ b/shared/utility/support/eigen_armadillo.hpp
@@ -1,0 +1,267 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2015 NUbots <nubots@nubots.net>
+ */
+
+#ifndef UTILITY_SUPPORT_EIGEN_ARMADILLO_HPP
+#define UTILITY_SUPPORT_EIGEN_ARMADILLO_HPP
+
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <armadillo>
+#include <type_traits>
+
+#include "utility/math/matrix/Rotation2D.hpp"
+#include "utility/math/matrix/Rotation3D.hpp"
+#include "utility/math/matrix/Transform2D.hpp"
+#include "utility/math/matrix/Transform3D.hpp"
+
+// We officially hate armadillo from this point on
+
+
+// FLOAT
+template <int... Args>
+auto convert(const typename arma::Col<float>::template fixed<2>& avec) {
+    return (Eigen::Map<Eigen::Matrix<float, 2, 1, Args...>>(const_cast<float*>(avec.memptr()), 2));
+}
+template <int... Args>
+auto convert(const typename arma::Col<float>::template fixed<3>& avec) {
+    return (Eigen::Map<Eigen::Matrix<float, 3, 1, Args...>>(const_cast<float*>(avec.memptr()), 3));
+}
+template <int... Args>
+auto convert(const typename arma::Col<float>::template fixed<4>& avec) {
+    return (Eigen::Map<Eigen::Matrix<float, 4, 1, Args...>>(const_cast<float*>(avec.memptr()), 4));
+}
+template <int... Args>
+auto convert(const typename arma::Col<float>& avec) {
+    return (
+        Eigen::Map<Eigen::Matrix<float, Eigen::Dynamic, 1, Args...>>(const_cast<float*>(avec.memptr()), avec.n_elem));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<float>::template fixed<2, 2>& amat) {
+    return (Eigen::Map<Eigen::Matrix<float, 2, 2, Args...>>(const_cast<float*>(amat.memptr()), 2, 2));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<float>::template fixed<3, 3>& amat) {
+    return (Eigen::Map<Eigen::Matrix<float, 3, 3, Args...>>(const_cast<float*>(amat.memptr()), 3, 3));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<float>::template fixed<4, 4>& amat) {
+    return (Eigen::Map<Eigen::Matrix<float, 4, 4, Args...>>(const_cast<float*>(amat.memptr()), 4, 4));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<float>& amat) {
+    return (Eigen::Map<Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Args...>>(const_cast<float*>(amat.memptr()),
+                                                                                      amat.n_rows,
+                                                                                      amat.n_cols));
+}
+// DOUBLE
+template <int... Args>
+auto convert(const typename arma::Col<double>::template fixed<2>& avec) {
+    return (Eigen::Map<Eigen::Matrix<double, 2, 1, Args...>>(const_cast<double*>(avec.memptr()), 2));
+}
+template <int... Args>
+auto convert(const typename arma::Col<double>::template fixed<3>& avec) {
+    return (Eigen::Map<Eigen::Matrix<double, 3, 1, Args...>>(const_cast<double*>(avec.memptr()), 3));
+}
+template <int... Args>
+auto convert(const utility::math::matrix::Transform2D& avec) {
+    return (Eigen::Map<Eigen::Matrix<double, 3, 1, Args...>>(const_cast<double*>(avec.memptr()), 3));
+}
+template <int... Args>
+auto convert(const typename arma::Col<double>::template fixed<4>& avec) {
+    return (Eigen::Map<Eigen::Matrix<double, 4, 1, Args...>>(const_cast<double*>(avec.memptr()), 4));
+}
+template <int... Args>
+auto convert(const typename arma::Col<double>& avec) {
+    return (
+        Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1, Args...>>(const_cast<double*>(avec.memptr()), avec.n_elem));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<double>::template fixed<2, 2>& amat) {
+    return (Eigen::Map<Eigen::Matrix<double, 2, 2, Args...>>(const_cast<double*>(amat.memptr()), 2, 2));
+}
+template <int... Args>
+auto convert(const utility::math::matrix::Rotation2D& amat) {
+    return (Eigen::Map<Eigen::Matrix<double, 2, 2, Args...>>(const_cast<double*>(amat.memptr()), 2, 2));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<double>::template fixed<3, 3>& amat) {
+    return (Eigen::Map<Eigen::Matrix<double, 3, 3, Args...>>(const_cast<double*>(amat.memptr()), 3, 3));
+}
+template <int... Args>
+auto convert(const utility::math::matrix::Rotation3D& amat) {
+    return (Eigen::Map<Eigen::Matrix<double, 3, 3, Args...>>(const_cast<double*>(amat.memptr()), 3, 3));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<double>::template fixed<4, 4>& amat) {
+    return (Eigen::Map<Eigen::Matrix<double, 4, 4, Args...>>(const_cast<double*>(amat.memptr()), 4, 4));
+}
+template <int... Args>
+auto convert(const utility::math::matrix::Transform3D& amat) {
+    return (Eigen::Map<Eigen::Matrix<double, 4, 4, Args...>>(const_cast<double*>(amat.memptr()), 4, 4));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<double>& amat) {
+    return (
+        Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Args...>>(const_cast<double*>(amat.memptr()),
+                                                                                   amat.n_rows,
+                                                                                   amat.n_cols));
+}
+// INT
+template <int... Args>
+auto convert(const typename arma::Col<int>::template fixed<2>& avec) {
+    return (Eigen::Map<Eigen::Matrix<int, 2, 1, Args...>>(const_cast<int*>(avec.memptr()), 2));
+}
+template <int... Args>
+auto convert(const typename arma::Col<int>::template fixed<3>& avec) {
+    return (Eigen::Map<Eigen::Matrix<int, 3, 1, Args...>>(const_cast<int*>(avec.memptr()), 3));
+}
+template <int... Args>
+auto convert(const typename arma::Col<int>::template fixed<4>& avec) {
+    return (Eigen::Map<Eigen::Matrix<int, 4, 1, Args...>>(const_cast<int*>(avec.memptr()), 4));
+}
+template <int... Args>
+auto convert(const typename arma::Col<int>& avec) {
+    return (Eigen::Map<Eigen::Matrix<int, Eigen::Dynamic, 1, Args...>>(const_cast<int*>(avec.memptr()), avec.n_elem));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<int>::template fixed<2, 2>& amat) {
+    return (Eigen::Map<Eigen::Matrix<int, 2, 2, Args...>>(const_cast<int*>(amat.memptr()), 2, 2));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<int>::template fixed<3, 3>& amat) {
+    return (Eigen::Map<Eigen::Matrix<int, 3, 3, Args...>>(const_cast<int*>(amat.memptr()), 3, 3));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<int>::template fixed<4, 4>& amat) {
+    return (Eigen::Map<Eigen::Matrix<int, 4, 4, Args...>>(const_cast<int*>(amat.memptr()), 4, 4));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<int>& amat) {
+    return (Eigen::Map<Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Args...>>(const_cast<int*>(amat.memptr()),
+                                                                                    amat.n_rows,
+                                                                                    amat.n_cols));
+}
+// UINT
+template <int... Args>
+auto convert(const typename arma::Col<uint>::template fixed<2>& avec) {
+    return (Eigen::Map<Eigen::Matrix<uint, 2, 1, Args...>>(const_cast<uint*>(avec.memptr()), 2));
+}
+template <int... Args>
+auto convert(const typename arma::Col<uint>::template fixed<3>& avec) {
+    return (Eigen::Map<Eigen::Matrix<uint, 3, 1, Args...>>(const_cast<uint*>(avec.memptr()), 3));
+}
+template <int... Args>
+auto convert(const typename arma::Col<uint>::template fixed<4>& avec) {
+    return (Eigen::Map<Eigen::Matrix<uint, 4, 1, Args...>>(const_cast<uint*>(avec.memptr()), 4));
+}
+template <int... Args>
+auto convert(const typename arma::Col<uint>& avec) {
+    return (Eigen::Map<Eigen::Matrix<uint, Eigen::Dynamic, 1, Args...>>(const_cast<uint*>(avec.memptr()), avec.n_elem));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<uint>::template fixed<2, 2>& amat) {
+    return (Eigen::Map<Eigen::Matrix<uint, 2, 2, Args...>>(const_cast<uint*>(amat.memptr()), 2, 2));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<uint>::template fixed<3, 3>& amat) {
+    return (Eigen::Map<Eigen::Matrix<uint, 3, 3, Args...>>(const_cast<uint*>(amat.memptr()), 3, 3));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<uint>::template fixed<4, 4>& amat) {
+    return (Eigen::Map<Eigen::Matrix<uint, 4, 4, Args...>>(const_cast<uint*>(amat.memptr()), 4, 4));
+}
+template <int... Args>
+auto convert(const typename arma::Mat<uint>& amat) {
+    return (Eigen::Map<Eigen::Matrix<uint, Eigen::Dynamic, Eigen::Dynamic, Args...>>(const_cast<uint*>(amat.memptr()),
+                                                                                     amat.n_rows,
+                                                                                     amat.n_cols));
+}
+
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, 2, 1, O, MR, MC>& evec) {
+    typename arma::Col<Scalar>::template fixed<2> avec;
+    Eigen::Map<Eigen::Matrix<Scalar, 2, 1, O, MR, MC>>(avec.memptr(), 2) = evec;
+    return (avec);
+}
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, 3, 1, O, MR, MC>& evec) {
+    typename arma::Col<Scalar>::template fixed<3> avec;
+    Eigen::Map<Eigen::Matrix<Scalar, 3, 1, O, MR, MC>>(avec.memptr(), 3) = evec;
+    return (avec);
+}
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, 4, 1, O, MR, MC>& evec) {
+    typename arma::Col<Scalar>::template fixed<4> avec;
+    Eigen::Map<Eigen::Matrix<Scalar, 4, 1, O, MR, MC>>(avec.memptr(), 4) = evec;
+    return (avec);
+}
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, 6, 1, O, MR, MC>& evec) {
+    typename arma::Col<Scalar>::template fixed<4> avec;
+    Eigen::Map<Eigen::Matrix<Scalar, 6, 1, O, MR, MC>>(avec.memptr(), 6) = evec;
+    return (avec);
+}
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, Eigen::Dynamic, 1, O, MR, MC>& evec) {
+    typename arma::Col<Scalar> avec(evec.rows());
+    Eigen::Map<Eigen::Matrix<Scalar, Eigen::Dynamic, 1, O, MR, MC>>(avec.memptr(), evec.rows()) = evec;
+    return (avec);
+}
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, 1, Eigen::Dynamic, O, MR, MC>& evec) {
+    typename arma::Row<Scalar> avec(evec.cols());
+    Eigen::Map<Eigen::Matrix<Scalar, 1, Eigen::Dynamic, O, MR, MC>>(avec.memptr(), evec.cols()) = evec;
+    return (avec);
+}
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, 2, 2, O, MR, MC>& evec) {
+    typename arma::Mat<Scalar>::template fixed<2, 2> avec;
+    Eigen::Map<Eigen::Matrix<Scalar, 2, 2, O, MR, MC>>(avec.memptr(), 2, 2) = evec;
+    return (avec);
+}
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, 3, 3, O, MR, MC>& emat) {
+    typename arma::Mat<Scalar>::template fixed<3, 3> amat;
+    Eigen::Map<Eigen::Matrix<Scalar, 3, 3, O, MR, MC>>(amat.memptr(), 3, 3) = emat;
+    return (amat);
+}
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, 4, 4, O, MR, MC>& emat) {
+    typename arma::Mat<Scalar>::template fixed<4, 4> amat;
+    Eigen::Map<Eigen::Matrix<Scalar, 4, 4, O, MR, MC>>(amat.memptr(), 4, 4) = emat;
+    return (amat);
+}
+template <typename Scalar, int Dim, int Options>
+auto convert(const typename Eigen::Transform<Scalar, Dim, Eigen::Affine, Options>& etrans) {
+    typename arma::Mat<Scalar>::template fixed<Dim + 1, Dim + 1> atrans;
+    Eigen::Map<Eigen::Matrix<Scalar, Dim + 1, Dim + 1, Options, Dim + 1, Dim + 1>>(atrans.memptr(), Dim + 1, Dim + 1) =
+        etrans.matrix();
+    return (atrans);
+}
+template <typename Scalar, int O, int MR, int MC>
+auto convert(const typename Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, O, MR, MC>& emat) {
+    typename arma::Mat<Scalar> amat(emat.rows(), emat.cols());
+    Eigen::Map<Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, O, MR, MC>>(amat.memptr(),
+                                                                                 emat.rows(),
+                                                                                 emat.cols()) = emat;
+    return (amat);
+}
+
+#endif  // UTILITY_SUPPORT_EIGEN_ARMADILLO_HPP

--- a/shared/utility/support/yaml_expression.hpp
+++ b/shared/utility/support/yaml_expression.hpp
@@ -21,6 +21,7 @@
 #define UTILITY_SUPPORT_yaml_expression_HPP
 
 #include <Eigen/Core>
+#include <armadillo>
 #include <fmt/format.h>
 #include <limits>
 #include <system_error>
@@ -267,6 +268,108 @@ namespace utility::support {
 
             return matrix;
         }
+
+        ////
+        //// ARMADILLO
+        ////
+
+        // Handle fixed-sized matrices.
+        template <typename T, std::enable_if_t<((!T::is_col) && (!T::is_row))>* = nullptr>
+        operator T() const {
+
+            // value : [[a, b], [c, d]]
+            const size_t rows = node.size();
+            const size_t cols = node[0].size();
+
+            // Count the columns on every row.
+            for (const auto& row : node) {
+                if (row.size() != cols) {
+                    throw std::out_of_range(
+                        fmt::format("Inconsistent number of cols in matrix (cols: {} vs {}).", row.size(), cols));
+                }
+            }
+
+            // Validate row and column sizes.
+            if ((rows != T::n_rows) || (cols != T::n_cols)) {
+                throw std::out_of_range(
+                    fmt::format("Rows and columns in YAML matrix do not align with output matrix. "
+                                "(rows: {} vs {}, cols: {} vs {}).",
+                                rows,
+                                T::n_rows,
+                                cols,
+                                T::n_cols));
+            }
+
+            T matrix;
+
+            try {
+                for (size_t row = 0; row < rows; row++) {
+                    for (size_t col = 0; col < cols; col++) {
+                        matrix(row, col) = parse_math_string<typename T::elem_type>(node[row][col].as<std::string>());
+                    }
+                }
+            }
+            catch (const std::invalid_argument& ex) {
+                throw std::invalid_argument(fmt::format("Unable to convert node to arithmetic type.\n{}", ex.what()));
+            }
+
+            return matrix;
+        }
+
+        // Handle fixed-sized column vectors.
+        template <typename T, std::enable_if_t<((T::is_col) && (!T::is_row))>* = nullptr>
+        operator T() const {
+
+            // Validate row size.
+            if (node.size() != T::n_rows) {
+                throw std::out_of_range(
+                    fmt::format("Rows in YAML column vector do not align with output vector. "
+                                "(rows: {} vs {}).",
+                                node.size(),
+                                T::n_rows));
+            }
+
+            T matrix;
+
+            try {
+                for (size_t i = 0; i < node.size(); i++) {
+                    matrix(i) = parse_math_string<typename T::elem_type>(node[i].as<std::string>());
+                }
+            }
+            catch (const std::invalid_argument& ex) {
+                throw std::invalid_argument(fmt::format("Unable to convert node to arithmetic type.\n{}", ex.what()));
+            }
+
+            return matrix;
+        }
+
+        // Handle fixed-sized row vectors.
+        template <typename T, std::enable_if_t<((!T::is_col) && (T::is_row))>* = nullptr>
+        operator T() const {
+
+            // Validate col size.
+            if (node.size() != T::n_cols) {
+                throw std::out_of_range(
+                    fmt::format("Columns in YAML row vector do not align with output vector. "
+                                "(cols: {} vs {}).",
+                                node.size(),
+                                T::n_cols));
+            }
+
+            T matrix;
+
+            try {
+                for (size_t i = 0; i < node.size(); i++) {
+                    matrix(i) = parse_math_string<typename T::elem_type>(node[i].as<std::string>());
+                }
+            }
+            catch (const std::invalid_argument& ex) {
+                throw std::invalid_argument(fmt::format("Unable to convert node to arithmetic type.\n{}", ex.what()));
+            }
+
+            return matrix;
+        }
+
 
     private:
         YAML::Node node;


### PR DESCRIPTION
Something in the arma purge didn't go to plan :cry: :sob: 
When running `keyboardwalk` or `keyboardwalkfake` on commits after this PR was merged, the following error occurs when `moving = true` is toggled for the first time, crashing the binary:
`keyboardwalkfake: /usr/local/include/eigen3/Eigen/src/Core/util/XprHelper.h:110: Eigen::internal::variable_if_dynamic<T, Value>::variable_if_dynamic(T) [with T = long int; int Value = 1]: Assertion 'v == T(Value)' failed.`

I couldn't find the exact change which did it, but this PR will get things back to usable while I hunt it down.
Tragic stuff