### PR TITLE
Fix up the penalty shootout behaviour

### DIFF
--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -172,6 +172,16 @@ namespace module::behaviour::planning {
 
                     return;
                 }
+
+                if (latestCommand.type == message::behaviour::MotionCommand::Type::STAND_SCRIPT) {
+
+                    // log("STAND SCRIPT");
+                    emit(std::make_unique<ExecuteScriptByName>(subsumptionId, "Stand.yaml"));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {45, 15}}));
+
+                    return;
+                }
+
                 else if (latestCommand.type == message::behaviour::MotionCommand::Type::PENALTY_KICK) {
                     // log("KICK PENALTY");
                     emit(std::make_unique<ExecuteScriptByName>(subsumptionId, "KickPenalty.yaml"));

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -147,7 +147,7 @@ namespace module::behaviour::planning {
             }
         });
 
-        on<Every<30, Per<std::chrono::seconds>>,
+        on<Every<40, Per<std::chrono::seconds>>,
            With<Ball>,
            With<Field>,
            With<Sensors>,

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -172,6 +172,13 @@ namespace module::behaviour::planning {
 
                     return;
                 }
+                else if (latestCommand.type == message::behaviour::MotionCommand::Type::PENALTY_KICK) {
+                    // log("KICK PENALTY");
+                    emit(std::make_unique<ExecuteScriptByName>(subsumptionId, "KickPenalty.yaml"));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {1000, 1000}}));
+                    return;
+                }
+
                 else if (latestCommand.type == message::behaviour::MotionCommand::Type::DIRECT_COMMAND) {
                     // TO DO, change to Bezier stuff
                     std::unique_ptr<WalkCommand> command =

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 
 #include "extension/Configuration.hpp"
+#include "extension/Script.hpp"
 
 #include "message/behaviour/KickPlan.hpp"
 #include "message/behaviour/MotionCommand.hpp"
@@ -46,6 +47,7 @@
 namespace module::behaviour::planning {
 
     using extension::Configuration;
+    using extension::ExecuteScriptByName;
 
     using message::behaviour::KickPlan;
     using message::behaviour::MotionCommand;
@@ -145,7 +147,7 @@ namespace module::behaviour::planning {
             }
         });
 
-        on<Every<20, Per<std::chrono::seconds>>,
+        on<Every<30, Per<std::chrono::seconds>>,
            With<Ball>,
            With<Field>,
            With<Sensors>,

