### PR TITLE
Set a max bound on the velocity we send to webots

### DIFF
--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -224,6 +224,8 @@ namespace module::platform {
             min_camera_time_step = config["min_camera_time_step"].as<int>();
             min_sensor_time_step = config["min_sensor_time_step"].as<int>();
 
+            max_velocity = config["max_velocity"].as<double>();
+
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
 
             clock_smoothing = config["clock_smoothing"].as<double>();
@@ -257,8 +259,9 @@ namespace module::platform {
                 // Otherwise, if the duration is negative or 0, the servo should have reached its position before now
                 // Because of this, we move the servo as fast as we can to reach the position.
                 // 5.236 == 50 rpm which is similar to the max speed of the servos
-                double speed = duration.count() > 0 ? diff / std::chrono::duration<double>(duration).count() : 5.236;
-
+                double speed =
+                    duration.count() > 0 ? diff / std::chrono::duration<double>(duration).count() : max_velocity;
+                speed = std::min(max_velocity, speed);
                 // Update our internal state
                 if (servo_state[target.id].p_gain != target.gain || servo_state[target.id].i_gain != target.gain * 0.0
                     || servo_state[target.id].d_gain != target.gain * 0.0

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -223,8 +223,7 @@ namespace module::platform {
             time_step            = config["time_step"].as<int>();
             min_camera_time_step = config["min_camera_time_step"].as<int>();
             min_sensor_time_step = config["min_sensor_time_step"].as<int>();
-
-            max_velocity = config["max_velocity"].as<double>();
+            max_velocity         = config["max_velocity"].as<double>();
 
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
 
@@ -258,7 +257,8 @@ namespace module::platform {
                 // If we have a positive duration, find the velocity.
                 // Otherwise, if the duration is negative or 0, the servo should have reached its position before now
                 // Because of this, we move the servo as fast as we can to reach the position.
-                // 5.236 == 50 rpm which is similar to the max speed of the servos
+                // The fastest speed is determined by the config, which comes from the max servo velocity from
+                // NUgus.proto in Webots
                 double speed =
                     duration.count() > 0 ? diff / std::chrono::duration<double>(duration).count() : max_velocity;
                 speed = std::min(max_velocity, speed);

--- a/module/platform/Webots/src/Webots.hpp
+++ b/module/platform/Webots/src/Webots.hpp
@@ -84,6 +84,9 @@ namespace module::platform {
         /// @brief The minimum allowed time between two sensor measurements, not including the camera
         int min_sensor_time_step;
 
+        /// @brief The maximum velocity allowed by the NUgus motors in webots
+        double max_velocity;
+
         /// @brief Current state of a servo
         struct ServoState {
             /// @brief True if we need to write new values to the simulator

--- a/module/platform/Webots/src/Webots.hpp
+++ b/module/platform/Webots/src/Webots.hpp
@@ -83,7 +83,6 @@ namespace module::platform {
         int min_camera_time_step;
         /// @brief The minimum allowed time between two sensor measurements, not including the camera
         int min_sensor_time_step;
-
         /// @brief The maximum velocity allowed by the NUgus motors in webots
         double max_velocity;
 


### PR DESCRIPTION
At the moment we don't set a max bound, which results in webots being sent ridiculous velocity requests. This gives the simulator warnings. We don't want a load of warnings in the simulator console (particularly not in official games!). This PR fixes this so we have a bound.