### PR TITLE
Updates the get ups for Webots

### DIFF
--- a/module/motion/ScriptEngine/data/scripts/docker/StandUpBack.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/StandUpBack.yaml
@@ -818,7 +818,7 @@
       position: 0.0813208371
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: L_ELBOW
       position: -1.35000002
@@ -900,7 +900,7 @@
       position: -0.0966643915
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: L_ELBOW
       position: -1.35000002
@@ -982,7 +982,7 @@
       position: -0.0966643915
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: L_ELBOW
       position: -1.35000002

--- a/module/motion/ScriptEngine/data/scripts/docker/StandUpFront.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/StandUpFront.yaml
@@ -654,7 +654,7 @@
       position: -2
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: R_HIP_PITCH
       position: -2
@@ -736,7 +736,7 @@
       position: 0.300000012
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: R_HIP_PITCH
       position: -2
@@ -818,7 +818,7 @@
       position: 0.300000012
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: R_HIP_PITCH
       position: -2

--- a/module/motion/ScriptEngine/data/scripts/webots/StandUpBack.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/StandUpBack.yaml
@@ -818,7 +818,7 @@
       position: 0.0813208371
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: L_ELBOW
       position: -1.35000002
@@ -900,7 +900,7 @@
       position: -0.0966643915
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: L_ELBOW
       position: -1.35000002
@@ -982,7 +982,7 @@
       position: -0.0966643915
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: L_ELBOW
       position: -1.35000002

--- a/module/motion/ScriptEngine/data/scripts/webots/StandUpFront.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/StandUpFront.yaml
@@ -654,7 +654,7 @@
       position: -2
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: R_HIP_PITCH
       position: -2
@@ -736,7 +736,7 @@
       position: 0.300000012
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: R_HIP_PITCH
       position: -2
@@ -818,7 +818,7 @@
       position: 0.300000012
       gain: 30
       torque: 100
-- duration: 300
+- duration: 500
   targets:
     - id: R_HIP_PITCH
       position: -2


### PR DESCRIPTION
Turns out we weren't tuning on the exact field used in the RoboCup world (see NUbots/NUWebots#77). This updates the get ups so they work on the right field.