### PR TITLE
Change camera config field names back to PascalCase

### DIFF
--- a/module/input/Camera/data/config/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/Cameras/Left.yaml
@@ -1,11 +1,11 @@
 buffer_count: 4 # The number of software buffers to use.
 
 settings:
-  pixel_format: BayerRG8
-  width: 1280
-  height: 1024
-  offset_x: 0
-  offset_y: 0
-  exposure_auto: Continuous
-  gain_auto: Continuous
-  balance_white_auto: Continuous
+  PixelFormat: BayerRG8
+  Width: 1280
+  Height: 1024
+  OffsetX: 0
+  OffsetY: 0
+  ExposureAuto: Continuous
+  GainAuto: Continuous
+  BalanceWhiteAuto: Continuous

--- a/module/input/Camera/data/config/Cameras/Right.yaml
+++ b/module/input/Camera/data/config/Cameras/Right.yaml
@@ -1,11 +1,11 @@
 buffer_count: 4 # The number of software buffers to use.
 
 settings:
-  pixel_format: BayerRG8
-  width: 1280
-  height: 1024
-  offset_x: 0
-  offset_y: 0
-  exposure_auto: Continuous
-  gain_auto: Continuous
-  balance_white_auto: Continuous
+  PixelFormat: BayerRG8
+  Width: 1280
+  Height: 1024
+  OffsetX: 0
+  OffsetY: 0
+  ExposureAuto: Continuous
+  GainAuto: Continuous
+  BalanceWhiteAuto: Continuous

--- a/module/input/Camera/src/Camera.cpp
+++ b/module/input/Camera/src/Camera.cpp
@@ -152,7 +152,7 @@ namespace module::input {
             context.time = sync_clocks(device);
 
             // Get the fourcc code from the pixel format
-            context.fourcc = description_to_fourcc(config["settings"]["pixel_format"].as<std::string>());
+            context.fourcc = description_to_fourcc(config["settings"]["PixelFormat"].as<std::string>());
 
             // Load Hpc from configuration
             context.Hpc = Eigen::Matrix4d(config["lens"]["Hpc"].as<Expression>());
@@ -161,10 +161,10 @@ namespace module::input {
             int full_width  = arv::device_get_integer_feature_value(device, "WidthMax");
             int full_height = arv::device_get_integer_feature_value(device, "HeightMax");
 
-            int offset_x = config["settings"]["offset_x"].as<Expression>();
-            int offset_y = config["settings"]["offset_y"].as<Expression>();
-            int width    = config["settings"]["width"].as<Expression>();
-            int height   = config["settings"]["height"].as<Expression>();
+            int offset_x = config["settings"]["OffsetX"].as<Expression>();
+            int offset_y = config["settings"]["OffsetY"].as<Expression>();
+            int width    = config["settings"]["Width"].as<Expression>();
+            int height   = config["settings"]["Height"].as<Expression>();
 
             // Renormalise the focal length
             float focal_length = config["lens"]["focal_length"].as<Expression>() * full_width / width;
@@ -210,7 +210,7 @@ namespace module::input {
                 std::string key = cfg.first.as<std::string>();
 
                 // Skip the region keys as we handle them above
-                if (key == "width" || key == "height" || key == "offset_x" || key == "offset_y") {
+                if (key == "Width" || key == "Height" || key == "OffsetX" || key == "OffsetY") {
                     continue;
                 }
 


### PR DESCRIPTION
They were changed in #436 to snake_case, but we need PascalCase since they're named that way on the cameras.