### PR TITLE
Changes return types of walk engine functions which mutated many references

### DIFF
--- a/module/motion/QuinticWalk/src/QuinticWalk.cpp
+++ b/module/motion/QuinticWalk/src/QuinticWalk.cpp
@@ -236,9 +236,8 @@ namespace module::motion {
                 .normalized()
                 .toRotationMatrix();
         };
-
         // Read the cartesian positions and orientations for trunk and fly foot
-        walk_engine.computeCartesianPosition(trunk_pos, trunk_axis, foot_pos, foot_axis, is_left_support);
+        std::tie(trunk_pos, trunk_axis, foot_pos, foot_axis, is_left_support) = walk_engine.computeCartesianPosition();
 
         // Change goals from support foot based coordinate system to trunk based coordinate system
         Eigen::Affine3f Hst;  // trunk_to_support_foot_goal

--- a/module/motion/QuinticWalk/src/WalkEngine.cpp
+++ b/module/motion/QuinticWalk/src/WalkEngine.cpp
@@ -31,7 +31,7 @@ namespace module::motion {
         , trunk_axis_acc_at_last()
         , trajs() {
         // Make sure to call the reset method after having the parameters
-        TrajectoriesInit(trajs);
+        trajectoriesInit(trajs);
     }
 
     bool QuinticWalkEngine::updateState(const float dt, const Eigen::Vector3f& orders) {
@@ -300,7 +300,7 @@ namespace module::motion {
         }
 
         // Reset the trajectories
-        TrajectoriesInit(trajs);
+        trajectoriesInit(trajs);
 
         // full period (float step) is needed for trunk splines
         float period = 2.0f * half_period;
@@ -538,7 +538,7 @@ namespace module::motion {
         foot_step.stepFromOrders(orders);
 
         // Reset the trajectories
-        TrajectoriesInit(trajs);
+        trajectoriesInit(trajs);
 
         // Time length of float and single support phase during the half cycle
         float doubleSupportLength = params.double_support_ratio * half_period;
@@ -687,9 +687,9 @@ namespace module::motion {
 
     QuinticWalkEngine::PositionSupportTuple QuinticWalkEngine::computeCartesianPositionAtTime(const float time) const {
         // Evaluate target cartesian state from trajectories
-        const auto [trunkPos, trunkAxis, footPos, footAxis] = TrajectoriesTrunkFootPos(time, trajs);
+        const auto [trunkPos, trunkAxis, footPos, footAxis] = trajectoriesTrunkFootPos(time, trajs);
         // Discard isDoubleSupport because we don't use it
-        const auto [_, isLeftSupportFoot] = TrajectoriesSupportFootState(time, trajs);
+        const auto [_, isLeftSupportFoot] = trajectoriesSupportFootState(time, trajs);
         return {trunkPos, trunkAxis, footPos, footAxis, isLeftSupportFoot};
     }
 

--- a/module/motion/QuinticWalk/src/WalkEngine.cpp
+++ b/module/motion/QuinticWalk/src/WalkEngine.cpp
@@ -679,29 +679,21 @@ namespace module::motion {
         trunk_axis_acc_at_last.setZero();
     }
 
-    void QuinticWalkEngine::computeCartesianPosition(Eigen::Vector3f& trunkPos,
-                                                     Eigen::Vector3f& trunkAxis,
-                                                     Eigen::Vector3f& footPos,
-                                                     Eigen::Vector3f& footAxis,
-                                                     bool& isLeftsupportFoot) {
+    using PositionSupportTuple = std::tuple<Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f, bool>;
+
+    PositionSupportTuple QuinticWalkEngine::computeCartesianPosition() const {
         // Compute trajectories time
-        float time = getTrajsTime();
-
-        computeCartesianPositionAtTime(trunkPos, trunkAxis, footPos, footAxis, isLeftsupportFoot, time);
+        const float time = getTrajsTime();
+        return computeCartesianPositionAtTime(time);
     }
 
-
-    void QuinticWalkEngine::computeCartesianPositionAtTime(Eigen::Vector3f& trunkPos,
-                                                           Eigen::Vector3f& trunkAxis,
-                                                           Eigen::Vector3f& footPos,
-                                                           Eigen::Vector3f& footAxis,
-                                                           bool& isLeftsupportFoot,
-                                                           float time) {
-        // We don't use the double support capability of the trajectory utils
-        // We need to initialise this (l-value) to pass in as a reference to the function though
-        bool isDoubleSupport = false;
+    PositionSupportTuple QuinticWalkEngine::computeCartesianPositionAtTime(const float time) const {
         // Evaluate target cartesian state from trajectories
-        TrajectoriesTrunkFootPos(time, trajs, trunkPos, trunkAxis, footPos, footAxis);
-        TrajectoriesSupportFootState(time, trajs, isDoubleSupport, isLeftsupportFoot);
+        const auto [trunkPos, trunkAxis, footPos, footAxis] = TrajectoriesTrunkFootPos(time, trajs);
+        // Discard isDoubleSupport because we don't use it
+        const auto [_, isLeftSupportFoot] = TrajectoriesSupportFootState(time, trajs);
+        return {trunkPos, trunkAxis, footPos, footAxis, isLeftSupportFoot};
     }
+
+
 }  // namespace module::motion

--- a/module/motion/QuinticWalk/src/WalkEngine.cpp
+++ b/module/motion/QuinticWalk/src/WalkEngine.cpp
@@ -679,15 +679,13 @@ namespace module::motion {
         trunk_axis_acc_at_last.setZero();
     }
 
-    using PositionSupportTuple = std::tuple<Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f, bool>;
-
-    PositionSupportTuple QuinticWalkEngine::computeCartesianPosition() const {
+    QuinticWalkEngine::PositionSupportTuple QuinticWalkEngine::computeCartesianPosition() const {
         // Compute trajectories time
         const float time = getTrajsTime();
         return computeCartesianPositionAtTime(time);
     }
 
-    PositionSupportTuple QuinticWalkEngine::computeCartesianPositionAtTime(const float time) const {
+    QuinticWalkEngine::PositionSupportTuple QuinticWalkEngine::computeCartesianPositionAtTime(const float time) const {
         // Evaluate target cartesian state from trajectories
         const auto [trunkPos, trunkAxis, footPos, footAxis] = TrajectoriesTrunkFootPos(time, trajs);
         // Discard isDoubleSupport because we don't use it

--- a/module/motion/QuinticWalk/src/WalkEngine.cpp
+++ b/module/motion/QuinticWalk/src/WalkEngine.cpp
@@ -683,7 +683,7 @@ namespace module::motion {
                                                      Eigen::Vector3f& trunkAxis,
                                                      Eigen::Vector3f& footPos,
                                                      Eigen::Vector3f& footAxis,
-                                                     bool isLeftsupportFoot) {
+                                                     bool& isLeftsupportFoot) {
         // Compute trajectories time
         float time = getTrajsTime();
 
@@ -695,10 +695,12 @@ namespace module::motion {
                                                            Eigen::Vector3f& trunkAxis,
                                                            Eigen::Vector3f& footPos,
                                                            Eigen::Vector3f& footAxis,
-                                                           bool isLeftsupportFoot,
+                                                           bool& isLeftsupportFoot,
                                                            float time) {
+        // We don't use the double support capability of the trajectory utils
+        // We need to initialise this (l-value) to pass in as a reference to the function though
+        bool isDoubleSupport = false;
         // Evaluate target cartesian state from trajectories
-        bool isDoubleSupport;
         TrajectoriesTrunkFootPos(time, trajs, trunkPos, trunkAxis, footPos, footAxis);
         TrajectoriesSupportFootState(time, trajs, isDoubleSupport, isLeftsupportFoot);
     }

--- a/module/motion/QuinticWalk/src/WalkEngine.hpp
+++ b/module/motion/QuinticWalk/src/WalkEngine.hpp
@@ -169,26 +169,16 @@ namespace module::motion {
          */
         bool updateState(const float dt, const Eigen::Vector3f& orders);
 
+        // Return type for the following two functions
+        using PositionSupportTuple =
+            std::tuple<Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f, bool>;
         /**
-         * Compute current cartesian
-         * target from trajectories and assign
-         * it to given model through inverse
-         * kinematics.
-         * Return false is the target is
-         * unreachable.
+         * @brief Compute current cartesian target from trajectories
+         * @return PositionSupportTuple The computed vectors with the bool indicating the support foot:
+         *         {trunkPositionTarget, trunkAxisTarget, footPositionTarget, footAxisTarget, isLeftsupportFoot}
          */
-        void computeCartesianPosition(Eigen::Vector3f& trunkPos,
-                                      Eigen::Vector3f& trunkAxis,
-                                      Eigen::Vector3f& footPos,
-                                      Eigen::Vector3f& footAxis,
-                                      bool& isLeftsupportFoot);
-
-        void computeCartesianPositionAtTime(Eigen::Vector3f& trunkPos,
-                                            Eigen::Vector3f& trunkAxis,
-                                            Eigen::Vector3f& footPos,
-                                            Eigen::Vector3f& footAxis,
-                                            bool& isLeftsupportFoot,
-                                            float time);
+        [[nodiscard]] PositionSupportTuple computeCartesianPosition() const;  // Gets current time and calls below func
+        [[nodiscard]] PositionSupportTuple computeCartesianPositionAtTime(const float time) const;
 
         void requestKick(const bool left) {
             if (left) {

--- a/module/motion/QuinticWalk/src/WalkEngine.hpp
+++ b/module/motion/QuinticWalk/src/WalkEngine.hpp
@@ -181,13 +181,13 @@ namespace module::motion {
                                       Eigen::Vector3f& trunkAxis,
                                       Eigen::Vector3f& footPos,
                                       Eigen::Vector3f& footAxis,
-                                      bool isLeftsupportFoot);
+                                      bool& isLeftsupportFoot);
 
         void computeCartesianPositionAtTime(Eigen::Vector3f& trunkPos,
                                             Eigen::Vector3f& trunkAxis,
                                             Eigen::Vector3f& footPos,
                                             Eigen::Vector3f& footAxis,
-                                            bool isLeftsupportFoot,
+                                            bool& isLeftsupportFoot,
                                             float time);
 
         void requestKick(const bool left) {

--- a/shared/utility/motion/splines/TrajectoryUtils.hpp
+++ b/shared/utility/motion/splines/TrajectoryUtils.hpp
@@ -168,7 +168,7 @@ namespace utility::motion::splines {
     /**
      * Return initialized trajectories for trunk/foot ik cartesian with empty splines
      */
-    inline void TrajectoriesInit(Trajectories& traj) {
+    inline void trajectoriesInit(Trajectories& traj) {
         if (traj.size() != 0) {
             traj.reset();
         }
@@ -194,7 +194,7 @@ namespace utility::motion::splines {
      * Compute from given spline container trajectory Cartesian trunk and foot position/velocity/acceleration
      * and assign it to given vector
      */
-    [[nodiscard]] inline Vector3fQuadruple TrajectoriesTrunkFootPos(const float t, const Trajectories& traj) {
+    [[nodiscard]] inline Vector3fQuadruple trajectoriesTrunkFootPos(const float t, const Trajectories& traj) {
         // Compute Cartesian positions
         const auto trunkPos  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).pos(t),
                                               traj.get(TrajectoryTypes::TRUNK_POS_Y).pos(t),
@@ -211,7 +211,7 @@ namespace utility::motion::splines {
         return {trunkPos, trunkAxis, footPos, footAxis};
     }
 
-    [[nodiscard]] inline Vector3fQuadruple TrajectoriesTrunkFootVel(const float t, const Trajectories& traj) {
+    [[nodiscard]] inline Vector3fQuadruple trajectoriesTrunkFootVel(const float t, const Trajectories& traj) {
         // Compute Cartesian velocities
         const auto trunkPosVel  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).vel(t),
                                                  traj.get(TrajectoryTypes::TRUNK_POS_Y).vel(t),
@@ -228,7 +228,7 @@ namespace utility::motion::splines {
         return {trunkPosVel, trunkAxisVel, footPosVel, footAxisVel};
     }
 
-    [[nodiscard]] inline Vector3fQuadruple TrajectoriesTrunkFootAcc(const float t, const Trajectories& traj) {
+    [[nodiscard]] inline Vector3fQuadruple trajectoriesTrunkFootAcc(const float t, const Trajectories& traj) {
         // Compute Cartesian accelerations
         const auto trunkPosAcc  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).acc(t),
                                                  traj.get(TrajectoryTypes::TRUNK_POS_Y).acc(t),
@@ -252,7 +252,7 @@ namespace utility::motion::splines {
      * @param traj The set of trajectories which are being evaluated
      * @return std::pair<bool, bool> {isDoubleSupportFoot, isLeftSupportFoot}, as evaluated at time t
      */
-    [[nodiscard]] inline std::pair<bool, bool> TrajectoriesSupportFootState(float t, const Trajectories& traj) {
+    [[nodiscard]] inline std::pair<bool, bool> trajectoriesSupportFootState(float t, const Trajectories& traj) {
         // Compute support foot state
         return {traj.get(TrajectoryTypes::IS_DOUBLE_SUPPORT).pos(t) >= 0.5f,
                 traj.get(TrajectoryTypes::IS_LEFT_SUPPORT_FOOT).pos(t) >= 0.5f};

--- a/shared/utility/motion/splines/TrajectoryUtils.hpp
+++ b/shared/utility/motion/splines/TrajectoryUtils.hpp
@@ -155,6 +155,8 @@ namespace utility::motion::splines {
         }
     };
 
+    using Vector3fQuadruple = std::tuple<Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f>;
+
     /**
      * Simple typedef for trajectories container
      */
@@ -189,111 +191,68 @@ namespace utility::motion::splines {
      * Compute from given spline container trajectory Cartesian trunk and foot position/velocity/acceleration
      * and assign it to given vector
      */
-    inline void TrajectoriesTrunkFootPos(float t,
-                                         const Trajectories& traj,
-                                         Eigen::Vector3f& trunkPos,
-                                         Eigen::Vector3f& trunkAxis,
-                                         Eigen::Vector3f& footPos,
-                                         Eigen::Vector3f& footAxis) {
+    inline Vector3fQuadruple TrajectoriesTrunkFootPos(const float t, const Trajectories& traj) {
         // Compute Cartesian positions
-        trunkPos  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).pos(t),
-                                   traj.get(TrajectoryTypes::TRUNK_POS_Y).pos(t),
-                                   traj.get(TrajectoryTypes::TRUNK_POS_Z).pos(t));
-        trunkAxis = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_AXIS_X).pos(t),
-                                    traj.get(TrajectoryTypes::TRUNK_AXIS_Y).pos(t),
-                                    traj.get(TrajectoryTypes::TRUNK_AXIS_Z).pos(t));
-        footPos   = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_POS_X).pos(t),
-                                  traj.get(TrajectoryTypes::FOOT_POS_Y).pos(t),
-                                  traj.get(TrajectoryTypes::FOOT_POS_Z).pos(t));
-        footAxis  = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_AXIS_X).pos(t),
-                                   traj.get(TrajectoryTypes::FOOT_AXIS_Y).pos(t),
-                                   traj.get(TrajectoryTypes::FOOT_AXIS_Z).pos(t));
+        const auto trunkPos  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).pos(t),
+                                              traj.get(TrajectoryTypes::TRUNK_POS_Y).pos(t),
+                                              traj.get(TrajectoryTypes::TRUNK_POS_Z).pos(t));
+        const auto trunkAxis = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_AXIS_X).pos(t),
+                                               traj.get(TrajectoryTypes::TRUNK_AXIS_Y).pos(t),
+                                               traj.get(TrajectoryTypes::TRUNK_AXIS_Z).pos(t));
+        const auto footPos   = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_POS_X).pos(t),
+                                             traj.get(TrajectoryTypes::FOOT_POS_Y).pos(t),
+                                             traj.get(TrajectoryTypes::FOOT_POS_Z).pos(t));
+        const auto footAxis  = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_AXIS_X).pos(t),
+                                              traj.get(TrajectoryTypes::FOOT_AXIS_Y).pos(t),
+                                              traj.get(TrajectoryTypes::FOOT_AXIS_Z).pos(t));
+        return {trunkPos, trunkAxis, footPos, footAxis};
     }
 
-    inline void TrajectoriesTrunkFootVel(float t,
-                                         const Trajectories& traj,
-                                         Eigen::Vector3f& trunkPosVel,
-                                         Eigen::Vector3f& trunkAxisVel,
-                                         Eigen::Vector3f& footPosVel,
-                                         Eigen::Vector3f& footAxisVel) {
+    inline Vector3fQuadruple TrajectoriesTrunkFootVel(const float t, const Trajectories& traj) {
         // Compute Cartesian velocities
-        trunkPosVel  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).vel(t),
-                                      traj.get(TrajectoryTypes::TRUNK_POS_Y).vel(t),
-                                      traj.get(TrajectoryTypes::TRUNK_POS_Z).vel(t));
-        trunkAxisVel = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_AXIS_X).vel(t),
-                                       traj.get(TrajectoryTypes::TRUNK_AXIS_Y).vel(t),
-                                       traj.get(TrajectoryTypes::TRUNK_AXIS_Z).vel(t));
-        footPosVel   = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_POS_X).vel(t),
-                                     traj.get(TrajectoryTypes::FOOT_POS_Y).vel(t),
-                                     traj.get(TrajectoryTypes::FOOT_POS_Z).vel(t));
-        footAxisVel  = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_AXIS_X).vel(t),
-                                      traj.get(TrajectoryTypes::FOOT_AXIS_Y).vel(t),
-                                      traj.get(TrajectoryTypes::FOOT_AXIS_Z).vel(t));
+        const auto trunkPosVel  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).vel(t),
+                                                 traj.get(TrajectoryTypes::TRUNK_POS_Y).vel(t),
+                                                 traj.get(TrajectoryTypes::TRUNK_POS_Z).vel(t));
+        const auto trunkAxisVel = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_AXIS_X).vel(t),
+                                                  traj.get(TrajectoryTypes::TRUNK_AXIS_Y).vel(t),
+                                                  traj.get(TrajectoryTypes::TRUNK_AXIS_Z).vel(t));
+        const auto footPosVel   = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_POS_X).vel(t),
+                                                traj.get(TrajectoryTypes::FOOT_POS_Y).vel(t),
+                                                traj.get(TrajectoryTypes::FOOT_POS_Z).vel(t));
+        const auto footAxisVel  = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_AXIS_X).vel(t),
+                                                 traj.get(TrajectoryTypes::FOOT_AXIS_Y).vel(t),
+                                                 traj.get(TrajectoryTypes::FOOT_AXIS_Z).vel(t));
+        return {trunkPosVel, trunkAxisVel, footPosVel, footAxisVel};
     }
 
