### PR TITLE
Adds dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Mandatory fields are `version` and `updates`
+version: 2
+updates:
+  # Package ecosystem for yarn is npm
+  - package-ecosystem: npm
+    directory: /nusight2
+    commit-message:
+      # include: "scope" tells it to add the names of the
+      # upgraded deps to the name, after the prefix
+      include: "scope"
+      prefix: "NUsight2 Dependency Update:"
+    labels:
+      - "-Dependencies"
+      - "P-NUsight2"
+      - "G-DevTools"
+    reviewers:
+      - "NUbots/nusight"


### PR DESCRIPTION
I went through the config options and selected the ones that seem relevant.
This will assign the members of the `nusight` group to review the PRs dependabot makes.