### PR TITLE
Create motion scripts to use in Webots

### DIFF
--- a/module/behaviour/skills/Getup/src/Getup.cpp
+++ b/module/behaviour/skills/Getup/src/Getup.cpp
@@ -104,7 +104,7 @@ namespace module::behaviour::skills {
             if (isFront) {
                 emit(std::make_unique<ExecuteScriptByName>(
                     id,
-                    std::vector<std::string>({"RollOverFront.yaml", "StandUpBack.yaml", "Stand.yaml"})));
+                    std::vector<std::string>({"StandUpFront.yaml", "Stand.yaml"})));
             }
             else {
                 emit(std::make_unique<ExecuteScriptByName>(

--- a/module/motion/ScriptEngine/data/scripts/docker/KickLeft.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/KickLeft.yaml
@@ -1,63 +1,63 @@
 - duration: 1000
   targets:
     - id: HEAD_YAW
-      position: -0.001534355
+      position: -0.00153435499
       gain: 30
       torque: 100
     - id: HEAD_PITCH
-      position: 0.5308869
+      position: 0.530886889
       gain: 30
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02915275
+      position: -0.0291527491
       gain: 30
       torque: 100
     - id: L_HIP_YAW
-      position: 0.01994662
+      position: 0.0199466199
       gain: 30
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.1503668
+      position: -0.150366798
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.09819874
+      position: 0.0981987417
       gain: 30
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.4802532
+      position: -0.48025319
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.4909937
+      position: -0.490993708
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 0.7854941
+      position: 0.785494089
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 0.8269216
+      position: 0.826921582
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.5324213
+      position: -0.532421291
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.556971
+      position: -0.556971014
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.1549699
+      position: 0.154969901
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.09513003
+      position: -0.0951300263
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.98373
+      position: 1.98372996
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
@@ -65,287 +65,287 @@
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -1.574249
+      position: -1.57424903
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.068119
+      position: 2.06811905
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.1348315
+      position: 0.134831503
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -1.565042
+      position: -1.56504202
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.06261409
+      position: 0.0626140907
       gain: 20
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.06909663
+      position: -0.0690966323
       gain: 20
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.06261409
+      position: -0.0626140907
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.06909663
+      position: 0.0690966323
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.256
+      position: 0.256000012
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.207138
+      position: -0.207138002
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.207
+      position: -0.207000002
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.2593061
+      position: -0.259306103
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.2224815
+      position: -0.222481504
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -0.6720477
+      position: -0.672047675
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -0.5815207
+      position: -0.581520677
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 1.922356
+      position: 1.92235601
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.802676
+      position: 1.80267596
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.3128167
+      position: 0.312816709
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.309748
+      position: -0.309747994
       gain: 30
       torque: 100
 - duration: 600
   targets:
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.963495
+      position: 1.96349502
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.2623748
+      position: -0.262374789
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2945004
+      position: 0.294500411
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.207138
+      position: -0.207138002
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.2393594
+      position: -0.239359394
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.2040693
+      position: -0.204069301
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
-      position: -0.116611
+      position: -0.116610996
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: 0.02454969
+      position: 0.0245496891
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.1917944
+      position: 0.191794395
       gain: 20
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.4526348
+      position: -0.452634811
       gain: 20
       torque: 100
     - id: R_ELBOW
-      position: -0.7932617
+      position: -0.793261707
       gain: 20
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.3143511
+      position: -0.314351112
       gain: 20
       torque: 100
     - id: L_ELBOW
-      position: -0.6198796
+      position: -0.619879603
       gain: 20
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.169387
+      position: 2.1693871
       gain: 20
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.7270927
+      position: 0.727092683
       gain: 30
       torque: 100
 - duration: 300
   targets:
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.2393594
+      position: -0.239359394
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.2040693
+      position: -0.204069301
       gain: 20
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.3789858
+      position: -0.378985792
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.5109404
+      position: 0.510940373
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 0.7578757
+      position: 0.757875681
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.3835889
+      position: -0.38358891
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.5293526
+      position: -0.529352605
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: -0.2178785
+      position: -0.217878506
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.667652
+      position: 1.66765201
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.416418
+      position: 2.41641808
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.2422364
+      position: -0.242236406
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -0.9574378
+      position: -0.957437813
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -0.997331
+      position: -0.997331023
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.8360319
+      position: 0.836031914
       gain: 30
       torque: 100
     - id: R_HIP_ROLL
-      position: 0.09819874
+      position: 0.0981987417
       gain: 30
       torque: 100
 - duration: 200
   targets:
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.2393594
+      position: -0.239359394
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.2040693
+      position: -0.204069301
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
-      position: -0.2163441
+      position: -0.216344103
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.9420942
+      position: -0.942094207
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.144437
+      position: 1.14443696
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.652709
+      position: 2.65270901
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.1102818
+      position: -0.110281803
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -1.278118
+      position: -1.27811801
       gain: 30
       torque: 100
     - id: L_ELBOW
@@ -353,205 +353,205 @@
       gain: 30
       torque: 100
     - id: HEAD_YAW
-      position: -0.003068711
+      position: -0.00306871091
       gain: 30
       torque: 100
     - id: HEAD_PITCH
-      position: 0.5308869
+      position: 0.530886889
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.2424282
+      position: -0.242428198
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 1.006441
+      position: 1.20000005
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.5078716
+      position: 0.507871628
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.392795
+      position: -0.392794997
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.6427031
+      position: 0.642703116
       gain: 30
       torque: 100
     - id: R_HIP_ROLL
-      position: 0.02915275
+      position: 0.0291527491
       gain: 30
       torque: 100
 - duration: 500
   targets:
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.2393594
+      position: -0.239359394
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.2040693
+      position: -0.204069301
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.4925281
+      position: 0.492528111
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.9880289
+      position: 0.988028884
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.626017
+      position: -0.626016974
       gain: 20
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.2746496
+      position: -0.27464959
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.681462
+      position: 1.68146205
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -0.5815207
+      position: -0.581520677
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -0.5661771
+      position: -0.56617713
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: -0.1764509
+      position: -0.176450893
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.6996661
+      position: -0.699666083
       gain: 30
       torque: 100
     - id: R_HIP_ROLL
-      position: 0.0859239
+      position: 0.0859239027
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.3404351
+      position: -0.340435088
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.8406349
+      position: 0.840634882
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.135631
+      position: 2.13563108
       gain: 30
       torque: 100
 - duration: 500
   targets:
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.2040693
+      position: -0.204069301
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: 0.2255502
+      position: 0.225550205
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.3130085
+      position: -0.313008487
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.5416275
+      position: 0.541627526
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.891668
+      position: 1.89166796
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.0896
+      position: 2.08960009
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -0.7073379
+      position: -0.707337916
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -0.6935287
+      position: -0.693528712
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: -0.164176
+      position: -0.164176002
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.3467643
+      position: -0.346764296
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 0.7900971
+      position: 0.790097117
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.2485656
+      position: -0.248565599
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.4986655
+      position: -0.498665512
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 1.027826
+      position: 1.02782595
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.2898014
+      position: -0.289801389
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2469353
+      position: 0.246935293
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.1150767
+      position: 0.115076698
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
@@ -559,7 +559,7 @@
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.06597728
+      position: 0.0659772828
       gain: 30
       torque: 100
     - id: R_HIP_ROLL
@@ -567,105 +567,105 @@
       gain: 30
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.4066042
+      position: -0.406604201
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.4020011
+      position: -0.402001113
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.1411607
+      position: -0.141160697
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.1196797
+      position: -0.119679697
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.748973
+      position: 1.74897301
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 1.845638
+      position: 1.84563804
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.3327633
+      position: -0.332763314
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.2898014
+      position: 0.289801389
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -0.626017
+      position: -0.626016974
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -0.6398262
+      position: -0.639826179
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: HEAD_YAW
-      position: -0.001534355
+      position: -0.00153435499
       gain: 30
       torque: 100
     - id: HEAD_PITCH
-      position: 0.5308869
+      position: 0.530886889
       gain: 30
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02915275
+      position: -0.0291527491
       gain: 30
       torque: 100
     - id: L_HIP_YAW
-      position: 0.01994662
+      position: 0.0199466199
       gain: 30
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.1503668
+      position: -0.150366798
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.09819874
+      position: 0.0981987417
       gain: 30
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.4802532
+      position: -0.48025319
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.4909937
+      position: -0.490993708
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 0.7854941
+      position: 0.785494089
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 0.8269216
+      position: 0.826921582
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.5324213
+      position: -0.532421291
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.556971
+      position: -0.556971014
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.1549699
+      position: 0.154969901
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.09513003
+      position: -0.0951300263
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.98373
+      position: 1.98372996
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
@@ -673,18 +673,18 @@
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -1.574249
+      position: -1.57424903
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.068119
+      position: 2.06811905
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.1348315
+      position: 0.134831503
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -1.565042
+      position: -1.56504202
       gain: 30
       torque: 100

--- a/module/motion/ScriptEngine/data/scripts/docker/KickRight.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/KickRight.yaml
@@ -1,682 +1,690 @@
 - duration: 1000
   targets:
     - id: HEAD_YAW
-      position: -0.001534355
+      position: -0.00153435499
       gain: 30
       torque: 100
     - id: HEAD_PITCH
-      position: 0.5308869
-      gain: 30
-      torque: 100
-    - id: R_HIP_YAW
-      position: -0.02915275
+      position: 0.530886889
       gain: 30
       torque: 100
     - id: L_HIP_YAW
-      position: 0.01994662
+      position: 0.0291527491
       gain: 30
       torque: 100
-    - id: R_HIP_ROLL
-      position: -0.1503668
+    - id: R_HIP_YAW
+      position: -0.0199466199
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.09819874
+      position: 0.150366798
       gain: 30
       torque: 100
-    - id: R_HIP_PITCH
-      position: -0.4802532
+    - id: R_HIP_ROLL
+      position: -0.0981987417
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.4909937
+      position: -0.48025319
       gain: 30
       torque: 100
-    - id: R_KNEE
-      position: 0.7854941
+    - id: R_HIP_PITCH
+      position: -0.490993708
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 0.8269216
+      position: 0.785494089
       gain: 30
       torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.5324213
+    - id: R_KNEE
+      position: 0.826921582
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.556971
+      position: -0.532421291
       gain: 30
       torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.1549699
+    - id: R_ANKLE_PITCH
+      position: -0.556971014
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.09513003
+      position: -0.154969901
       gain: 30
       torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.98373
-      gain: 30
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.1762591
-      gain: 30
-      torque: 100
-    - id: R_ELBOW
-      position: -1.574249
+    - id: R_ANKLE_ROLL
+      position: 0.0951300263
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.068119
+      position: 1.98372996
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.1348315
+      position: 0.1762591
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -1.565042
+      position: -1.57424903
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.06811905
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.134831503
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.56504202
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.06261409
+      position: -0.0626140907
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.06909663
+      position: 0.0690966323
       gain: 20
       torque: 100
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.06261409
+      position: 0.0626140907
       gain: 20
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.06909663
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.1239184
-      gain: 20
-      torque: 100
-    - id: L_ELBOW
-      position: -2.443461
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.963495
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.1239184
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -2.443461
+      position: -0.0690966323
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.256
+      position: 0.256000012
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.207138
+      position: -0.207138002
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.207
+      position: -0.207000002
       gain: 20
       torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.781195
-      gain: 30
-      torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.1994662
+      position: -0.259306103
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.2010006
+      position: -0.222481504
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.672047675
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.581520677
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.92235601
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.80267596
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.312816709
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.309747994
       gain: 30
       torque: 100
 - duration: 600
   targets:
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 1.963495
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.1239184
-      gain: 20
-      torque: 100
-    - id: L_ELBOW
-      position: -2.443461
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.963495
+      position: 1.96349502
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.2623748
+      position: -0.262374789
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.294500411
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.207138
+      position: -0.207138002
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.2393594
+      position: -0.239359394
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.2040693
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0.116610996
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: -0.02454969
+      position: -0.0245496891
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.1917944
+      position: -0.191794395
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.452634811
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -0.793261707
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.314351112
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.619879603
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.1693871
       gain: 20
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.4171529
-      gain: 30
-      torque: 100
-    - id: R_ELBOW
-      position: -1.784455
-      gain: 30
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.4418944
-      gain: 30
-      torque: 100
-    - id: R_KNEE
-      position: 0.4955009
-      gain: 30
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0.1503668
+      position: -0.727092683
       gain: 30
       torque: 100
 - duration: 300
   targets:
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.239359394
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2561415
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.204069301
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.3789858
+      position: 0.378985792
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.5109404
-      gain: 20
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -0.3835889
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.5293526
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.94844
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.957646
-      gain: 30
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.8590472
-      gain: 30
-      torque: 100
-    - id: L_ELBOW
-      position: -2.431953
-      gain: 30
-      torque: 100
-    - id: R_ELBOW
-      position: -0.8868574
-      gain: 30
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.4601148
-      gain: 30
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0.02454969
-      gain: 30
-      torque: 100
-    - id: L_HIP_ROLL
-      position: -0.1426951
-      gain: 30
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.207138
-      gain: 30
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0.242
+      position: -0.510940373
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 1.093899
+      position: 0.757875681
       gain: 30
       torque: 100
-    - id: L_HIP_PITCH
-      position: -0.1411607
+    - id: R_HIP_PITCH
+      position: -0.38358891
       gain: 30
       torque: 100
-- duration: 300
+    - id: R_ANKLE_PITCH
+      position: -0.529352605
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0.217878506
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.66765201
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.41641808
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.242236406
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.957437813
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.997331023
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.836031914
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: -0.0981987417
+      gain: 30
+      torque: 100
+- duration: 200
   targets:
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: L_HIP_YAW
-      position: 0.02923973
+      position: 0.0292397309
       gain: 20
       torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.963495
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.1239184
-      gain: 20
-      torque: 100
-    - id: L_ELBOW
-      position: -2.443461
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -2.443461
+    - id: L_ANKLE_PITCH
+      position: -0.239359394
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
-    - id: R_HIP_ROLL
-      position: -0.4925281
+    - id: L_HIP_PITCH
+      position: -0.204069301
       gain: 20
       torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.2777183
+    - id: L_ANKLE_ROLL
+      position: 0.216344103
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.9420942
+      position: -0.942094207
       gain: 30
       torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.1593812
+    - id: L_SHOULDER_PITCH
+      position: 1.14443696
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 2.204677
+      position: 2.65270901
       gain: 30
       torque: 100
-    - id: L_HIP_PITCH
-      position: -0.1549699
+    - id: L_SHOULDER_ROLL
+      position: 0.110281803
       gain: 30
       torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.2163441
+    - id: L_ELBOW
+      position: -1.27811801
       gain: 30
       torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0.2424282
+    - id: R_ELBOW
+      position: -1.063308
+      gain: 30
+      torque: 100
+    - id: HEAD_YAW
+      position: -0.00306871091
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.530886889
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.242428198
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 0.780891
+      position: 1.006441
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.507871628
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.185657
+      position: -0.392794997
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.642703116
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: -0.1718478
+      position: -0.0291527491
       gain: 30
       torque: 100
 - duration: 500
   targets:
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: L_HIP_YAW
-      position: 0.02923973
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.963495
-      gain: 20
-      torque: 100
-    - id: L_ELBOW
-      position: -2.443461
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -2.443461
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.2393594
+      position: -0.239359394
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.2040693
+      position: -0.204069301
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.4925281
-      gain: 20
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -0.5324213
+      position: -0.492528111
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.9880289
+      position: 0.988028884
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.626017
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.960714
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0.2439625
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.7700546
+      position: -0.626016974
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.3421612
-      gain: 20
+      position: 0.27464959
+      gain: 30
       torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.3695879
-      gain: 20
+    - id: L_SHOULDER_PITCH
+      position: 1.68146205
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.581520677
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.56617713
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0.176450893
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.699666083
+      gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: -0.03989324
+      position: -0.0859239027
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.340435088
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.840634882
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.13563108
       gain: 30
       torque: 100
 - duration: 500
   targets:
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: L_HIP_YAW
-      position: 0.02923973
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.963495
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.1239184
-      gain: 20
-      torque: 100
-    - id: L_ELBOW
-      position: -2.443461
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.963495
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -2.443461
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.2393594
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.2040693
+      position: -0.204069301
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: -0.2255502
+      position: -0.225550205
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.3130085
-      gain: 20
-      torque: 100
-    - id: R_KNEE
-      position: 0.5829592
-      gain: 20
+      position: -0.313008487
+      gain: 30
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.5416275
-      gain: 20
+      position: -0.541627526
+      gain: 30
       torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.5030768
-      gain: 20
+    - id: L_SHOULDER_PITCH
+      position: 1.89166796
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.08960009
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.707337916
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.693528712
+      gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: 0.244
-      gain: 20
+      position: 0.164176002
+      gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.3820545
+      position: 0.346764296
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.790097117
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.248565599
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: 0
-      gain: 10
-      torque: 0
+      position: -0.498665512
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -1.02782595
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.289801389
+      gain: 30
+      torque: 100
 - duration: 1000
   targets:
     - id: R_HIP_YAW
-      position: -0.02923973
+      position: -0.0292397309
       gain: 20
       torque: 100
     - id: L_HIP_YAW
-      position: 0.02923973
-      gain: 20
-      torque: 100
-    - id: L_ELBOW
-      position: -2.443461
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -2.443461
+      position: 0.0292397309
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2561415
+      position: 0.256141514
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.2469353
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.06597728
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.1519012
-      gain: 20
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -0.4066042
-      gain: 20
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -0.4020011
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.501942
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.675324
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.3772596
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.3588474
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.1396263
-      gain: 30
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.1549699
+      position: 0.246935293
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: 0.001534355
+      position: -0.115076698
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.06137422
+      position: 0.1058705
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0659772828
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.1519012
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.406604201
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.402001113
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.141160697
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.119679697
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.74897301
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.84563804
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.332763314
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.289801389
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.626016974
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.639826179
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: HEAD_YAW
-      position: -0.001534355
+      position: -0.00153435499
       gain: 30
       torque: 100
     - id: HEAD_PITCH
-      position: 0.5308869
-      gain: 30
-      torque: 100
-    - id: R_HIP_YAW
-      position: -0.02915275
+      position: 0.530886889
       gain: 30
       torque: 100
     - id: L_HIP_YAW
-      position: 0.01994662
+      position: 0.0291527491
       gain: 30
       torque: 100
-    - id: R_HIP_ROLL
-      position: -0.1503668
+    - id: R_HIP_YAW
+      position: -0.0199466199
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.09819874
+      position: 0.150366798
       gain: 30
       torque: 100
-    - id: R_HIP_PITCH
-      position: -0.4802532
+    - id: R_HIP_ROLL
+      position: -0.0981987417
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.4909937
+      position: -0.48025319
       gain: 30
       torque: 100
-    - id: R_KNEE
-      position: 0.7854941
+    - id: R_HIP_PITCH
+      position: -0.490993708
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 0.8269216
+      position: 0.785494089
       gain: 30
       torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.5324213
+    - id: R_KNEE
+      position: 0.826921582
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.556971
+      position: -0.532421291
       gain: 30
       torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.1549699
+    - id: R_ANKLE_PITCH
+      position: -0.556971014
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.09513003
+      position: -0.154969901
       gain: 30
       torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.98373
-      gain: 30
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.1762591
-      gain: 30
-      torque: 100
-    - id: R_ELBOW
-      position: -1.574249
+    - id: R_ANKLE_ROLL
+      position: 0.0951300263
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.068119
+      position: 1.98372996
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.1348315
+      position: 0.1762591
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -1.565042
+      position: -1.57424903
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.06811905
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.134831503
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.56504202
       gain: 30
       torque: 100

--- a/module/motion/ScriptEngine/data/scripts/docker/KickRight.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/KickRight.yaml
@@ -365,7 +365,7 @@
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 1.006441
+      position: 1.20000005
       gain: 30
       torque: 100
     - id: R_HIP_ROLL

--- a/module/motion/ScriptEngine/data/scripts/docker/StandUpBack.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/StandUpBack.yaml
@@ -1,15 +1,15 @@
-- duration: 2000
+- duration: 1000
   targets:
     - id: L_ELBOW
-      position: -1.8
+      position: -1.79999995
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.08
+      position: 0
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.08
+      position: 0
       gain: 20
       torque: 100
     - id: R_KNEE
@@ -17,11 +17,11 @@
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
       gain: 20
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.670796
+      position: 1.67079604
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
@@ -29,7 +29,7 @@
       gain: 20
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.04
+      position: -0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
@@ -37,7 +37,7 @@
       gain: 20
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.04
+      position: 0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -49,7 +49,7 @@
       gain: 20
       torque: 100
     - id: R_ELBOW
-      position: -1.8
+      position: -1.79999995
       gain: 20
       torque: 100
     - id: R_HIP_YAW
@@ -65,11 +65,11 @@
       gain: 20
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 1.670796
+      position: 1.67079604
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
@@ -77,185 +77,21 @@
       gain: 20
       torque: 100
     - id: HEAD_PITCH
-      position: 0.05063373
-      gain: 30
-      torque: 100
-- duration: 2000
-  targets:
-    - id: L_ELBOW
-      position: -1.8
-      gain: 20
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -0.08
-      gain: 20
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -0.08
-      gain: 20
-      torque: 100
-    - id: R_KNEE
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.670796
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -1.8
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_KNEE
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.670796
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: 0.1074049
-      gain: 30
-      torque: 100
-- duration: 500
-  targets:
-    - id: L_ELBOW
-      position: -1.8
-      gain: 20
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -0.08
-      gain: 20
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -0.08
-      gain: 20
-      torque: 100
-    - id: R_KNEE
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.670796
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -1.8
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_KNEE
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.670796
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: 0.1365576
+      position: 0.0506337285
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: L_ELBOW
-      position: -1.715873
+      position: -1.79999995
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -1.38
+      position: -1
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -1.38
+      position: -1
       gain: 20
       torque: 100
     - id: R_KNEE
@@ -263,27 +99,27 @@
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
       gain: 20
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 2.918733
+      position: 1.67079604
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
-      position: 0.11
+      position: 0
       gain: 20
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.04
+      position: -0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: 0.11
+      position: 0
       gain: 20
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.04
+      position: 0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -295,7 +131,7 @@
       gain: 20
       torque: 100
     - id: R_ELBOW
-      position: -1.715873
+      position: -1.79999995
       gain: 20
       torque: 100
     - id: R_HIP_YAW
@@ -311,11 +147,11 @@
       gain: 20
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.918733
+      position: 1.67079604
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
@@ -323,377 +159,49 @@
       gain: 20
       torque: 100
     - id: HEAD_PITCH
-      position: 0.211741
-      gain: 30
-      torque: 100
-- duration: 700
-  targets:
-    - id: L_ELBOW
-      position: -1.66
-      gain: 20
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -2.27
-      gain: 20
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -2.27
-      gain: 20
-      torque: 100
-    - id: R_KNEE
-      position: 1.98
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 2.870796
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: 0.54
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: 0.54
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -1.66
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_KNEE
-      position: 1.98
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 2.870796
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: 0.2224815
-      gain: 30
-      torque: 100
-- duration: 500
-  targets:
-    - id: L_ELBOW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -2.27
-      gain: 20
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -2.27
-      gain: 20
-      torque: 100
-    - id: R_KNEE
-      position: 2.61
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.930796
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.6
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.6
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_KNEE
-      position: 2.61
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.930796
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: 0.08132084
-      gain: 30
-      torque: 100
-- duration: 300
-  targets:
-    - id: L_ELBOW
-      position: -1.35
-      gain: 20
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -2.27
-      gain: 20
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -2.27
-      gain: 20
-      torque: 100
-    - id: R_KNEE
-      position: 2.53
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.930796
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.8
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.2
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.8
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.2
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -1.35
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_KNEE
-      position: 2.53
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.930796
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: 0.0276184
-      gain: 30
-      torque: 100
-- duration: 300
-  targets:
-    - id: L_ELBOW
-      position: -1.35
-      gain: 20
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -2.27
-      gain: 20
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -2.27
-      gain: 20
-      torque: 100
-    - id: R_KNEE
-      position: 2.42
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.930796
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.8
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.2
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.8
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.2
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -1.35
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_KNEE
-      position: 2.42
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.930796
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: -0.09666439
+      position: 0.0506337285
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: L_ELBOW
-      position: -0.7
+      position: -1.79999995
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -1.48
+      position: -1
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -1.48
+      position: -1
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 2.6
+      position: 0
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
       gain: 20
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.290796
+      position: 1.67079604
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -1.3
+      position: 0
       gain: 20
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.2
+      position: -0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -1.3
+      position: 0
       gain: 20
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.2
+      position: 0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -705,7 +213,7 @@
       gain: 20
       torque: 100
     - id: R_ELBOW
-      position: -0.7
+      position: -1.79999995
       gain: 20
       torque: 100
     - id: R_HIP_YAW
@@ -717,15 +225,15 @@
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 2.6
+      position: 0
       gain: 20
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 1.290796
+      position: 1.67079604
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
@@ -733,193 +241,49 @@
       gain: 20
       torque: 100
     - id: HEAD_PITCH
-      position: -0.03682453
-      gain: 30
-      torque: 100
-- duration: 1000
-  targets:
-    - id: L_ELBOW
-      position: -0.7
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.290796
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.2
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.2
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -0.7
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.290796
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: -0.03682453
-      gain: 30
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.993
-      gain: 30
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.9927279
-      gain: 30
-      torque: 100
-    - id: L_KNEE
-      position: 2.096
-      gain: 30
-      torque: 100
-    - id: R_KNEE
-      position: 2.095834
-      gain: 30
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -1.678585
-      gain: 30
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -1.618745
-      gain: 30
-      torque: 100
-- duration: 1000
-  targets:
-    - id: L_ELBOW
-      position: -0.7
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.290796
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.2
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.2
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -0.7
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.290796
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: -0.03682453
-      gain: 30
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.807
-      gain: 30
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.8070709
-      gain: 30
-      torque: 100
-    - id: L_KNEE
-      position: 1.451
-      gain: 30
-      torque: 100
-    - id: R_KNEE
-      position: 1.451404
-      gain: 30
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -1.103202
-      gain: 30
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -1.097064
+      position: 0.0506337285
       gain: 30
       torque: 100
 - duration: 800
   targets:
     - id: L_ELBOW
-      position: -0.7
+      position: -1.70000005
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
       gain: 20
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.290796
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
       gain: 20
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.2
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
       gain: 20
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.2
+      position: 0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -931,7 +295,725 @@
       gain: 20
       torque: 100
     - id: R_ELBOW
-      position: -0.7
+      position: -1.70000005
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0506337285
+      gain: 30
+      torque: 100
+- duration: 800
+  targets:
+    - id: L_ELBOW
+      position: -1.70000005
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.70000005
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0506337285
+      gain: 30
+      torque: 100
+- duration: 800
+  targets:
+    - id: L_ELBOW
+      position: -1.65999997
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 1.98000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.540000021
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.540000021
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.65999997
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 1.98000002
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.222481504
+      gain: 30
+      torque: 100
+- duration: 800
+  targets:
+    - id: L_ELBOW
+      position: -1.65999997
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 1.98000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.540000021
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.540000021
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.65999997
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 1.98000002
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.222481504
+      gain: 30
+      torque: 100
+- duration: 600
+  targets:
+    - id: L_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0813208371
+      gain: 30
+      torque: 100
+- duration: 600
+  targets:
+    - id: L_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0813208371
+      gain: 30
+      torque: 100
+- duration: 600
+  targets:
+    - id: L_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0813208371
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: L_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0966643915
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.48000002
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.48000002
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.29999995
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.29999995
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0.699999988
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0368245319
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.699999988
       gain: 20
       torque: 100
     - id: R_HIP_YAW
@@ -943,11 +1025,11 @@
       gain: 20
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 1.290796
+      position: 1.29079604
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
@@ -955,15 +1037,179 @@
       gain: 20
       torque: 100
     - id: HEAD_PITCH
-      position: -0.03682453
+      position: -0.0368245319
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.397
+      position: -0.992999971
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.3973981
+      position: -0.992727876
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 2.09599996
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 2.09583402
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.67858505
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.61874497
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0368245319
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.806999981
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.807070911
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 1.45099998
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 1.45140398
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.10320199
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.09706402
+      gain: 30
+      torque: 100
+- duration: 800
+  targets:
+    - id: L_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0368245319
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.397000015
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.397398114
       gain: 30
       torque: 100
     - id: L_KNEE
@@ -971,77 +1217,77 @@
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 0.7133794
+      position: 0.713379383
       gain: 30
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.7809869
+      position: -0.780986905
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.781
+      position: -0.781000018
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: HEAD_YAW
-      position: -0.001534355
+      position: -0.00153435499
       gain: 30
       torque: 100
     - id: HEAD_PITCH
-      position: 0.5308869
+      position: 0.530886889
       gain: 30
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02915275
+      position: -0.0291527491
       gain: 30
       torque: 100
     - id: L_HIP_YAW
-      position: 0.01994662
+      position: 0.0199466199
       gain: 30
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.1503668
+      position: -0.150366798
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.09819874
+      position: 0.0981987417
       gain: 30
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.4802532
+      position: -0.48025319
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.4909937
+      position: -0.490993708
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 0.7854941
+      position: 0.785494089
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 0.8269216
+      position: 0.826921582
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.5324213
+      position: -0.532421291
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.556971
+      position: -0.556971014
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.1549699
+      position: 0.154969901
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.09513003
+      position: -0.0951300263
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.98373
+      position: 1.98372996
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
@@ -1049,18 +1295,18 @@
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -1.574249
+      position: -1.57424903
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.068119
+      position: 2.06811905
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.1348315
+      position: 0.134831503
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -1.565042
+      position: -1.56504202
       gain: 30
       torque: 100

--- a/module/motion/ScriptEngine/data/scripts/docker/StandUpBack.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/StandUpBack.yaml
@@ -900,6 +900,252 @@
       position: -0.0966643915
       gain: 30
       torque: 100
+- duration: 300
+  targets:
+    - id: L_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0966643915
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: L_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0966643915
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: L_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0966643915
+      gain: 30
+      torque: 100
 - duration: 1000
   targets:
     - id: L_ELBOW

--- a/module/motion/ScriptEngine/data/scripts/docker/StandUpFront.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/StandUpFront.yaml
@@ -1,35 +1,35 @@
-- duration: 3000
+- duration: 1000
   targets:
     - id: L_ELBOW
-      position: -2.45
+      position: 0
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: 0.06
+      position: 0
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: 0.06
+      position: 0
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.45
+      position: 0
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: 0
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -1.54
+      position: 0
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -1.54
+      position: 0
       gain: 20
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: -0.12
+      position: 0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -41,7 +41,7 @@
       gain: 20
       torque: 100
     - id: R_ELBOW
-      position: -2.45
+      position: 0
       gain: 20
       torque: 100
     - id: R_HIP_YAW
@@ -53,15 +53,15 @@
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.45
+      position: 0
       gain: 20
       torque: 100
     - id: HEAD_PITCH
-      position: -0.2073009
+      position: 0
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0
       gain: 20
       torque: 100
     - id: L_HIP_YAW
@@ -69,41 +69,369 @@
       gain: 20
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: 0.08304699
+      position: -0.300000012
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 2.757045
+      position: 1.70000005
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.830694
+      position: 1.70000005
+      gain: 30
+      torque: 100
+- duration: 1500
+  targets:
+    - id: L_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.70000005
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.70000005
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.56524992
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.57599092
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.56524992
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.57599092
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.56524992
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.57599092
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
       gain: 30
       torque: 100
 - duration: 300
   targets:
     - id: R_HIP_PITCH
-      position: 0.06
+      position: 0.0599999987
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: 0.06
+      position: 0.0599999987
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 0.2
+      position: 0.200000003
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -1.54
+      position: -1.53999996
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -1.54
+      position: -1.53999996
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -123,15 +451,15 @@
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 0.2
+      position: 0.200000003
       gain: 20
       torque: 100
     - id: HEAD_PITCH
-      position: -0.2073009
+      position: -0.207300901
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
@@ -139,27 +467,27 @@
       gain: 20
       torque: 100
     - id: L_ELBOW
-      position: -2.485656
+      position: -3
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -2.408938
+      position: -3
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 2.56525
+      position: 2.56524992
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.575991
+      position: 2.57599092
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: 0.0723065
+      position: -0.300000012
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: -0.0584973
+      position: 0.300000012
       gain: 30
       torque: 100
 - duration: 1000
@@ -173,31 +501,31 @@
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 2.6
+      position: 2.5999999
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
       gain: 20
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 0.8907963
+      position: 1
       gain: 20
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -1.54
+      position: -1.53999996
       gain: 20
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.04
+      position: -0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -1.54
+      position: -1.53999996
       gain: 20
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.04
+      position: 0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -217,19 +545,19 @@
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 2.6
+      position: 2.5999999
       gain: 20
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 0.8907963
+      position: 1
       gain: 20
       torque: 100
     - id: HEAD_PITCH
-      position: -0.2073009
+      position: -0.207300901
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
@@ -237,111 +565,49 @@
       gain: 20
       torque: 100
     - id: R_ELBOW
-      position: -1.815
+      position: -2
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -1.815142
-      gain: 30
-      torque: 100
-- duration: 700
-  targets:
-    - id: R_HIP_PITCH
       position: -2
-      gain: 20
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -2
-      gain: 20
-      torque: 100
-    - id: R_KNEE
-      position: 2.6
-      gain: 20
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 0.8907963
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.54
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.54
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.04
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_KNEE
-      position: 2.6
-      gain: 20
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 0.8907963
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: -0.2073009
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_ELBOW
-      position: -0.8745826
-      gain: 30
-      torque: 100
-    - id: L_ELBOW
-      position: -0.7825212
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: R_HIP_PITCH
-      position: -1.4
+      position: -2
       gain: 20
       torque: 100
     - id: L_HIP_PITCH
-      position: -1.4
+      position: -2
       gain: 20
       torque: 100
     - id: R_KNEE
-      position: 2.6
+      position: 2.5999999
       gain: 20
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -361,57 +627,69 @@
       gain: 20
       torque: 100
     - id: L_KNEE
-      position: 2.6
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1
       gain: 20
       torque: 100
     - id: HEAD_PITCH
-      position: 0.04269908
+      position: -0.207300901
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
       position: 0
       gain: 20
       torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.262774
-      gain: 30
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.264309
+    - id: R_ELBOW
+      position: -2
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -0.2347564
+      position: -2
       gain: 30
       torque: 100
-    - id: R_ELBOW
-      position: -0.2439625
-      gain: 30
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.1271597
-      gain: 30
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.1992744
-      gain: 30
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.188934
-      gain: 30
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.313216
-      gain: 30
-      torque: 100
-- duration: 2000
+- duration: 1000
   targets:
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -423,77 +701,57 @@
       gain: 20
       torque: 100
     - id: R_HIP_YAW
-      position: 0
+      position: -0.200000003
       gain: 20
       torque: 100
     - id: HEAD_YAW
       position: 0
       gain: 20
       torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
     - id: HEAD_PITCH
-      position: 0.04269908
+      position: -0.207300901
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
-      position: 0
+      position: 0.200000003
       gain: 20
       torque: 100
-    - id: L_ELBOW
-      position: -0.2347564
-      gain: 30
-      torque: 100
     - id: R_ELBOW
-      position: -0.2439625
+      position: 0
       gain: 30
       torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.1271597
+    - id: L_ELBOW
+      position: 0.300000012
       gain: 30
       torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.1992744
-      gain: 30
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.188934
-      gain: 30
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.313216
-      gain: 30
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -1.115476
-      gain: 30
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.222881
-      gain: 30
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.248965
-      gain: 30
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -1.093995
-      gain: 30
-      torque: 100
-    - id: L_KNEE
-      position: 2.108109
-      gain: 30
-      torque: 100
-    - id: R_KNEE
-      position: 2.039062
-      gain: 30
-      torque: 100
-- duration: 3000
+- duration: 1000
   targets:
+    - id: R_HIP_PITCH
+      position: -1.39999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.39999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -512,70 +770,58 @@
       position: 0
       gain: 20
       torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
     - id: HEAD_PITCH
       position: 0.04269908
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
       position: 0
       gain: 20
       torque: 100
-    - id: L_ELBOW
-      position: -0.2347564
-      gain: 30
-      torque: 100
-    - id: R_ELBOW
-      position: -0.2439625
-      gain: 30
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.1271597
-      gain: 30
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.1992744
-      gain: 30
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.188934
-      gain: 30
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.313216
-      gain: 30
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -1.241294
-      gain: 30
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -1.235156
-      gain: 30
-      torque: 100
-    - id: R_KNEE
-      position: 1.457542
-      gain: 30
-      torque: 100
-    - id: L_KNEE
-      position: 1.514313
+    - id: L_ANKLE_PITCH
+      position: -1.26277399
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.8040022
+      position: -1.26430905
       gain: 30
       torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.8454298
+    - id: L_ELBOW
+      position: -0.234756395
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.243962497
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.18893397
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.31321597
       gain: 30
       torque: 100
 - duration: 1500
   targets:
     - id: R_HIP_ROLL
-      position: -0.02
+      position: -0.0199999996
       gain: 20
       torque: 100
     - id: R_ANKLE_ROLL
@@ -599,7 +845,7 @@
       gain: 20
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.02
+      position: 0.0199999996
       gain: 20
       torque: 100
     - id: L_HIP_YAW
@@ -607,214 +853,132 @@
       gain: 20
       torque: 100
     - id: R_HIP_PITCH
-      position: -1.052568
+      position: -1.05256796
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -1.006537
+      position: -1.00653696
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 1.178289
+      position: 1.17828906
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 1.196701
+      position: 1.19670105
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.5278183
+      position: -0.527818322
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.5891925
+      position: -0.58919251
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.175124
+      position: 1.17512405
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 1.179728
+      position: 1.17972803
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.2575799
+      position: -0.300000012
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.1547781
+      position: 0.300000012
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -1.417744
+      position: -1.41774404
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -1.364042
-      gain: 30
-      torque: 100
-- duration: 1500
-  targets:
-    - id: R_HIP_ROLL
-      position: -0.02
-      gain: 20
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: HEAD_PITCH
-      position: 0.04269908
-      gain: 20
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.02
-      gain: 20
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0
-      gain: 20
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.175124
-      gain: 30
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.179728
-      gain: 30
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.2575799
-      gain: 30
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.1547781
-      gain: 30
-      torque: 100
-    - id: R_ELBOW
-      position: -1.417744
-      gain: 30
-      torque: 100
-    - id: L_ELBOW
-      position: -1.364042
-      gain: 30
-      torque: 100
-    - id: L_KNEE
-      position: 0.4433328
-      gain: 30
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.1058705
-      gain: 30
-      torque: 100
-    - id: R_KNEE
-      position: 0.3635463
-      gain: 30
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.1917944
-      gain: 30
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -0.5431618
-      gain: 30
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -0.5293526
+      position: -1.36404204
       gain: 30
       torque: 100
 - duration: 1000
   targets:
     - id: HEAD_YAW
-      position: -0.001534355
+      position: -0.00153435499
       gain: 30
       torque: 100
     - id: HEAD_PITCH
-      position: 0.5308869
+      position: 0.530886889
       gain: 30
       torque: 100
     - id: R_HIP_YAW
-      position: -0.02915275
+      position: -0.0291527491
       gain: 30
       torque: 100
     - id: L_HIP_YAW
-      position: 0.01994662
+      position: 0.0199466199
       gain: 30
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.1503668
+      position: -0.150366798
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.09819874
+      position: 0.0981987417
       gain: 30
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.4802532
+      position: -0.48025319
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.4909937
+      position: -0.490993708
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 0.7854941
+      position: 0.785494089
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 0.8269216
+      position: 0.826921582
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.5324213
+      position: -0.532421291
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.556971
+      position: -0.556971014
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.1549699
+      position: 0.154969901
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.09513003
+      position: -0.0951300263
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.98373
+      position: 1.98372996
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.1762591
+      position: -0.300000012
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -1.574249
+      position: -1.57424903
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.068119
+      position: 2.06811905
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.1348315
+      position: 0.300000012
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -1.565042
+      position: -1.56504202
       gain: 30
       torque: 100

--- a/module/motion/ScriptEngine/data/scripts/docker/StandUpFront.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/StandUpFront.yaml
@@ -654,7 +654,171 @@
       position: -2
       gain: 30
       torque: 100
-- duration: 1000
+- duration: 300
+  targets:
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 300
   targets:
     - id: R_HIP_PITCH
       position: -2

--- a/module/motion/ScriptEngine/data/scripts/nugus/KickLeft.yaml
+++ b/module/motion/ScriptEngine/data/scripts/nugus/KickLeft.yaml
@@ -365,7 +365,7 @@
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 1.006441
+      position: 1.206441
       gain: 30
       torque: 100
     - id: L_HIP_ROLL

--- a/module/motion/ScriptEngine/data/scripts/webots/KickLeft.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/KickLeft.yaml
@@ -1,0 +1,690 @@
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: -0.00153435499
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.530886889
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0291527491
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0199466199
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.150366798
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0981987417
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.48025319
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.490993708
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.785494089
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.826921582
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.532421291
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.556971014
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.154969901
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0951300263
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.98372996
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.1762591
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.57424903
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.06811905
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.134831503
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.56504202
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0626140907
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0690966323
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0626140907
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.0690966323
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.256000012
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.207138002
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.207000002
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.259306103
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.222481504
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.672047675
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.581520677
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.92235601
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.80267596
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.312816709
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.309747994
+      gain: 30
+      torque: 100
+- duration: 600
+  targets:
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.96349502
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.262374789
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.294500411
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.207138002
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.239359394
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.116610996
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0245496891
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.191794395
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.452634811
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.793261707
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.314351112
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -0.619879603
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.1693871
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.727092683
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.239359394
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.378985792
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.510940373
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.757875681
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.38358891
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.529352605
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.217878506
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.66765201
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.41641808
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.242236406
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.957437813
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.997331023
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.836031914
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0981987417
+      gain: 30
+      torque: 100
+- duration: 200
+  targets:
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.239359394
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.216344103
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.942094207
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.14443696
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.65270901
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.110281803
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.27811801
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.063308
+      gain: 30
+      torque: 100
+    - id: HEAD_YAW
+      position: -0.00306871091
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.530886889
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.242428198
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 1.20000005
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.507871628
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.392794997
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.642703116
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0291527491
+      gain: 30
+      torque: 100
+- duration: 500
+  targets:
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.239359394
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.492528111
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.988028884
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.626016974
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.27464959
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.68146205
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.581520677
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.56617713
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.176450893
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.699666083
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0859239027
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.340435088
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.840634882
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.13563108
+      gain: 30
+      torque: 100
+- duration: 500
+  targets:
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.225550205
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.313008487
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.541627526
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.89166796
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.08960009
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.707337916
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.693528712
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.164176002
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.346764296
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.790097117
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.248565599
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.498665512
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 1.02782595
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.289801389
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.246935293
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.115076698
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.1058705
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0659772828
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.1519012
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.406604201
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.402001113
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.141160697
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.119679697
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.74897301
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.84563804
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.332763314
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.289801389
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.626016974
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.639826179
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: -0.00153435499
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.530886889
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0291527491
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0199466199
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.150366798
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0981987417
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.48025319
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.490993708
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.785494089
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.826921582
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.532421291
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.556971014
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.154969901
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0951300263
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.98372996
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.1762591
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.57424903
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.06811905
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.134831503
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.56504202
+      gain: 30
+      torque: 100

--- a/module/motion/ScriptEngine/data/scripts/webots/KickRight.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/KickRight.yaml
@@ -1,0 +1,690 @@
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: -0.00153435499
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.530886889
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0291527491
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0199466199
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.150366798
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0981987417
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.48025319
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.490993708
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.785494089
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.826921582
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.532421291
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.556971014
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.154969901
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.0951300263
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.98372996
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.1762591
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.57424903
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.06811905
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.134831503
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.56504202
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0626140907
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.0690966323
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0626140907
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0690966323
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.256000012
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.207138002
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.207000002
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.259306103
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.222481504
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.672047675
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.581520677
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.92235601
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.80267596
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.312816709
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.309747994
+      gain: 30
+      torque: 100
+- duration: 600
+  targets:
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.96349502
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.262374789
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.294500411
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.207138002
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.239359394
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0.116610996
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: -0.0245496891
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.191794395
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.452634811
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -0.793261707
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.314351112
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.619879603
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.1693871
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.727092683
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.239359394
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.378985792
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.510940373
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.757875681
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.38358891
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.529352605
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0.217878506
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.66765201
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.41641808
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.242236406
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.957437813
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.997331023
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.836031914
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: -0.0981987417
+      gain: 30
+      torque: 100
+- duration: 200
+  targets:
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.239359394
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0.216344103
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.942094207
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.14443696
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.65270901
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.110281803
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.27811801
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.063308
+      gain: 30
+      torque: 100
+    - id: HEAD_YAW
+      position: -0.00306871091
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.530886889
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.242428198
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 1.20000005
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.507871628
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.392794997
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.642703116
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: -0.0291527491
+      gain: 30
+      torque: 100
+- duration: 500
+  targets:
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.239359394
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.492528111
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.988028884
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.626016974
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.27464959
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.68146205
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.581520677
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.56617713
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0.176450893
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.699666083
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: -0.0859239027
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.340435088
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.840634882
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.13563108
+      gain: 30
+      torque: 100
+- duration: 500
+  targets:
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.204069301
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: -0.225550205
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.313008487
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.541627526
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.89166796
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.08960009
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.707337916
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.693528712
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0.164176002
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.346764296
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.790097117
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.248565599
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.498665512
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -1.02782595
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.289801389
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_YAW
+      position: -0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0292397309
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.256141514
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.246935293
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.115076698
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.1058705
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0659772828
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.1519012
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.406604201
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.402001113
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.141160697
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.119679697
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.74897301
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.84563804
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.332763314
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.289801389
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.626016974
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.639826179
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: -0.00153435499
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.530886889
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0291527491
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0199466199
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.150366798
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0981987417
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.48025319
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.490993708
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.785494089
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.826921582
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.532421291
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.556971014
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.154969901
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.0951300263
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.98372996
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.1762591
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.57424903
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.06811905
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.134831503
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.56504202
+      gain: 30
+      torque: 100

--- a/module/motion/ScriptEngine/data/scripts/webots/NodYes.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/NodYes.yaml
@@ -1,0 +1,40 @@
+- duration: 500
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 30
+      torque: 100
+- duration: 150
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.3
+      gain: 30
+      torque: 100
+- duration: 250
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 30
+      torque: 100

--- a/module/motion/ScriptEngine/data/scripts/webots/Relax.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/Relax.yaml
@@ -1,0 +1,27 @@
+[
+    {
+        "duration": 25,
+        "targets": [
+            { "id": "R_SHOULDER_PITCH", "position": 0.7, "gain": .NaN, "torque": 0 },
+            { "id": "L_SHOULDER_PITCH", "position": 0.7, "gain": .NaN, "torque": 0  },
+            { "id": "R_SHOULDER_ROLL", "position": 0.7, "gain": .NaN, "torque": 0  },
+            { "id": "L_SHOULDER_ROLL", "position": 0.7, "gain": .NaN, "torque": 0  },
+            { "id": "R_ELBOW", "position": -1.5, "gain": .NaN, "torque": 0  },
+            { "id": "L_ELBOW", "position": -1.5, "gain": .NaN, "torque": 0  },
+            { "id": "R_HIP_YAW", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "L_HIP_YAW", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "R_HIP_PITCH", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "L_HIP_PITCH", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "R_KNEE", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "L_KNEE", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "R_ANKLE_PITCH", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "L_ANKLE_PITCH", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "R_HIP_ROLL", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "L_HIP_ROLL", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "HEAD_YAW", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "HEAD_PITCH", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "R_ANKLE_ROLL", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "L_ANKLE_ROLL", "position": 0, "gain": .NaN, "torque": 0  }
+        ]
+    }
+]

--- a/module/motion/ScriptEngine/data/scripts/webots/RelaxHead.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/RelaxHead.yaml
@@ -1,0 +1,9 @@
+[
+    {
+        "duration": 25,
+        "targets": [
+            { "id": "HEAD_YAW", "position": 0, "gain": .NaN, "torque": 0  },
+            { "id": "HEAD_PITCH", "position": 0, "gain": .NaN, "torque": 0  }
+        ]
+    }
+]

--- a/module/motion/ScriptEngine/data/scripts/webots/RollOverFront.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/RollOverFront.yaml
@@ -1,0 +1,656 @@
+- duration: 1000
+  targets:
+    - id: R_HIP_ROLL
+      position: -0.02
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.02
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.05063373
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.004603066
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.003068711
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.1778893
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.2070421
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.1396263
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.07518341
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.0859239
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: 0.1672447
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.2008088
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.1639842
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.57866
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.546438
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_ROLL
+      position: -0.02
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.02
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.05063373
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.004603066
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.003068711
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.1778893
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.2070421
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.1396263
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.07518341
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.0859239
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: 0.1672447
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.2008088
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.57866
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.546438
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -1.581729
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_ROLL
+      position: -0.02
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.02
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.05063373
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.004603066
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.003068711
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.1778893
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.2070421
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.1396263
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.07518341
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.0859239
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: 0.1672447
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.2008088
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.57866
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -1.581729
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: -1.5637
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_ROLL
+      position: -0.02
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.02
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.05063373
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.004603066
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.003068711
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.1778893
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.2070421
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.1396263
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.07518341
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.0859239
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: 0.1672447
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.2008088
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.57866
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: -1.5637
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.1010757
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_ROLL
+      position: -0.02
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.02
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.05063373
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.004603066
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.003068711
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.2070421
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.07518341
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.0859239
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: 0.1672447
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.2008088
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.1639842
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.57866
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 1.497435
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.9436285
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0.5186121
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: -1.559097
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_ROLL
+      position: -0.02
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.02
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.05063373
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.004603066
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.003068711
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.2070421
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.07518341
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: 0.1672447
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.2008088
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.1639842
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.57866
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.9436285
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0.5186121
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: -0.6308119
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.4279892
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.453035
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_ROLL
+      position: -0.02
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.05063373
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.004603066
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.003068711
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.2070421
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.07518341
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: 0.1672447
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.2008088
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.57866
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.9436285
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: -0.6308119
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.453035
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.8776513
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.2516343
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.3252833
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 1.383893
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -1.612416
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_ROLL
+      position: -0.02
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.05063373
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.004603066
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.003068711
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: 0.1672447
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.2008088
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.57866
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.57866
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.171656
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.05063373
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: -0.03375582
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.02148098
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.2132754
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.2777183
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.08429365
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.05360654
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.2991993
+      gain: 30
+      torque: 100

--- a/module/motion/ScriptEngine/data/scripts/webots/Stand.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/Stand.yaml
@@ -1,0 +1,74 @@
+- duration: 1000
+  targets:
+    - id: R_HIP_YAW
+      position: -0.02915275
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.01994662
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.1503668
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.09819874
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.4802532
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.4909937
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.7854941
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.8269216
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.5324213
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.556971
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.1549699
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.09513003
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.98373
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.1762591
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.574249
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.068119
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.1348315
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.565042
+      gain: 30
+      torque: 100

--- a/module/motion/ScriptEngine/data/scripts/webots/StandUpBack.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/StandUpBack.yaml
@@ -900,6 +900,252 @@
       position: -0.0966643915
       gain: 30
       torque: 100
+- duration: 300
+  targets:
+    - id: L_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0966643915
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: L_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0966643915
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: L_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0966643915
+      gain: 30
+      torque: 100
 - duration: 1000
   targets:
     - id: L_ELBOW

--- a/module/motion/ScriptEngine/data/scripts/webots/StandUpBack.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/StandUpBack.yaml
@@ -1,0 +1,1312 @@
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: -1.79999995
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.67079604
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.79999995
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.67079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0506337285
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: -1.79999995
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.67079604
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.79999995
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.67079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0506337285
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: -1.79999995
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.67079604
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.79999995
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.67079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0506337285
+      gain: 30
+      torque: 100
+- duration: 800
+  targets:
+    - id: L_ELBOW
+      position: -1.70000005
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.70000005
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0506337285
+      gain: 30
+      torque: 100
+- duration: 800
+  targets:
+    - id: L_ELBOW
+      position: -1.70000005
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.70000005
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0506337285
+      gain: 30
+      torque: 100
+- duration: 800
+  targets:
+    - id: L_ELBOW
+      position: -1.65999997
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 1.98000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.540000021
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.540000021
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.65999997
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 1.98000002
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.222481504
+      gain: 30
+      torque: 100
+- duration: 800
+  targets:
+    - id: L_ELBOW
+      position: -1.65999997
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 1.98000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0.540000021
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0.540000021
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.65999997
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 1.98000002
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 3.0999999
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.222481504
+      gain: 30
+      torque: 100
+- duration: 600
+  targets:
+    - id: L_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0813208371
+      gain: 30
+      torque: 100
+- duration: 600
+  targets:
+    - id: L_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0813208371
+      gain: 30
+      torque: 100
+- duration: 600
+  targets:
+    - id: L_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.600000024
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.6099999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.0813208371
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: L_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.26999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.800000012
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -1.35000002
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.42000008
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.93079603
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0966643915
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.48000002
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.48000002
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.29999995
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.29999995
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0.699999988
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0368245319
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0368245319
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.992999971
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.992727876
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 2.09599996
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 2.09583402
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.67858505
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.61874497
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0368245319
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.806999981
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.807070911
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 1.45099998
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 1.45140398
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.10320199
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.09706402
+      gain: 30
+      torque: 100
+- duration: 800
+  targets:
+    - id: L_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -0.699999988
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.29079604
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.0368245319
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.397000015
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.397398114
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.713
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.713379383
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.780986905
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.781000018
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: -0.00153435499
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.530886889
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0291527491
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0199466199
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.150366798
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0981987417
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.48025319
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.490993708
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.785494089
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.826921582
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.532421291
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.556971014
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.154969901
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0951300263
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.98372996
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.1762591
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.57424903
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.06811905
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.134831503
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.56504202
+      gain: 30
+      torque: 100

--- a/module/motion/ScriptEngine/data/scripts/webots/StandUpFront.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/StandUpFront.yaml
@@ -1,0 +1,984 @@
+- duration: 1000
+  targets:
+    - id: L_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.70000005
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.70000005
+      gain: 30
+      torque: 100
+- duration: 1500
+  targets:
+    - id: L_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.70000005
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.70000005
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.56524992
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.57599092
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.56524992
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.57599092
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.56524992
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.57599092
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: R_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.0599999987
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -3
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.56524992
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.57599092
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -2
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -2
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: -2
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -2
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: R_HIP_PITCH
+      position: -1.39999998
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.39999998
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.04269908
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.26277399
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.26430905
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -0.234756395
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -0.243962497
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.18893397
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.31321597
+      gain: 30
+      torque: 100
+- duration: 1500
+  targets:
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.04269908
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.05256796
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.00653696
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 1.17828906
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 1.19670105
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.527818322
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.58919251
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.17512405
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.17972803
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.41774404
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.36404204
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: -0.00153435499
+      gain: 30
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0.530886889
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0291527491
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0199466199
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.150366798
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0981987417
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.48025319
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.490993708
+      gain: 30
+      torque: 100
+    - id: R_KNEE
+      position: 0.785494089
+      gain: 30
+      torque: 100
+    - id: L_KNEE
+      position: 0.826921582
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -0.532421291
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.556971014
+      gain: 30
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.154969901
+      gain: 30
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0951300263
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.98372996
+      gain: 30
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 30
+      torque: 100
+    - id: R_ELBOW
+      position: -1.57424903
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.06811905
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: -1.56504202
+      gain: 30
+      torque: 100

--- a/module/motion/ScriptEngine/data/scripts/webots/StandUpFront.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/StandUpFront.yaml
@@ -654,7 +654,171 @@
       position: -2
       gain: 30
       torque: 100
-- duration: 1000
+- duration: 300
+  targets:
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 300
+  targets:
+    - id: R_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0199999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.53999996
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.300000012
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.200000003
+      gain: 20
+      torque: 100
+    - id: HEAD_YAW
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 2.5999999
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 0.890796304
+      gain: 20
+      torque: 100
+    - id: HEAD_PITCH
+      position: -0.207300901
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0199999996
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.200000003
+      gain: 20
+      torque: 100
+    - id: R_ELBOW
+      position: 0
+      gain: 30
+      torque: 100
+    - id: L_ELBOW
+      position: 0.300000012
+      gain: 30
+      torque: 100
+- duration: 300
   targets:
     - id: R_HIP_PITCH
       position: -2

--- a/module/motion/ScriptEngine/data/scripts/webots/Zombie.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/Zombie.yaml
@@ -1,0 +1,62 @@
+- targets:
+    - id: R_SHOULDER_PITCH
+      position: 0
+      gain: 30
+    - gain: 30
+      position: 0
+      id: L_SHOULDER_PITCH
+    - id: R_SHOULDER_ROLL
+      gain: 30
+      position: 0
+    - position: 0
+      id: L_SHOULDER_ROLL
+      gain: 30
+    - position: 0
+      gain: 30
+      id: R_ELBOW
+    - position: 0
+      id: L_ELBOW
+      gain: 30
+    - id: R_HIP_YAW
+      gain: 30
+      position: 0
+    - gain: 30
+      position: 0
+      id: L_HIP_YAW
+    - position: 0
+      gain: 30
+      id: R_HIP_ROLL
+    - position: 0
+      id: L_HIP_ROLL
+      gain: 30
+    - gain: 30
+      id: R_HIP_PITCH
+      position: 0
+    - id: L_HIP_PITCH
+      gain: 30
+      position: 0
+    - id: R_KNEE
+      gain: 30
+      position: 0
+    - id: L_KNEE
+      gain: 30
+      position: 0
+    - gain: 30
+      position: 0
+      id: R_ANKLE_PITCH
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 30
+    - gain: 30
+      position: 0
+      id: R_ANKLE_ROLL
+    - id: L_ANKLE_ROLL
+      gain: 30
+      position: 0
+    - id: HEAD_PITCH
+      gain: 30
+      position: 0
+    - id: HEAD_YAW
+      position: 0
+      gain: 30
+  duration: 1000

--- a/roles/scripttuner.role
+++ b/roles/scripttuner.role
@@ -5,11 +5,10 @@ nuclear_role(
   # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
   motion::KinematicsConfiguration
   support::configuration::GlobalConfig
-  # platform::darwin::HardwareIO
+  platform::darwin::HardwareIO
   behaviour::tools::ScriptTuner
   behaviour::Controller
   network::NUClearNet
   support::NUsight
   motion::ScriptEngine
-  platform::Webots
 )

--- a/roles/scripttuner.role
+++ b/roles/scripttuner.role
@@ -5,10 +5,11 @@ nuclear_role(
   # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
   motion::KinematicsConfiguration
   support::configuration::GlobalConfig
-  platform::darwin::HardwareIO
+  # platform::darwin::HardwareIO
   behaviour::tools::ScriptTuner
   behaviour::Controller
   network::NUClearNet
   support::NUsight
   motion::ScriptEngine
+  platform::Webots
 )

--- a/roles/webots_keyboard.role
+++ b/roles/webots_keyboard.role
@@ -9,12 +9,15 @@ nuclear_role(
   support::configuration::GlobalConfig
   support::configuration::SoccerConfig
   input::SensorFilter
+  platform::Webots
   # Motion
   motion::QuinticWalk
   motion::HeadController
+  motion::ScriptEngine
   # Behaviour
   behaviour::Controller
+  behaviour::skills::Getup
+  behaviour::skills::KickScript
   behaviour::skills::DirectWalkController
   behaviour::strategy::KeyboardWalk
-  platform::Webots
 )


### PR DESCRIPTION
This creates a folder for scripts for `webots#` robots. The scripts are tuned to work for the NUgus in Webots.

- `StandUpFront.yaml`
- `StandUpBack.yaml`
- `KickLeft.yaml`
- `KickRight.yaml`

It also updates from using the roll over method for getting up to just using either front or back get up.

When this is run normally (outside of RoboCup), the robot is `docker`, so those files are also updated. (Do we want to somehow make it use the `webots` folder when using webots?)