-    inline void TrajectoriesTrunkFootAcc(float t,
-                                         const Trajectories& traj,
-                                         Eigen::Vector3f& trunkPosAcc,
-                                         Eigen::Vector3f& trunkAxisAcc,
-                                         Eigen::Vector3f& footPosAcc,
-                                         Eigen::Vector3f& footAxisAcc) {
+    inline Vector3fQuadruple TrajectoriesTrunkFootAcc(const float t, const Trajectories& traj) {
         // Compute Cartesian accelerations
-        trunkPosAcc  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).acc(t),
-                                      traj.get(TrajectoryTypes::TRUNK_POS_Y).acc(t),
-                                      traj.get(TrajectoryTypes::TRUNK_POS_Z).acc(t));
-        trunkAxisAcc = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_AXIS_X).acc(t),
-                                       traj.get(TrajectoryTypes::TRUNK_AXIS_Y).acc(t),
-                                       traj.get(TrajectoryTypes::TRUNK_AXIS_Z).acc(t));
-        footPosAcc   = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_POS_X).acc(t),
-                                     traj.get(TrajectoryTypes::FOOT_POS_Y).acc(t),
-                                     traj.get(TrajectoryTypes::FOOT_POS_Z).acc(t));
-        footAxisAcc  = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_AXIS_X).acc(t),
-                                      traj.get(TrajectoryTypes::FOOT_AXIS_Y).acc(t),
-                                      traj.get(TrajectoryTypes::FOOT_AXIS_Z).acc(t));
-    }
-
-    inline void TrajectoriesSupportFootState(float t,
-                                             const Trajectories& traj,
-                                             bool& isDoubleSupport,
-                                             bool& isLeftSupportFoot) {
-        // Compute support foot state
-        isDoubleSupport   = (traj.get(TrajectoryTypes::IS_DOUBLE_SUPPORT).pos(t) >= 0.5f);
-        isLeftSupportFoot = (traj.get(TrajectoryTypes::IS_LEFT_SUPPORT_FOOT).pos(t) >= 0.5f);
+        const auto trunkPosAcc  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).acc(t),
+                                                 traj.get(TrajectoryTypes::TRUNK_POS_Y).acc(t),
+                                                 traj.get(TrajectoryTypes::TRUNK_POS_Z).acc(t));
+        const auto trunkAxisAcc = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_AXIS_X).acc(t),
+                                                  traj.get(TrajectoryTypes::TRUNK_AXIS_Y).acc(t),
+                                                  traj.get(TrajectoryTypes::TRUNK_AXIS_Z).acc(t));
+        const auto footPosAcc   = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_POS_X).acc(t),
+                                                traj.get(TrajectoryTypes::FOOT_POS_Y).acc(t),
+                                                traj.get(TrajectoryTypes::FOOT_POS_Z).acc(t));
+        const auto footAxisAcc  = Eigen::Vector3f(traj.get(TrajectoryTypes::FOOT_AXIS_X).acc(t),
+                                                 traj.get(TrajectoryTypes::FOOT_AXIS_Y).acc(t),
+                                                 traj.get(TrajectoryTypes::FOOT_AXIS_Z).acc(t));
+        return {trunkPosAcc, trunkAxisAcc, footPosAcc, footAxisAcc};
     }
 
     /**
-     * Default Cartesian state check function.
-     * Return positive cost value if given time and Cartesian state are outside standard valid range
+     * @brief Computes the support foot state, evaluating double support foot and whether isLeftsupportFoot is true
+     * at time t
+     * @param t Time at which the state should be evaluated
+     * @param traj The set of trajectories which are being evaluated
+     * @return std::pair<bool, bool> {isDoubleSupportFoot, isLeftSupportFoot}, as evaluated at time t
      */
