### PR TITLE
Add debug statments to nugus_sim image entrypoint

### DIFF
--- a/docker/nugus_sim/run.py
+++ b/docker/nugus_sim/run.py
@@ -143,10 +143,13 @@ def run_role(role: str, binaries_dir: str, env_vars: dict) -> None:
 
     # Run the role binary
     while True:
-        subprocess.run(f"./{role}", env=modified_env)
+        print(f"Binary '{role}' starting...")  # For debugging
+        exit_code = subprocess.run(f"./{role}", env=modified_env).returncode
+        print(f"Binary '{role}' crashed! Exit code: {exit_code}")  # For debugging
 
 
 if __name__ == "__main__":
     args = read_args()
+    print("main args: ", args)  # For Debugging
     update_config_files(args)
     run_role(args["role"], args["binaries_dir"], args["env_vars"])


### PR DESCRIPTION
Adds some debugging statements to nugus_sim entrypoint, specifically for finding out if our binary crashed.