### PR TITLE
Upgrade configuration `.as<>` so it can use yaml-cpp overloads

### DIFF
--- a/shared/extension/Configuration.hpp
+++ b/shared/extension/Configuration.hpp
@@ -176,7 +176,7 @@ namespace extension {
         }
 
         template <typename T, typename... Args>
-        T as(Args&& args...) const {
+        T as(Args&&... args) const {
             return config.as<T>(std::forward<Args>(args)...);
         }
 

--- a/shared/extension/Configuration.hpp
+++ b/shared/extension/Configuration.hpp
@@ -175,9 +175,9 @@ namespace extension {
             return Configuration(fileName, hostname, binary, config[index]);
         }
 
-        template <typename T>
-        T as() const {
-            return config.as<T>();
+        template <typename T, typename... Args>
+        T as(Args&& args...) const {
+            return config.as<T>(std::forward<Args>(args)...);
         }
 
         // All of these disables for this template are because the std::string constructor is magic and screwy


### PR DESCRIPTION
Yaml-cpp has some overloads that let you set a default for .as calls.
This forwards arguments using perfect forwarding to yaml-cpp so it can use them