-    inline float DefaultCheckState(const Eigen::VectorXf& params,
-                                   float t,
-                                   const Eigen::Vector3f& trunkPos,
-                                   const Eigen::Vector3f& trunkAxis,
-                                   const Eigen::Vector3f& footPos,
-                                   const Eigen::Vector3f& footAxis) {
-        (void) params;
-        (void) t;
-        float cost = 0.0f;
-        if (trunkPos.z() < 0.0f) {
-            cost += 1000.0f - 1000.0f * trunkPos.z();
-        }
-        if (trunkAxis.norm() >= M_PI_2) {
-            cost += 1000.0f + 1000.0f * (trunkAxis.norm() - M_PI_2);
-        }
-        if (std::abs(footPos.y()) < 2.0f * 0.037f) {
-            cost += 1000.0f + 1000.0f * (2.0f * 0.037f - std::abs(footPos.y()));
-        }
-        if (footPos.z() < -1e6) {
-            cost += 1000.0f - 1000.0f * footPos.z();
-        }
-        if (trunkPos.z() - footPos.z() < 0.20f) {
-            cost += 1000.0f - 1000.0f * (trunkPos.z() - footPos.z() - 0.20f);
-        }
-        if (footAxis.norm() >= M_PI_2) {
-            cost += 1000.0f + 1000.0f * (footAxis.norm() - M_PI_2);
-        }
-
-        return cost;
+    inline std::pair<bool, bool> TrajectoriesSupportFootState(float t, const Trajectories& traj) {
+        // Compute support foot state
+        return {traj.get(TrajectoryTypes::IS_DOUBLE_SUPPORT).pos(t) >= 0.5f,
+                traj.get(TrajectoryTypes::IS_LEFT_SUPPORT_FOOT).pos(t) >= 0.5f};
     }
 
 }  // namespace utility::motion::splines

