### PR TITLE
Removes gyro stuff from hardware simulator

### DIFF
--- a/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
+++ b/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
@@ -21,7 +21,6 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <iostream>
 #include <limits>
 #include <mutex>
 

--- a/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
+++ b/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
@@ -21,6 +21,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <iostream>
 #include <limits>
 #include <mutex>
 
@@ -50,7 +51,7 @@ namespace module::platform::darwin {
     using utility::support::Expression;
 
     HardwareSimulator::HardwareSimulator(std::unique_ptr<NUClear::Environment> environment)
-        : Reactor(std::move(environment)), sensors(), gyroQueue(), gyroQueueMutex(), noise() {
+        : Reactor(std::move(environment)), sensors(), noise() {
 
         /*
          CM740 Data
@@ -164,14 +165,6 @@ namespace module::platform::darwin {
                 bodyTilt = config["body_tilt"].as<Expression>();
             });
 
-        on<Trigger<RawSensors::Gyroscope>>().then("Receive Simulated Gyroscope",
-                                                  [this](const RawSensors::Gyroscope& gyro) {
-                                                      std::lock_guard<std::mutex> lock(gyroQueueMutex);
-                                                      RawSensors::Gyroscope tmpGyro = gyro;
-                                                      gyroQueue.push(tmpGyro);
-                                                  });
-
-
         on<Every<UPDATE_FREQUENCY, Per<std::chrono::seconds>>, Optional<With<Sensors>>, Single>().then(
             [this](std::shared_ptr<const Sensors> previousSensors) {
                 if (previousSensors) {
@@ -221,26 +214,9 @@ namespace module::platform::darwin {
                     }
                 }
 
-                // Gyro:
-                // Note: This reaction is not (and should not be) synced with the
-                // 'Receive Simulated Gyroscope' reaction above, so we can't
-                // reliably query the size of the gyroQueue.
-                Eigen::Vector3d sumGyro = Eigen::Vector3d::Zero();
-                /* mutext scope */ {
-                    std::lock_guard<std::mutex> lock(gyroQueueMutex);
-                    while (!gyroQueue.empty()) {
-                        RawSensors::Gyroscope g = gyroQueue.front();
-                        sumGyro += Eigen::Vector3d(g.x, g.y, g.z);
-
-                        std::lock_guard<std::mutex> lock(gyroQueueMutex);
-                        gyroQueue.pop();
-                    }
-                }
-                sumGyro                 = (sumGyro * UPDATE_FREQUENCY + Eigen::Vector3d(0.0, 0.0, imu_drift_rate));
-                sumGyro.x()             = -sumGyro.x();
-                sensors.gyroscope.x     = sumGyro.x();
-                sensors.gyroscope.y     = sumGyro.y();
-                sensors.gyroscope.z     = sumGyro.z();
+                sensors.gyroscope.x     = 0.0;
+                sensors.gyroscope.y     = 0.0;
+                sensors.gyroscope.z     = imu_drift_rate;
                 sensors.accelerometer.x = -9.8 * std::sin(bodyTilt);
                 sensors.accelerometer.y = 0.0;
                 sensors.accelerometer.z = 9.8 * std::cos(bodyTilt);

--- a/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.hpp
+++ b/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.hpp
@@ -38,9 +38,6 @@ namespace module::platform::darwin {
     private:
         message::platform::RawSensors sensors;
 
-        std::queue<message::platform::RawSensors::Gyroscope> gyroQueue;
-        std::mutex gyroQueueMutex;
-
         float imu_drift_rate                     = 0;
         static constexpr size_t UPDATE_FREQUENCY = 90;
         void addNoise(std::unique_ptr<message::platform::RawSensors>& sensors);


### PR DESCRIPTION
At the moment, hardware simulator has a mechanism for handling gyroscope data using a queue of gyro readings. However, (I am reasonably sure) that nothing emits gyro readings. 
If they were emitted, we think the code would break because as @Bidski  pointed out to me, if it was executed, it would attempt to acquire the same mutex twice in a row.

This PR removes that stuff which handles gyroscope readings in hardware simulator. We might want to fix it instead, in which case I am happy to close this PR, but I figure it might as well go if we used it this long without that function anyway lol