### PR TITLE
Fix communication in the Webots module to successfully connect to the official RoboCup controller

### DIFF
--- a/module/platform/Webots/data/config/webots.yaml
+++ b/module/platform/Webots/data/config/webots.yaml
@@ -13,5 +13,5 @@ min_sensor_time_step: 8
 clock_smoothing: 0.6
 
 # Connection details
-server_address: "127.0.0.1"
-port: 10020
+server_address: "127.0.1.1"
+port: 10001

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -335,8 +335,9 @@ namespace module::platform {
                     // If we have not seen the welcome message yet, look for it
                     if (!connection_active) {
                         // Initaliase the string with 0s
-                        std::array<char, 8> initial_message{};
-                        const int n = ::read(fd, initial_message.data(), initial_message.size());
+                        // make sure we have an extra character just in case we read something that isn't a null terminator
+                        std::array<char, 9> initial_message{};
+                        const int n = ::read(fd, initial_message.data(), initial_message.size() - 1);
 
                         if (n >= 0) {
                             if (initial_message.data() == std::string("Welcome")) {

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -403,10 +403,12 @@ namespace module::platform {
                             // Decode the protocol buffer and emit it as a message
                             char* payload = reinterpret_cast<char*>(buffer.data()) + sizeof(length);
 
-                            // Service the watchdog
-                            emit<Scope::WATCHDOG>(ServiceWatchdog<Webots>());
                             translate_and_emit_sensor(
                                 NUClear::util::serialise::Serialise<SensorMeasurements>::deserialise(payload, length));
+
+                            // Service the watchdog
+                            emit<Scope::WATCHDOG>(ServiceWatchdog<Webots>());
+
                             // Delete the packet we just read ready to read the next one
                             buffer.erase(buffer.begin(), std::next(buffer.begin(), sizeof(length) + length));
                         }

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -339,11 +339,11 @@ namespace module::platform {
                         const int n = ::read(fd, initial_message.data(), initial_message.size());
 
                         if (n >= 0) {
-                            if (std::string("Welcome") == initial_message.data()) {
+                            if (initial_message.data() == std::string("Welcome")) {
                                 // good
                                 log<NUClear::INFO>(fmt::format("Connected to {}:{}", server_address, server_port));
                             }
-                            else if (std::string("Refused") == initial_message.data()) {
+                            else if (initial_message.data() == std::string("Refused")) {
                                 log<NUClear::FATAL>(
                                     fmt::format("Connection to {}:{} refused: your IP is not white listed.",
                                                 server_address,

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -332,8 +332,6 @@ namespace module::platform {
             // Receiving
             read_io = on<IO>(fd, IO::READ | IO::CLOSE | IO::ERROR).then("Read Stream", [this](const IO::Event& event) {
                 if ((event.events & IO::READ) != 0) {
-                    // Service the watchdog
-                    emit<Scope::WATCHDOG>(ServiceWatchdog<Webots>());
                     // If we have not seen the welcome message yet, look for it
                     if (!connection_active) {
                         // Initaliase the string with 0s
@@ -405,6 +403,8 @@ namespace module::platform {
                             // Decode the protocol buffer and emit it as a message
                             char* payload = reinterpret_cast<char*>(buffer.data()) + sizeof(length);
 
+                            // Service the watchdog
+                            emit<Scope::WATCHDOG>(ServiceWatchdog<Webots>());
                             translate_and_emit_sensor(
                                 NUClear::util::serialise::Serialise<SensorMeasurements>::deserialise(payload, length));
                             // Delete the packet we just read ready to read the next one

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -337,7 +337,7 @@ namespace module::platform {
                     // If we have not seen the welcome message yet, look for it
                     if (!connection_active) {
                         // Initaliase the string with 0s
-                        std::array<char, 8> initial_message = {'\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0'};
+                        std::array<char, 8> initial_message{};
                         const int n = ::read(fd, initial_message.data(), initial_message.size());
 
                         if (n >= 0) {

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -335,7 +335,8 @@ namespace module::platform {
                     // If we have not seen the welcome message yet, look for it
                     if (!connection_active) {
                         // Initaliase the string with 0s
-                        // make sure we have an extra character just in case we read something that isn't a null terminator
+                        // make sure we have an extra character just in case we read something that isn't a null
+                        // terminator
                         std::array<char, 9> initial_message{};
                         const int n = ::read(fd, initial_message.data(), initial_message.size() - 1);
 

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -341,11 +341,11 @@ namespace module::platform {
                         const int n = ::read(fd, initial_message.data(), initial_message.size());
 
                         if (n >= 0) {
-                            if (std::strncmp(initial_message.data(), "Welcome", initial_message.size()) == 0) {
+                            if (std::string("Welcome") == initial_message.data()) {
                                 // good
                                 log<NUClear::INFO>(fmt::format("Connected to {}:{}", server_address, server_port));
                             }
-                            else if (std::strncmp(initial_message.data(), "Refused", initial_message.size()) == 0) {
+                            else if (std::string("Refused") == initial_message.data()) {
                                 log<NUClear::FATAL>(
                                     fmt::format("Connection to {}:{} refused: your IP is not white listed.",
                                                 server_address,
@@ -405,16 +405,10 @@ namespace module::platform {
                             // Decode the protocol buffer and emit it as a message
                             char* payload = reinterpret_cast<char*>(buffer.data()) + sizeof(length);
 
-                            try {
-                                translate_and_emit_sensor(
-                                    NUClear::util::serialise::Serialise<SensorMeasurements>::deserialise(payload,
-                                                                                                         length));
-                                // Delete the packet we just read ready to read the next one
-                                buffer.erase(buffer.begin(), std::next(buffer.begin(), sizeof(length) + length));
-                            }
-                            catch (std::exception e) {
-                                log<NUClear::WARN>(e.what());
-                            }
+                            translate_and_emit_sensor(
+                                NUClear::util::serialise::Serialise<SensorMeasurements>::deserialise(payload, length));
+                            // Delete the packet we just read ready to read the next one
+                            buffer.erase(buffer.begin(), std::next(buffer.begin(), sizeof(length) + length));
                         }
                     }
                 }

--- a/module/support/configuration/GlobalConfig/data/config/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/GlobalConfig.yaml
@@ -1,2 +1,2 @@
 player_id: 1
-team_id: 23
+team_id: 12


### PR DESCRIPTION
The welcome message was read in as 7 bytes, but 8 bytes were associated with the message. One byte left over messed with the rest of communication. This fixed that.
It also updates the config so that we are using the right team id (as from GameController) and the right host IP address.