### PR TITLE
Refactors vector style messages into vectors

### DIFF
--- a/module/behaviour/skills/Getup/src/Getup.cpp
+++ b/module/behaviour/skills/Getup/src/Getup.cpp
@@ -73,7 +73,7 @@ namespace module::behaviour::skills {
                 Eigen::Vector3d acc_reading = Eigen::Vector3d::Zero();
 
                 for (const auto& s : sensors) {
-                    acc_reading += Eigen::Vector3d(s->accelerometer.x, s->accelerometer.y, s->accelerometer.z);
+                    acc_reading += s->accelerometer.cast<double>();
                 }
                 acc_reading = (acc_reading / double(sensors.size())).normalized();
 

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -203,8 +203,8 @@ namespace module::input {
 
                     for (const auto& s : sensors) {
                         // Accumulate accelerometer and gyroscope readings
-                        acc += Eigen::Vector3d(s->accelerometer.x, s->accelerometer.y, s->accelerometer.z);
-                        gyro += Eigen::Vector3d(s->gyroscope.x, s->gyroscope.y, s->gyroscope.z);
+                        acc += s->accelerometer.cast<double>();
+                        gyro += s->gyroscope.cast<double>();
 
                         // Make sure we have servo positions
                         for (uint32_t id = 0; id < 20; ++id) {
@@ -459,8 +459,7 @@ namespace module::input {
                             sensors->accelerometer = previousSensors->accelerometer;
                         }
                         else {
-                            sensors->accelerometer =
-                                Eigen::Vector3d(input.accelerometer.x, input.accelerometer.y, input.accelerometer.z);
+                            sensors->accelerometer = input.accelerometer;
                         }
 
                         // If we have a previous Sensors message and (our platform has errors or we are spinning too
@@ -470,16 +469,12 @@ namespace module::input {
                                 // One of the gyros would occasionally throw massive numbers without an error flag
                                 // If our hardware is working as intended, it should never read that we're spinning at 2
                                 // revs/s
-                                || Eigen::Vector3d(input.gyroscope.x, input.gyroscope.y, input.gyroscope.z).norm()
-                                       > 4.0 * M_PI)) {
-                            NUClear::log<NUClear::WARN>(
-                                "Bad gyroscope value",
-                                Eigen::Vector3d(input.gyroscope.x, input.gyroscope.y, input.gyroscope.z).norm());
+                                || input.gyroscope.norm() > 4.0 * M_PI)) {
+                            NUClear::log<NUClear::WARN>("Bad gyroscope value", input.gyroscope.norm());
                             sensors->gyroscope = previousSensors->gyroscope;
                         }
                         else {
-                            sensors->gyroscope =
-                                Eigen::Vector3d(input.gyroscope.x, input.gyroscope.y, input.gyroscope.z);
+                            sensors->gyroscope = input.gyroscope;
                         }
 
                         /************************************************

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -459,7 +459,7 @@ namespace module::input {
                             sensors->accelerometer = previousSensors->accelerometer;
                         }
                         else {
-                            sensors->accelerometer = input.accelerometer;
+                            sensors->accelerometer = input.accelerometer.cast<double>();
                         }
 
                         // If we have a previous Sensors message and (our platform has errors or we are spinning too
@@ -474,7 +474,7 @@ namespace module::input {
                             sensors->gyroscope = previousSensors->gyroscope;
                         }
                         else {
-                            sensors->gyroscope = input.gyroscope;
+                            sensors->gyroscope = input.gyroscope.cast<double>();
                         }
 
                         /************************************************

--- a/module/platform/Gazebo/src/Gazebo.cpp
+++ b/module/platform/Gazebo/src/Gazebo.cpp
@@ -66,8 +66,8 @@ namespace module::platform {
             if (network_source.name == config.simulator_name && sensors.model == config.model_name) {
                 // Swizzle the IMU axes so that they match the CM740
                 RawSensors msg(sensors.sensors);
-                msg.accelerometer = {-msg.accelerometer.y, -msg.accelerometer.x, -msg.accelerometer.z};
-                msg.gyroscope     = {-msg.gyroscope.x, -msg.gyroscope.y, msg.gyroscope.z};
+                msg.accelerometer = -msg.accelerometer;
+                msg.gyroscope     = Eigen::Vector3f(-msg.gyroscope.x(), -msg.gyroscope.y(), msg.gyroscope.z());
                 emit(std::make_unique<RawSensors>(msg));
             }
         });

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -733,9 +733,9 @@ namespace module::platform {
                 // Webots has a strictly positive output for the accelerometers. We minus 100 to center the output
                 // over 0 The value 100.0 is based on the Look-up Table from NUgus.proto and should be kept
                 // consistent with that
-                sensor_data->accelerometer.x = static_cast<float>(accelerometer.value.X) - 100.0f;
-                sensor_data->accelerometer.y = static_cast<float>(accelerometer.value.Y) - 100.0f;
-                sensor_data->accelerometer.z = static_cast<float>(accelerometer.value.Z) - 100.0f;
+                sensor_data->accelerometer.x() = static_cast<float>(accelerometer.value.X) - 100.0f;
+                sensor_data->accelerometer.y() = static_cast<float>(accelerometer.value.Y) - 100.0f;
+                sensor_data->accelerometer.z() = static_cast<float>(accelerometer.value.Z) - 100.0f;
             }
 
             if (sensor_measurements.gyros.size() > 0) {
@@ -744,9 +744,9 @@ namespace module::platform {
                 // Webots has a strictly positive output for the gyros. We minus 100 to center the output over 0
                 // The value 100.0 is based on the Look-up Table from NUgus.proto and should be kept consistent with
                 // that
-                sensor_data->gyroscope.x = static_cast<float>(gyro.value.X) - 100.0f;
-                sensor_data->gyroscope.y = static_cast<float>(gyro.value.Y) - 100.0f;
-                sensor_data->gyroscope.z = static_cast<float>(gyro.value.Z) - 100.0f;
+                sensor_data->gyroscope.x() = static_cast<float>(gyro.value.X) - 100.0f;
+                sensor_data->gyroscope.y() = static_cast<float>(gyro.value.Y) - 100.0f;
+                sensor_data->gyroscope.z() = static_cast<float>(gyro.value.Z) - 100.0f;
             }
 
             for (const auto& bumper : sensor_measurements.bumpers) {

--- a/module/platform/darwin/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/darwin/HardwareIO/src/HardwareIO.cpp
@@ -82,18 +82,18 @@ namespace module::platform::darwin {
         //      z axis reports a +1g acceleration when robot is vertical
         // The CM740 currently has
         //      x is backward, y is to the left, and z is up
-        sensors.accelerometer.x = Convert::accelerometer(data.cm740.accelerometer.x);
-        sensors.accelerometer.y = -Convert::accelerometer(data.cm740.accelerometer.y);
-        sensors.accelerometer.z = -Convert::accelerometer(data.cm740.accelerometer.z);
+        sensors.accelerometer.x() = Convert::accelerometer(data.cm740.accelerometer.x);
+        sensors.accelerometer.y() = -Convert::accelerometer(data.cm740.accelerometer.y);
+        sensors.accelerometer.z() = -Convert::accelerometer(data.cm740.accelerometer.z);
 
         // Gyroscope (in radians/second)
         // Swizzle axes to that
         //      x is forward, y is to the left, and z is up
         // The CM740 currently has
         //      x is to the right, y is backward, and z is down
-        sensors.gyroscope.x = Convert::gyroscope(data.cm740.gyroscope.y);
-        sensors.gyroscope.y = Convert::gyroscope(data.cm740.gyroscope.x);
-        sensors.gyroscope.z = -Convert::gyroscope(data.cm740.gyroscope.z);
+        sensors.gyroscope.x() = Convert::gyroscope(data.cm740.gyroscope.y);
+        sensors.gyroscope.y() = Convert::gyroscope(data.cm740.gyroscope.x);
+        sensors.gyroscope.z() = -Convert::gyroscope(data.cm740.gyroscope.z);
 
         /*
          Force Sensitive Resistor Data

--- a/module/platform/darwin/HardwareSimulator/data/config/DarwinHardwareSimulator.yaml
+++ b/module/platform/darwin/HardwareSimulator/data/config/DarwinHardwareSimulator.yaml
@@ -2,14 +2,7 @@
 imu_drift_rate: 0.0
 
 noise:
-  accelerometer:
-    x: 0.01
-    y: 0.01
-    z: 0.01
-
-  gyroscope:
-    x: 0.01
-    y: 0.01
-    z: 0.01
+  accelerometer: [0.01, 0.01, 0.01]
+  gyroscope: [0.01, 0.01, 0.01]
 
 body_tilt: 0 #25 * pi / 180 # set this to be the same as the WalkEngine.yaml:stance:bodyTilt TODO: read this from WalkEngine

--- a/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
+++ b/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.cpp
@@ -77,9 +77,7 @@ namespace module::platform::darwin {
         sensors.voltage = 0;
 
         // Gyroscope (in radians/second)
-        sensors.gyroscope.x = 0;
-        sensors.gyroscope.y = 0;
-        sensors.gyroscope.z = 0;
+        sensors.gyroscope = Eigen::Vector3f::Zero();
 
         /*
          Force Sensitive Resistor Data
@@ -151,17 +149,10 @@ namespace module::platform::darwin {
 
         on<Configuration>("DarwinHardwareSimulator.yaml")
             .then("Hardware Simulator Config", [this](const Configuration& config) {
-                imu_drift_rate = config["imu_drift_rate"].as<float>();
-
-                noise.accelerometer.x = config["noise"]["accelerometer"]["x"].as<float>();
-                noise.accelerometer.y = config["noise"]["accelerometer"]["y"].as<float>();
-                noise.accelerometer.z = config["noise"]["accelerometer"]["z"].as<float>();
-
-                noise.gyroscope.x = config["noise"]["gyroscope"]["x"].as<float>();
-                noise.gyroscope.y = config["noise"]["gyroscope"]["y"].as<float>();
-                noise.gyroscope.z = config["noise"]["gyroscope"]["z"].as<float>();
-
-                bodyTilt = config["body_tilt"].as<Expression>();
+                imu_drift_rate      = config["imu_drift_rate"].as<float>();
+                noise.accelerometer = config["noise"]["accelerometer"].as<Expression>();
+                noise.gyroscope     = config["noise"]["gyroscope"].as<Expression>();
+                bodyTilt            = config["body_tilt"].as<Expression>();
             });
 
         on<Every<UPDATE_FREQUENCY, Per<std::chrono::seconds>>, Optional<With<Sensors>>, Single>().then(
@@ -213,13 +204,9 @@ namespace module::platform::darwin {
                     }
                 }
 
-                sensors.gyroscope.x     = 0.0;
-                sensors.gyroscope.y     = 0.0;
-                sensors.gyroscope.z     = imu_drift_rate;
-                sensors.accelerometer.x = -9.8 * std::sin(bodyTilt);
-                sensors.accelerometer.y = 0.0;
-                sensors.accelerometer.z = 9.8 * std::cos(bodyTilt);
-                sensors.timestamp       = NUClear::clock::now();
+                sensors.gyroscope     = Eigen::Vector3f(0.0f, 0.0f, imu_drift_rate);
+                sensors.accelerometer = Eigen::Vector3f(-9.8 * std::sin(bodyTilt), 0.0, 9.8 * std::cos(bodyTilt));
+                sensors.timestamp     = NUClear::clock::now();
 
                 // Add some noise so that sensor fusion doesnt converge to a singularity
                 auto sensors_message = std::make_unique<RawSensors>(sensors);
@@ -269,13 +256,8 @@ namespace module::platform::darwin {
 
     void HardwareSimulator::addNoise(std::unique_ptr<RawSensors>& sensors) {
         // TODO: Use a more standard c++ random generator.
-        sensors->accelerometer.x += noise.accelerometer.x * centered_noise();
-        sensors->accelerometer.y += noise.accelerometer.y * centered_noise();
-        sensors->accelerometer.z += noise.accelerometer.z * centered_noise();
-
-        sensors->gyroscope.x += noise.gyroscope.x * centered_noise();
-        sensors->gyroscope.y += noise.gyroscope.y * centered_noise();
-        sensors->gyroscope.z += noise.gyroscope.z * centered_noise();
+        sensors->accelerometer += noise.accelerometer * centered_noise();
+        sensors->gyroscope += noise.gyroscope * centered_noise();
     }
 
     void HardwareSimulator::setRightFootDown(bool down) {

--- a/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.hpp
+++ b/module/platform/darwin/HardwareSimulator/src/HardwareSimulator.hpp
@@ -42,14 +42,9 @@ namespace module::platform::darwin {
         static constexpr size_t UPDATE_FREQUENCY = 90;
         void addNoise(std::unique_ptr<message::platform::RawSensors>& sensors);
         struct NoiseConfig {
-            NoiseConfig() : accelerometer(), gyroscope() {}
-            struct Vec3Noise {
-                float x = 0.001;
-                float y = 0.001;
-                float z = 0.001;
-            };
-            Vec3Noise accelerometer;
-            Vec3Noise gyroscope;
+            NoiseConfig() = default;
+            Eigen::Vector3f accelerometer{0.001, 0.001, 0.001};
+            Eigen::Vector3f gyroscope{0.001, 0.001, 0.001};
         } noise;
         double bodyTilt                      = 0;
         Eigen::Vector3d integrated_gyroscope = Eigen::Vector3d::Zero();

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -22,6 +22,8 @@ package message.platform;
 
 import "google/protobuf/timestamp.proto";
 
+import "Vector.proto";
+
 /**
  * @author Trent Houliston
  */
@@ -59,18 +61,6 @@ message RawSensors {
     message Buttons {
         bool left   = 1;
         bool middle = 2;
-    }
-
-    message Accelerometer {
-        float x = 1;
-        float y = 2;
-        float z = 3;
-    }
-
-    message Gyroscope {
-        float x = 1;
-        float y = 2;
-        float z = 3;
     }
 
     message FSR {
@@ -134,8 +124,8 @@ message RawSensors {
     EyeLED                    eye_led              = 5;
     Buttons                   buttons              = 6;
     float                     voltage              = 7;
-    Accelerometer             accelerometer        = 8;
-    Gyroscope                 gyroscope            = 9;
+    fvec3                     accelerometer        = 8;
+    fvec3                     gyroscope            = 9;
     FSRs                      fsr                  = 10;
     Servos                    servo                = 11;
 }


### PR DESCRIPTION
`RawSensors::{Accelerometer, Gyroscope}` are both message types wrapping vectors. Now that we have nice vector types in proto + neutrons, these are unnecessary. 
This PR removes those message types and changes the code where they were used.