--- a/shared/utility/motion/splines/TrajectoryUtils.hpp
+++ b/shared/utility/motion/splines/TrajectoryUtils.hpp
@@ -155,6 +155,9 @@ namespace utility::motion::splines {
         }
     };
 
+    /**
+     * @brief Tuple of 4 vectors, useful for the TrajectoriesTrunkFoot* functions
+     */
     using Vector3fQuadruple = std::tuple<Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f, Eigen::Vector3f>;
 
     /**
@@ -191,7 +194,7 @@ namespace utility::motion::splines {
      * Compute from given spline container trajectory Cartesian trunk and foot position/velocity/acceleration
      * and assign it to given vector
      */
-    inline Vector3fQuadruple TrajectoriesTrunkFootPos(const float t, const Trajectories& traj) {
+    [[nodiscard]] inline Vector3fQuadruple TrajectoriesTrunkFootPos(const float t, const Trajectories& traj) {
         // Compute Cartesian positions
         const auto trunkPos  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).pos(t),
                                               traj.get(TrajectoryTypes::TRUNK_POS_Y).pos(t),
@@ -208,7 +211,7 @@ namespace utility::motion::splines {
         return {trunkPos, trunkAxis, footPos, footAxis};
     }
 
-    inline Vector3fQuadruple TrajectoriesTrunkFootVel(const float t, const Trajectories& traj) {
+    [[nodiscard]] inline Vector3fQuadruple TrajectoriesTrunkFootVel(const float t, const Trajectories& traj) {
         // Compute Cartesian velocities
         const auto trunkPosVel  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).vel(t),
                                                  traj.get(TrajectoryTypes::TRUNK_POS_Y).vel(t),
@@ -225,7 +228,7 @@ namespace utility::motion::splines {
         return {trunkPosVel, trunkAxisVel, footPosVel, footAxisVel};
     }
 
-    inline Vector3fQuadruple TrajectoriesTrunkFootAcc(const float t, const Trajectories& traj) {
+    [[nodiscard]] inline Vector3fQuadruple TrajectoriesTrunkFootAcc(const float t, const Trajectories& traj) {
         // Compute Cartesian accelerations
         const auto trunkPosAcc  = Eigen::Vector3f(traj.get(TrajectoryTypes::TRUNK_POS_X).acc(t),
                                                  traj.get(TrajectoryTypes::TRUNK_POS_Y).acc(t),
@@ -249,7 +252,7 @@ namespace utility::motion::splines {
      * @param traj The set of trajectories which are being evaluated
      * @return std::pair<bool, bool> {isDoubleSupportFoot, isLeftSupportFoot}, as evaluated at time t
      */
-    inline std::pair<bool, bool> TrajectoriesSupportFootState(float t, const Trajectories& traj) {
+    [[nodiscard]] inline std::pair<bool, bool> TrajectoriesSupportFootState(float t, const Trajectories& traj) {
         // Compute support foot state
         return {traj.get(TrajectoryTypes::IS_DOUBLE_SUPPORT).pos(t) >= 0.5f,
                 traj.get(TrajectoryTypes::IS_LEFT_SUPPORT_FOOT).pos(t) >= 0.5f};


### PR DESCRIPTION
~`computeCartesianPosition[AtTime]` takes a boolean parameter `isLeftsupportFoot` (passed by value), which is then passed to `TrajectoriesSupportFootState`, which modifies the value as a reference. The call to that function does nothing because the bool is passed by value into the previous function call (this is the only use of `TrajectoriesSupportFootState`).~

~This changes it to be passed by reference, which is certainly the intention~

Update:
I have made the trajectoryutils functions return a tuple instead of mutating its parameters. This is much nicer