### PR TITLE
Reduce logging in the `webotsrobocup` role

### DIFF
--- a/module/support/logging/DataLogging/data/config/webotsrobocup/DataLogging.yaml
+++ b/module/support/logging/DataLogging/data/config/webotsrobocup/DataLogging.yaml
@@ -4,7 +4,7 @@ output:
 
 # You can put any messages that is emitted in the system here and it will be logged
 messages:
-  message.output.CompressedImage: true
+  message.output.CompressedImage: false
   message.input.Sensors: true
   message.platform.RawSensors: true
   message.vision.Balls: true
@@ -13,5 +13,5 @@ messages:
   message.localisation.Field: true
   message.localisation.ResetRobotHypotheses: true
   # These two are fairly large, we can turn them off if we're running out of log space
-  message.vision.VisualMesh: true
-  message.vision.GreenHorizon: true
+  message.vision.VisualMesh: false
+  message.vision.GreenHorizon: false


### PR DESCRIPTION
This turns of logging off `CompressedImage`, `VisualMesh`, and `GreenHorizon` messages in the webotsrobocup role. This is needed to not exceed the 10GB per robot limit, which we've exceeded so far in our first few games.