--- a/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.cpp
+++ b/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.cpp
@@ -230,7 +230,7 @@ namespace module::behaviour::strategy {
                             }
                             else if (phase == Phase::SET) {
                                 standStill();
-                                find({FieldTarget(FieldTarget::Target::BALL)});
+                                // find({FieldTarget(FieldTarget::Target::BALL)});
                                 currentState = Behaviour::State::SET;
                                 if (mode == GameMode::PENALTY_SHOOTOUT) {
                                     if (currentState != previousState) {
@@ -261,7 +261,7 @@ namespace module::behaviour::strategy {
                                         // log("Opponent is kicking");
                                         // Do goalie behaviour
                                         find({FieldTarget(FieldTarget::Target::BALL)});
-                                        goalieWalk(field, ball);
+                                        // goalieWalk(field, ball);
                                         currentState = Behaviour::State::GOALIE_WALK;
                                     }
                                     // We are kicking!

--- a/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.cpp
+++ b/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.cpp
@@ -230,7 +230,7 @@ namespace module::behaviour::strategy {
                             }
                             else if (phase == Phase::SET) {
                                 standStill();
-                                // find({FieldTarget(FieldTarget::Target::BALL)});
+                                find({FieldTarget(FieldTarget::Target::BALL)});
                                 currentState = Behaviour::State::SET;
                                 if (mode == GameMode::PENALTY_SHOOTOUT) {
                                     if (currentState != previousState) {
@@ -239,7 +239,6 @@ namespace module::behaviour::strategy {
                                     }
                                     else {
                                     }
-                                    // log("set penalty shoot-out");
                                     penaltyShootoutLocalisationReset(fieldDescription);
                                 }
                             }
@@ -258,15 +257,14 @@ namespace module::behaviour::strategy {
                                 if (mode == GameMode::PENALTY_SHOOTOUT) {
                                     // Our opponent is kicking!
                                     if (team_kicking_off == GameEvents::Context::OPPONENT) {
-                                        // log("Opponent is kicking");
                                         // Do goalie behaviour
                                         find({FieldTarget(FieldTarget::Target::BALL)});
+                                        // This is commented out until goalie behaviour is fixed
                                         // goalieWalk(field, ball);
                                         currentState = Behaviour::State::GOALIE_WALK;
                                     }
                                     // We are kicking!
                                     else if (team_kicking_off == GameEvents::Context::TEAM) {
-                                        // log("We are kicking");
                                         currentState = Behaviour::State::SHOOTOUT;
                                         // If our state has changed, kick!
                                         if (currentState != previousState) {

--- a/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.cpp
+++ b/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.cpp
@@ -26,6 +26,7 @@
 #include "message/behaviour/MotionCommand.hpp"
 #include "message/behaviour/Nod.hpp"
 #include "message/behaviour/SoccerObjectPriority.hpp"
+#include "message/input/GameEvents.hpp"
 #include "message/input/Sensors.hpp"
 #include "message/localisation/ResetRobotHypotheses.hpp"
 #include "message/motion/BodySide.hpp"
@@ -103,7 +104,7 @@ namespace module::behaviour::strategy {
 
             cfg_.is_goalie = config["goalie"].as<bool>();
 
-            // Use configuration here from file GoalieWalkPlanner.yaml
+            // Use configuration here from file SoccerStrategy.yaml
             cfg_.goalie_command_timeout           = config["goalie_command_timeout"].as<float>();
             cfg_.goalie_rotation_speed_factor     = config["goalie_rotation_speed_factor"].as<float>();
             cfg_.goalie_max_rotation_speed        = config["goalie_max_rotation_speed"].as<float>();
@@ -230,11 +231,17 @@ namespace module::behaviour::strategy {
                             else if (phase == Phase::SET) {
                                 standStill();
                                 find({FieldTarget(FieldTarget::Target::BALL)});
-                                if (mode == GameMode::PENALTY_SHOOTOUT) {
-                                    penaltyShootoutLocalisationReset(fieldDescription);
-                                    emit(std::make_unique<ResetRawSensors>());
-                                }
                                 currentState = Behaviour::State::SET;
+                                if (mode == GameMode::PENALTY_SHOOTOUT) {
+                                    if (currentState != previousState) {
+                                        emit(std::make_unique<ResetRawSensors>());
+                                        standStill();
+                                    }
+                                    else {
+                                    }
+                                    // log("set penalty shoot-out");
+                                    penaltyShootoutLocalisationReset(fieldDescription);
+                                }
                             }
                             else if (phase == Phase::TIMEOUT) {
                                 standStill();
@@ -415,6 +422,10 @@ namespace module::behaviour::strategy {
 
     void SoccerStrategy::standStill() {
         emit(std::make_unique<MotionCommand>(utility::behaviour::StandStill()));
+    }
+
+    void SoccerStrategy::standScript() {
+        emit(std::make_unique<MotionCommand>(utility::behaviour::StandScript()));
     }
 
     void SoccerStrategy::walkTo(const FieldDescription& fieldDescription, const FieldTarget::Target& target) {

--- a/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.hpp
+++ b/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.hpp
@@ -87,10 +87,11 @@ namespace module::behaviour::strategy {
         std::vector<message::behaviour::FieldTarget> lookTarget;
 
         // TODO: remove horrible
-        bool isGettingUp            = false;
-        bool selfPenalised          = false;
-        bool manualOrientationReset = false;
-        double manualOrientation    = 0.0;
+        bool isGettingUp                                     = false;
+        bool selfPenalised                                   = false;
+        bool manualOrientationReset                          = false;
+        double manualOrientation                             = 0.0;
+        message::input::GameEvents::Context team_kicking_off = message::input::GameEvents::Context::UNKNOWN;
         message::behaviour::KickPlan::KickType kickType;
         message::behaviour::Behaviour::State currentState = message::behaviour::Behaviour::State::INIT;
 

--- a/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.hpp
+++ b/module/behaviour/strategy/SoccerStrategy/src/SoccerStrategy.hpp
@@ -105,6 +105,7 @@ namespace module::behaviour::strategy {
         void unpenalisedLocalisationReset(const message::support::FieldDescription& fieldDescription);
 
         void standStill();
+        void standScript();
         void searchWalk();
         void walkTo(const message::support::FieldDescription& fieldDescription,
                     const message::behaviour::FieldTarget::Target& object);

--- a/module/input/GameController/src/GameController.cpp
+++ b/module/input/GameController/src/GameController.cpp
@@ -86,7 +86,7 @@ namespace module::input {
 
                           // Bind our new handle
                           std::tie(listenHandle, std::ignore, std::ignore) =
-                              on<UDP::Broadcast, With<GameState>>(recieve_port)
+                              on<UDP::Broadcast, With<GameState>, Single>(recieve_port)
                                   .then([this](const UDP::Packet& p, const GameState& gameState) {
                                       std::string remoteAddr = ipAddressIntToString(p.remote.address);
 

--- a/module/input/GameController/src/GameController.cpp
+++ b/module/input/GameController/src/GameController.cpp
@@ -160,7 +160,7 @@ namespace module::input {
         packet.playersPerTeam = PLAYERS_PER_TEAM;
         packet.state          = static_cast<gamecontroller::State>(-1);
         packet.firstHalf      = true;
-        packet.kickOffTeam    = static_cast<gamecontroller::TeamColour>(-1);
+        packet.kickOffTeam    = -1;
         packet.mode           = static_cast<gamecontroller::Mode>(-1);
         packet.dropInTeam     = static_cast<gamecontroller::TeamColour>(-1);
         packet.dropInTime     = -1;
@@ -421,10 +421,10 @@ namespace module::input {
         if (oldPacket.kickOffTeam != newPacket.kickOffTeam) {
 
             // Update the kickoff team (us or them)
-            state->data.our_kick_off = newPacket.kickOffTeam == newOwnTeam.teamColour;
+            state->data.our_kick_off = newPacket.kickOffTeam == newOwnTeam.teamId;
 
             // new kick off team? :/
-            GameEvents::Context team = newPacket.kickOffTeam == newOwnTeam.teamColour
+            GameEvents::Context team = newPacket.kickOffTeam == newOwnTeam.teamId
                                            ? GameEvents::Context::Value::TEAM
                                            : GameEvents::Context::Value::OPPONENT;
             stateChanges.push_back([this, team] { emit(std::make_unique<KickOffTeam>(KickOffTeam{team})); });

--- a/module/input/GameController/src/GameControllerData.hpp
+++ b/module/input/GameController/src/GameControllerData.hpp
@@ -105,7 +105,7 @@ namespace module::input::gamecontroller {
         GameType gameType;                       // type of the game (GAME_ROUNDROBIN, GAME_PLAYOFF, GAME_DROPIN)
         State state;                             // state of the game (STATE_READY, STATE_PLAYING, etc)
         bool firstHalf;                          // 1 = game in first half, 0 otherwise
-        TeamColour kickOffTeam;                  // the team number of the next team to kick off or DROPBALL
+        uint8_t kickOffTeam;                     // the team number of the next team to kick off or DROPBALL
         Mode mode;                               // extra state information - (STATE2_NORMAL, STATE2_PENALTYSHOOT, etc)
         std::array<char, 4> secondaryStateInfo;  // Extra info on the secondary state
         TeamColour dropInTeam;                   // number of team that caused last drop in

--- a/module/motion/ScriptEngine/data/scripts/docker/KickPenalty.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/KickPenalty.yaml
@@ -1,27 +1,27 @@
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -3.88E-15
+      position: -7.38E-24
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: -0.026817275
+      position: -0.080270784
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -4.48E-15
+      position: 2.93E-23
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.12529981
+      position: 0.058150131
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.105771986
+      position: -0.037501524
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.025749
+      position: 0.061661752
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -37,35 +37,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -1.76E-08
+      position: -0.002165994
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: 2.04E-16
+      position: 2.20E-40
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.01128275
+      position: 0.001688342
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.309181726
+      position: -0.11813267
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.062150689
+      position: -0.040870822
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.001909744
+      position: 0.141208
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.046668963
+      position: -0.075248191
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.25109466
+      position: 0.070229464
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -80,30 +80,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: 1.20E-14
+      position: -2.47E-24
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: -0.033067273
+      position: -0.1085279
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: 4.62E-14
+      position: -2.23E-23
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.125306302
+      position: 0.061076838
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.063487753
+      position: -0.034837145
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.028654427
+      position: 0.13113073
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -119,35 +119,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -8.67E-08
+      position: -0.002337709
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.32E-15
+      position: 2.37E-40
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.01398669
+      position: 0.006498421
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.328624958
+      position: -0.149128528
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.099045423
+      position: -0.110482557
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.007557696
+      position: 0.365137921
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.061925045
+      position: -0.213955043
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.281039874
+      position: 0.146723877
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -162,30 +162,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -1.04E-10
+      position: -1.22E-17
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.066482951
+      position: -0.045760926
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -1.37E-09
+      position: -5.90E-17
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.060502227
+      position: 0.060882367
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.010688994
+      position: -0.052263907
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.034195093
+      position: 0.142211574
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -201,35 +201,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000125111
+      position: -0.000363006
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -5.79E-21
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.050934245
+      position: 0.006856121
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.241164001
+      position: -0.095734278
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.079430071
+      position: -0.150427331
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.163475701
+      position: 0.629658134
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.188149456
+      position: -0.44303868
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.32599644
+      position: 0.182252277
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -244,30 +244,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -5.18E-11
+      position: -4.48E-16
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.042097103
+      position: -0.020350023
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: 2.56E-14
+      position: 1.38E-14
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.060188108
+      position: 0.060952001
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.02089378
+      position: -0.071383165
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.095320046
+      position: 0.139394587
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -283,35 +283,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000138081
+      position: -0.000865897
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.044315516
+      position: 0.01075643
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.281539791
+      position: -0.081352501
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.065017945
+      position: -0.141911791
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.385424458
+      position: 0.821070229
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.389016543
+      position: -0.647601296
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.39811674
+      position: 0.195902831
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -326,30 +326,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -2.59E-11
+      position: -2.24E-16
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.091086654
+      position: -0.015246781
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -9.84E-23
+      position: -6.66E-26
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.05638262
+      position: 0.061012611
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.044637841
+      position: -0.078713204
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.08754832
+      position: 0.137776089
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -365,35 +365,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000146648
+      position: -0.001062546
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.05071145
+      position: 0.011392592
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.240909521
+      position: -0.081810113
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.090553609
+      position: -0.122295339
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.408968676
+      position: 0.883200709
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.455260019
+      position: -0.730707714
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.409507045
+      position: 0.201758731
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -408,30 +408,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 30
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -2.59E-11
+      position: -2.24E-16
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.091086654
+      position: -0.015246781
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -9.84E-23
+      position: -6.66E-26
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.05638262
+      position: 0.061012611
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.044637841
+      position: -0.078713204
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.08754832
+      position: 0.137776089
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -447,35 +447,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000146648
+      position: -0.001062546
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.05071145
+      position: 0.011392592
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.240909521
+      position: -0.081810113
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.090553609
+      position: -0.122295339
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.408968676
+      position: 0.883200709
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.455260019
+      position: -0.730707714
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.409507045
+      position: 0.201758731
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -490,30 +490,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 30
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -1.30E-11
+      position: -1.12E-16
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.0620116
+      position: -0.004384514
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: 2.88E-19
+      position: -7.47E-19
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.062062226
+      position: 0.062105168
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.047370894
+      position: -0.05122685
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.122491498
+      position: 0.137744225
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -529,35 +529,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000725382
+      position: -0.00155355
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.026423045
+      position: 0.005864714
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.277449067
+      position: -0.07448339
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: -0.245026545
+      position: -0.48609603
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.595599053
+      position: 1.078230719
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.502947245
+      position: -0.601508349
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.451659694
+      position: 0.206514978
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -572,30 +572,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 15
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -6.48E-12
+      position: -5.60E-17
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.009662866
+      position: -0.084127521
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: 8.79E-17
+      position: 4.03E-26
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.066579281
+      position: 0.06335775
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.148581165
+      position: -0.074618429
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.071554756
+      position: 0.129571143
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -611,35 +611,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000602586
+      position: 0.008465093
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: -0.07570659
+      position: -0.033289691
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.317561875
+      position: -0.138156093
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: -0.686190495
+      position: -0.837851752
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.364669264
+      position: 0.638313382
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: 0.226951467
+      position: 0.15111768
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.40966147
+      position: 0.186925003
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -654,30 +654,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 15
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -3.22E-12
+      position: 7.52E-14
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.036626843
+      position: -0.264135191
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -6.30E-14
+      position: -1.47E-13
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.125324879
+      position: 0.125325148
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.232596126
+      position: -0.232378656
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.00346138
+      position: 0.067035551
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -693,35 +693,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000602553
+      position: 0.008464845
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: 5.37E-16
+      position: -8.32E-17
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: -0.105165946
+      position: -0.105445079
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.211500145
+      position: -0.188155378
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: -0.921386853
+      position: -1.015392271
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.053440818
+      position: 0.072139359
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: 0.759681943
+      position: 0.837917019
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.279937472
+      position: 0.019816079
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -736,30 +736,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 15
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -1.62E-12
+      position: 6.25E-14
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.033952026
+      position: -0.27062267
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -3.74E-15
+      position: -1.22E-13
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.125327694
+      position: 0.125327707
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.22590583
+      position: -0.226487609
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.000774562
+      position: 0.066715461
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -775,35 +775,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000603259
+      position: 0.008464863
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -3.10E-16
+      position: 1.24E-15
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: -0.100649527
+      position: -0.093297551
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.177134319
+      position: -0.160733065
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: -1.012737899
+      position: -1.094207833
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.018071539
+      position: 0.027870911
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: 0.892617404
+      position: 0.964522775
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.242542508
+      position: -0.013045236
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH

--- a/module/motion/ScriptEngine/data/scripts/docker/KickPenalty.yaml
+++ b/module/motion/ScriptEngine/data/scripts/docker/KickPenalty.yaml
@@ -1,0 +1,820 @@
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: -3.88E-15
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: -0.026817275
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -4.48E-15
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.12529981
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.105771986
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.025749
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -1.76E-08
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: 2.04E-16
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.01128275
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.309181726
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.062150689
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.001909744
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.046668963
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.25109466
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: 1.20E-14
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: -0.033067273
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: 4.62E-14
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.125306302
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.063487753
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.028654427
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -8.67E-08
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.32E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.01398669
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.328624958
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.099045423
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.007557696
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.061925045
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.281039874
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: -1.04E-10
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.066482951
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -1.37E-09
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.060502227
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.010688994
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.034195093
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000125111
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.050934245
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.241164001
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.079430071
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.163475701
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.188149456
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.32599644
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: -5.18E-11
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.042097103
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: 2.56E-14
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.060188108
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.02089378
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.095320046
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000138081
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.044315516
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.281539791
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.065017945
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.385424458
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.389016543
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.39811674
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: -2.59E-11
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.091086654
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -9.84E-23
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.05638262
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.044637841
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.08754832
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000146648
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.05071145
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.240909521
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.090553609
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.408968676
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.455260019
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.409507045
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 30
+  targets:
+    - id: L_HIP_YAW
+      position: -2.59E-11
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.091086654
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -9.84E-23
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.05638262
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.044637841
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.08754832
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000146648
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.05071145
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.240909521
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.090553609
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.408968676
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.455260019
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.409507045
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 30
+  targets:
+    - id: L_HIP_YAW
+      position: -1.30E-11
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.0620116
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: 2.88E-19
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.062062226
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.047370894
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.122491498
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000725382
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.026423045
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.277449067
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: -0.245026545
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.595599053
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.502947245
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.451659694
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 15
+  targets:
+    - id: L_HIP_YAW
+      position: -6.48E-12
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.009662866
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: 8.79E-17
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.066579281
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.148581165
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.071554756
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000602586
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: -0.07570659
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.317561875
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: -0.686190495
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.364669264
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: 0.226951467
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.40966147
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 15
+  targets:
+    - id: L_HIP_YAW
+      position: -3.22E-12
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.036626843
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -6.30E-14
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.125324879
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.232596126
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.00346138
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000602553
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: 5.37E-16
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: -0.105165946
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.211500145
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: -0.921386853
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.053440818
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: 0.759681943
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.279937472
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 15
+  targets:
+    - id: L_HIP_YAW
+      position: -1.62E-12
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.033952026
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -3.74E-15
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.125327694
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.22590583
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.000774562
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000603259
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -3.10E-16
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: -0.100649527
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.177134319
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: -1.012737899
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.018071539
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: 0.892617404
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.242542508
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300

--- a/module/motion/ScriptEngine/data/scripts/webots/KickPenalty.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/KickPenalty.yaml
@@ -1,27 +1,27 @@
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -3.88E-15
+      position: -7.38E-24
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: -0.026817275
+      position: -0.080270784
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -4.48E-15
+      position: 2.93E-23
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.12529981
+      position: 0.058150131
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.105771986
+      position: -0.037501524
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.025749
+      position: 0.061661752
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -37,35 +37,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -1.76E-08
+      position: -0.002165994
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: 2.04E-16
+      position: 2.20E-40
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.01128275
+      position: 0.001688342
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.309181726
+      position: -0.11813267
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.062150689
+      position: -0.040870822
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.001909744
+      position: 0.141208
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.046668963
+      position: -0.075248191
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.25109466
+      position: 0.070229464
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -80,30 +80,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: 1.20E-14
+      position: -2.47E-24
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: -0.033067273
+      position: -0.1085279
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: 4.62E-14
+      position: -2.23E-23
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.125306302
+      position: 0.061076838
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.063487753
+      position: -0.034837145
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.028654427
+      position: 0.13113073
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -119,35 +119,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -8.67E-08
+      position: -0.002337709
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.32E-15
+      position: 2.37E-40
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.01398669
+      position: 0.006498421
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.328624958
+      position: -0.149128528
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.099045423
+      position: -0.110482557
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.007557696
+      position: 0.365137921
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.061925045
+      position: -0.213955043
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.281039874
+      position: 0.146723877
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -162,30 +162,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -1.04E-10
+      position: -1.22E-17
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.066482951
+      position: -0.045760926
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -1.37E-09
+      position: -5.90E-17
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.060502227
+      position: 0.060882367
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.010688994
+      position: -0.052263907
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.034195093
+      position: 0.142211574
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -201,35 +201,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000125111
+      position: -0.000363006
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -5.79E-21
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.050934245
+      position: 0.006856121
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.241164001
+      position: -0.095734278
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.079430071
+      position: -0.150427331
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.163475701
+      position: 0.629658134
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.188149456
+      position: -0.44303868
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.32599644
+      position: 0.182252277
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -244,30 +244,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -5.18E-11
+      position: -4.48E-16
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.042097103
+      position: -0.020350023
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: 2.56E-14
+      position: 1.38E-14
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.060188108
+      position: 0.060952001
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.02089378
+      position: -0.071383165
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.095320046
+      position: 0.139394587
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -283,35 +283,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000138081
+      position: -0.000865897
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.044315516
+      position: 0.01075643
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.281539791
+      position: -0.081352501
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.065017945
+      position: -0.141911791
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.385424458
+      position: 0.821070229
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.389016543
+      position: -0.647601296
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.39811674
+      position: 0.195902831
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -326,30 +326,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 110
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -2.59E-11
+      position: -2.24E-16
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.091086654
+      position: -0.015246781
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -9.84E-23
+      position: -6.66E-26
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.05638262
+      position: 0.061012611
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.044637841
+      position: -0.078713204
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.08754832
+      position: 0.137776089
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -365,35 +365,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000146648
+      position: -0.001062546
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.05071145
+      position: 0.011392592
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.240909521
+      position: -0.081810113
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.090553609
+      position: -0.122295339
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.408968676
+      position: 0.883200709
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.455260019
+      position: -0.730707714
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.409507045
+      position: 0.201758731
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -408,30 +408,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 30
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -2.59E-11
+      position: -2.24E-16
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.091086654
+      position: -0.015246781
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -9.84E-23
+      position: -6.66E-26
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.05638262
+      position: 0.061012611
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.044637841
+      position: -0.078713204
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.08754832
+      position: 0.137776089
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -447,35 +447,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000146648
+      position: -0.001062546
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.05071145
+      position: 0.011392592
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.240909521
+      position: -0.081810113
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: 0.090553609
+      position: -0.122295339
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.408968676
+      position: 0.883200709
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.455260019
+      position: -0.730707714
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.409507045
+      position: 0.201758731
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -490,30 +490,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 30
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -1.30E-11
+      position: -1.12E-16
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.0620116
+      position: -0.004384514
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: 2.88E-19
+      position: -7.47E-19
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.062062226
+      position: 0.062105168
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.047370894
+      position: -0.05122685
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.122491498
+      position: 0.137744225
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -529,35 +529,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000725382
+      position: -0.00155355
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: 0.026423045
+      position: 0.005864714
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.277449067
+      position: -0.07448339
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: -0.245026545
+      position: -0.48609603
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.595599053
+      position: 1.078230719
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: -0.502947245
+      position: -0.601508349
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.451659694
+      position: 0.206514978
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -572,30 +572,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 15
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -6.48E-12
+      position: -5.60E-17
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.009662866
+      position: -0.084127521
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: 8.79E-17
+      position: 4.03E-26
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.066579281
+      position: 0.06335775
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.148581165
+      position: -0.074618429
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.071554756
+      position: 0.129571143
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -611,35 +611,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000602586
+      position: 0.008465093
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -1.03E-15
+      position: -2.70E-20
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: -0.07570659
+      position: -0.033289691
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.317561875
+      position: -0.138156093
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: -0.686190495
+      position: -0.837851752
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.364669264
+      position: 0.638313382
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: 0.226951467
+      position: 0.15111768
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.40966147
+      position: 0.186925003
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -654,30 +654,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 15
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -3.22E-12
+      position: 7.52E-14
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.036626843
+      position: -0.264135191
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -6.30E-14
+      position: -1.47E-13
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.125324879
+      position: 0.125325148
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.232596126
+      position: -0.232378656
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.00346138
+      position: 0.067035551
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -693,35 +693,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000602553
+      position: 0.008464845
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: 5.37E-16
+      position: -8.32E-17
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: -0.105165946
+      position: -0.105445079
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.211500145
+      position: -0.188155378
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: -0.921386853
+      position: -1.015392271
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.053440818
+      position: 0.072139359
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: 0.759681943
+      position: 0.837917019
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.279937472
+      position: 0.019816079
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH
@@ -736,30 +736,30 @@
       position: -2.443461
       gain: 200
       torque: 300
-- duration: 15
+- duration: 50
   targets:
     - id: L_HIP_YAW
-      position: -1.62E-12
+      position: 6.25E-14
       gain: 200
       torque: 300
     - id: L_HIP_ROLL
-      position: 0.033952026
+      position: -0.27062267
       gain: 200
       torque: 300
     - id: L_HIP_PITCH
-      position: -3.74E-15
+      position: -1.22E-13
       gain: 200
       torque: 300
     - id: L_KNEE
-      position: 0.125327694
+      position: 0.125327707
       gain: 200
       torque: 300
     - id: L_ANKLE_PITCH
-      position: -0.22590583
+      position: -0.226487609
       gain: 200
       torque: 300
     - id: L_ANKLE_ROLL
-      position: 0.000774562
+      position: 0.066715461
       gain: 200
       torque: 300
     - id: L_SHOULDER_PITCH
@@ -775,35 +775,35 @@
       gain: 200
       torque: 300
     - id: HEAD_YAW
-      position: -0.000603259
+      position: 0.008464863
       gain: 200
       torque: 300
     - id: HEAD_PITCH
-      position: -3.10E-16
+      position: 1.24E-15
       gain: 200
       torque: 300
     - id: R_HIP_YAW
-      position: -0.100649527
+      position: -0.093297551
       gain: 200
       torque: 300
     - id: R_HIP_ROLL
-      position: -0.177134319
+      position: -0.160733065
       gain: 200
       torque: 300
     - id: R_HIP_PITCH
-      position: -1.012737899
+      position: -1.094207833
       gain: 200
       torque: 300
     - id: R_KNEE
-      position: 0.018071539
+      position: 0.027870911
       gain: 200
       torque: 300
     - id: R_ANKLE_PITCH
-      position: 0.892617404
+      position: 0.964522775
       gain: 200
       torque: 300
     - id: R_ANKLE_ROLL
-      position: 0.242542508
+      position: -0.013045236
       gain: 200
       torque: 300
     - id: R_SHOULDER_PITCH

--- a/module/motion/ScriptEngine/data/scripts/webots/KickPenalty.yaml
+++ b/module/motion/ScriptEngine/data/scripts/webots/KickPenalty.yaml
@@ -1,0 +1,820 @@
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: -3.88E-15
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: -0.026817275
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -4.48E-15
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.12529981
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.105771986
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.025749
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -1.76E-08
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: 2.04E-16
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.01128275
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.309181726
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.062150689
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.001909744
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.046668963
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.25109466
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: 1.20E-14
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: -0.033067273
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: 4.62E-14
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.125306302
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.063487753
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.028654427
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -8.67E-08
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.32E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.01398669
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.328624958
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.099045423
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.007557696
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.061925045
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.281039874
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: -1.04E-10
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.066482951
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -1.37E-09
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.060502227
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.010688994
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.034195093
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000125111
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.050934245
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.241164001
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.079430071
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.163475701
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.188149456
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.32599644
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: -5.18E-11
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.042097103
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: 2.56E-14
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.060188108
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.02089378
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.095320046
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000138081
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.044315516
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.281539791
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.065017945
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.385424458
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.389016543
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.39811674
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 110
+  targets:
+    - id: L_HIP_YAW
+      position: -2.59E-11
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.091086654
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -9.84E-23
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.05638262
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.044637841
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.08754832
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000146648
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.05071145
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.240909521
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.090553609
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.408968676
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.455260019
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.409507045
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 30
+  targets:
+    - id: L_HIP_YAW
+      position: -2.59E-11
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.091086654
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -9.84E-23
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.05638262
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.044637841
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.08754832
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000146648
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.05071145
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.240909521
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: 0.090553609
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.408968676
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.455260019
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.409507045
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 30
+  targets:
+    - id: L_HIP_YAW
+      position: -1.30E-11
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.0620116
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: 2.88E-19
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.062062226
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.047370894
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.122491498
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000725382
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: 0.026423045
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.277449067
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: -0.245026545
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.595599053
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: -0.502947245
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.451659694
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 15
+  targets:
+    - id: L_HIP_YAW
+      position: -6.48E-12
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.009662866
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: 8.79E-17
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.066579281
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.148581165
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.071554756
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000602586
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -1.03E-15
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: -0.07570659
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.317561875
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: -0.686190495
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.364669264
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: 0.226951467
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.40966147
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 15
+  targets:
+    - id: L_HIP_YAW
+      position: -3.22E-12
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.036626843
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -6.30E-14
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.125324879
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.232596126
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.00346138
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000602553
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: 5.37E-16
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: -0.105165946
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.211500145
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: -0.921386853
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.053440818
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: 0.759681943
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.279937472
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+- duration: 15
+  targets:
+    - id: L_HIP_YAW
+      position: -1.62E-12
+      gain: 200
+      torque: 300
+    - id: L_HIP_ROLL
+      position: 0.033952026
+      gain: 200
+      torque: 300
+    - id: L_HIP_PITCH
+      position: -3.74E-15
+      gain: 200
+      torque: 300
+    - id: L_KNEE
+      position: 0.125327694
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_PITCH
+      position: -0.22590583
+      gain: 200
+      torque: 300
+    - id: L_ANKLE_ROLL
+      position: 0.000774562
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: L_SHOULDER_ROLL
+      position: 0.1239184
+      gain: 200
+      torque: 300
+    - id: L_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300
+    - id: HEAD_YAW
+      position: -0.000603259
+      gain: 200
+      torque: 300
+    - id: HEAD_PITCH
+      position: -3.10E-16
+      gain: 200
+      torque: 300
+    - id: R_HIP_YAW
+      position: -0.100649527
+      gain: 200
+      torque: 300
+    - id: R_HIP_ROLL
+      position: -0.177134319
+      gain: 200
+      torque: 300
+    - id: R_HIP_PITCH
+      position: -1.012737899
+      gain: 200
+      torque: 300
+    - id: R_KNEE
+      position: 0.018071539
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_PITCH
+      position: 0.892617404
+      gain: 200
+      torque: 300
+    - id: R_ANKLE_ROLL
+      position: 0.242542508
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_PITCH
+      position: 1.963495
+      gain: 200
+      torque: 300
+    - id: R_SHOULDER_ROLL
+      position: -0.1239184
+      gain: 200
+      torque: 300
+    - id: R_ELBOW
+      position: -2.443461
+      gain: 200
+      torque: 300

--- a/roles/webotsrobocup.role
+++ b/roles/webotsrobocup.role
@@ -9,8 +9,8 @@ nuclear_role(
   motion::KinematicsConfiguration
   # Support
   support::configuration::GlobalConfig
-  network::NUClearNet
-  output::NetworkForwarder
+  # network::NUClearNet
+  # output::NetworkForwarder
   support::configuration::SoccerConfig
   # input
   input::GameController

--- a/roles/webotsrobocup.role
+++ b/roles/webotsrobocup.role
@@ -9,15 +9,14 @@ nuclear_role(
   motion::KinematicsConfiguration
   # Support
   support::configuration::GlobalConfig
-  # network::NUClearNet
-  # output::NetworkForwarder
   support::configuration::SoccerConfig
   # input
   input::GameController
   # Simulator connection
   input::SensorFilter
   platform::Webots
-  # Vision vision::VisualMesh
+  # Vision
+  vision::VisualMesh
   vision::GreenHorizonDetector
   vision::GoalDetector
   vision::BallDetector
@@ -30,7 +29,7 @@ nuclear_role(
   behaviour::skills::Stand
   behaviour::skills::Getup
   behaviour::skills::KickScript
-  # behaviour::skills::HeadBehaviourSoccer
+  behaviour::skills::HeadBehaviourSoccer
   behaviour::planning::KickPlanner
   behaviour::planning::SimpleWalkPathPlanner # Creates WalkPaths.
   behaviour::strategy::SoccerStrategy

--- a/roles/webotsrobocup.role
+++ b/roles/webotsrobocup.role
@@ -17,8 +17,7 @@ nuclear_role(
   # Simulator connection
   input::SensorFilter
   platform::Webots
-  # Vision
-  vision::VisualMesh
+  # Vision vision::VisualMesh
   vision::GreenHorizonDetector
   vision::GoalDetector
   vision::BallDetector

--- a/roles/webotsrobocup.role
+++ b/roles/webotsrobocup.role
@@ -15,8 +15,7 @@ nuclear_role(
   # Simulator connection
   input::SensorFilter
   platform::Webots
-  # Vision
-  vision::VisualMesh
+  # Vision vision::VisualMesh
   vision::GreenHorizonDetector
   vision::GoalDetector
   vision::BallDetector
@@ -29,7 +28,7 @@ nuclear_role(
   behaviour::skills::Stand
   behaviour::skills::Getup
   behaviour::skills::KickScript
-  behaviour::skills::HeadBehaviourSoccer
+  # behaviour::skills::HeadBehaviourSoccer
   behaviour::planning::KickPlanner
   behaviour::planning::SimpleWalkPathPlanner # Creates WalkPaths.
   behaviour::strategy::SoccerStrategy

--- a/roles/webotsrobocup.role
+++ b/roles/webotsrobocup.role
@@ -30,7 +30,7 @@ nuclear_role(
   behaviour::skills::Stand
   behaviour::skills::Getup
   behaviour::skills::KickScript
-  behaviour::skills::HeadBehaviourSoccer
+  # behaviour::skills::HeadBehaviourSoccer
   behaviour::planning::KickPlanner
   behaviour::planning::SimpleWalkPathPlanner # Creates WalkPaths.
   behaviour::strategy::SoccerStrategy

--- a/shared/message/behaviour/Behaviour.proto
+++ b/shared/message/behaviour/Behaviour.proto
@@ -39,6 +39,7 @@ message Behaviour {
         GOALIE_WALK      = 12;
         MOVE_TO_CENTRE   = 13;
         LOCALISING       = 14;
+        SHOOTOUT         = 15;
     }
 
     State state = 1;

--- a/shared/message/behaviour/MotionCommand.proto
+++ b/shared/message/behaviour/MotionCommand.proto
@@ -34,7 +34,9 @@ message MotionCommand {
         // Execute the kick for penalty shoot-out
         PENALTY_KICK = 3;
         // Stop all current motion and directly send the given WalkCommand to the WalkEngine.
-        DIRECT_COMMAND = 3;
+        DIRECT_COMMAND = 4;
+        // Run the stand script
+        STAND_SCRIPT = 5;
     }
 
     // The type of this motion command:

--- a/shared/message/behaviour/MotionCommand.proto
+++ b/shared/message/behaviour/MotionCommand.proto
@@ -31,6 +31,8 @@ message MotionCommand {
         WALK_TO_STATE = 1;
         // Approach the ball, ready to perform a forward kick toward the given kickTarget. Avoids obstacles.
         BALL_APPROACH = 2;
+        // Execute the kick for penalty shoot-out
+        PENALTY_KICK = 3;
         // Stop all current motion and directly send the given WalkCommand to the WalkEngine.
         DIRECT_COMMAND = 3;
     }

--- a/shared/utility/behaviour/MotionCommand.hpp
+++ b/shared/utility/behaviour/MotionCommand.hpp
@@ -34,6 +34,12 @@ namespace utility::behaviour {
         return cmd;
     }
 
+    inline MotionCommand StandScript() {
+        MotionCommand cmd;
+        cmd.type = MotionCommand::Type::Value::STAND_SCRIPT;
+        return cmd;
+    }
+
     inline MotionCommand PenaltyKick() {
         MotionCommand cmd;
         cmd.type = MotionCommand::Type::Value::PENALTY_KICK;

--- a/shared/utility/behaviour/MotionCommand.hpp
+++ b/shared/utility/behaviour/MotionCommand.hpp
@@ -34,6 +34,12 @@ namespace utility::behaviour {
         return cmd;
     }
 
+    inline MotionCommand PenaltyKick() {
+        MotionCommand cmd;
+        cmd.type = MotionCommand::Type::Value::PENALTY_KICK;
+        return cmd;
+    }
+
     inline MotionCommand WalkToState(const Eigen::Affine2d& goalState_) {
         MotionCommand cmd;
         cmd.type       = MotionCommand::Type::Value::WALK_TO_STATE;


### PR DESCRIPTION
This allows us to complete a penalty shootout with behaviour as follows:

- Goalie stands still
- Kicker kicks the ball once into the goal (works a majority of times)