### PR TITLE
DRAFT: Docker image logging for Robocup

### DIFF
--- a/docker/nugus_sim/run.py
+++ b/docker/nugus_sim/run.py
@@ -143,10 +143,13 @@ def run_role(role: str, binaries_dir: str, env_vars: dict) -> None:
 
     # Run the role binary
     while True:
+        print(f"Binary '{role}' starting...")  # For debugging
         subprocess.run(f"./{role}", env=modified_env)
+        print(f"Binary '{role}' crashed!")  # For debugging
 
 
 if __name__ == "__main__":
     args = read_args()
+    print(args)  # For debugging
     update_config_files(args)
     run_role(args["role"], args["binaries_dir"], args["env_vars"])

--- a/docker/nugus_sim/run.py
+++ b/docker/nugus_sim/run.py
@@ -144,12 +144,13 @@ def run_role(role: str, binaries_dir: str, env_vars: dict) -> None:
     # Run the role binary
     while True:
         print(f"Binary '{role}' starting...")  # For debugging
-        subprocess.run(f"./{role}", env=modified_env)
-        print(f"Binary '{role}' crashed!")  # For debugging
+        exit_code = subprocess.run(f"./{role}", env=modified_env).returncode
+        print(f"Binary '{role}' crashed! Exit code: {exit_code}")  # For debugging
 
 
 if __name__ == "__main__":
+    print("starting nugus run.py")
     args = read_args()
-    print(args)  # For debugging
+    print("main args", args)  # For debugging
     update_config_files(args)
     run_role(args["role"], args["binaries_dir"], args["env_vars"])

--- a/module/localisation/RobotParticleLocalisation/data/config/RobotParticleLocalisation.yaml
+++ b/module/localisation/RobotParticleLocalisation/data/config/RobotParticleLocalisation.yaml
@@ -1,5 +1,5 @@
 # Controls the minimum log level that NUClear log will display
-log_level: DEBUG
+log_level: WARN
 
 process_noise_diagonal: [0.001, 0.001, 0.0001]
 

--- a/module/support/logging/DataLogging/data/config/webotsrobocup/DataLogging.yaml
+++ b/module/support/logging/DataLogging/data/config/webotsrobocup/DataLogging.yaml
@@ -13,5 +13,5 @@ messages:
   message.localisation.Field: true
   message.localisation.ResetRobotHypotheses: true
   # These two are fairly large, we can turn them off if we're running out of log space
-  message.vision.VisualMesh: true
-  message.vision.GreenHorizon: true
+  message.vision.VisualMesh: false
+  message.vision.GreenHorizon: false

--- a/module/support/logging/FileLogHandler/src/FileLogHandler.cpp
+++ b/module/support/logging/FileLogHandler/src/FileLogHandler.cpp
@@ -116,7 +116,9 @@ namespace module::support::logging {
             }
 
             // Output the message
-            logFile << message.message << std::endl;
+            // logFile << message.message << std::endl;
+            // TEMPORARY: Send to std::cout for RoboCup as we currently are not getting our logs back
+            std::cout << message.message << std::endl;
         });
     }
 }  // namespace module::support::logging


### PR DESCRIPTION
 - Add some logging to entrypoint script
 - Temporarily Disable logging of VisualMesh and GreenHorison to *hopfully* not exceed our 10GB limit
 - Temporarily log to stdout instead of file so that we can actually get some logs from games as we currently are not.