### PR TITLE
Adds flags to enable or disable a set of roles, doing the opposite to the other roles

### DIFF
--- a/nuclear/b.py
+++ b/nuclear/b.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
+
 import argparse
+import glob
 import os
 import pkgutil
 import re
 import sys
+from pathlib import Path
 
 # Don't make .pyc files
 sys.dont_write_bytecode = True
@@ -69,6 +72,28 @@ try:
     source_dir = cmake_cache[cmake_cache["CMAKE_PROJECT_NAME"] + "_SOURCE_DIR"]
 except:
     source_dir = project_dir
+
+
+def get_cmake_role_flags(roles_to_build):
+    """Utility function to get list of CMake flags corresponding to the roles passed in"""
+
+    roles_dir = os.path.join(project_dir, "roles")
+    roles_glob = os.path.join(roles_dir, "*.role")
+
+    available_roles = [Path(role_path).stem for role_path in glob.glob(roles_glob)]
+
+    # Ensure that all the roles requested are available
+    for role in roles_to_build:
+        if role not in available_roles:
+            print(f"role '{role}' not found", color="red", attrs=["bold"])
+            sys.exit(1)
+
+    role_flags = [f"-DROLE_{role}=ON" for role in available_roles if role in roles_to_build] + [
+        f"-DROLE_{role}=OFF" for role in available_roles if role not in roles_to_build
+    ]
+
+    return role_flags
+
 
 if __name__ == "__main__":
 

--- a/nuclear/b.py
+++ b/nuclear/b.py
@@ -74,8 +74,14 @@ except:
     source_dir = project_dir
 
 
-def get_cmake_role_flags(roles_to_build):
-    """Utility function to get list of CMake flags corresponding to the roles passed in"""
+def get_cmake_role_flags(roles, disable_instead=False):
+    """
+    @brief Utility function to get list of CMake flags corresponding to the roles passed in.
+    If disable_instead == True, then those roles are the only ones not enabled in the
+    resulting flag list
+    @param roles The roles to enable (or disable, if disable_instead == True)
+    @param disable_instead Indicates whether the roles passed in should be enabled or disabled
+    """
 
     roles_dir = os.path.join(project_dir, "roles")
     roles_glob = os.path.join(roles_dir, "*.role")
@@ -83,13 +89,18 @@ def get_cmake_role_flags(roles_to_build):
     available_roles = [Path(role_path).stem for role_path in glob.glob(roles_glob)]
 
     # Ensure that all the roles requested are available
-    for role in roles_to_build:
+    for role in roles:
         if role not in available_roles:
             print(f"role '{role}' not found", color="red", attrs=["bold"])
             sys.exit(1)
 
-    role_flags = [f"-DROLE_{role}=ON" for role in available_roles if role in roles_to_build] + [
-        f"-DROLE_{role}=OFF" for role in available_roles if role not in roles_to_build
+    # If the roles passed in are meant to be disabled instead of enabled then
+    # we take the complement of our roles list, in the universe of available_roles
+    if disable_instead:
+        roles = [role for role in available_roles if role not in roles]
+
+    role_flags = [f"-DROLE_{role}=ON" for role in available_roles if role in roles] + [
+        f"-DROLE_{role}=OFF" for role in available_roles if role not in roles
     ]
 
     return role_flags

--- a/nuclear/b.py
+++ b/nuclear/b.py
@@ -91,7 +91,7 @@ def get_cmake_role_flags(roles, disable_instead=False):
     # Ensure that all the roles requested are available
     for role in roles:
         if role not in available_roles:
-            print(f"role '{role}' not found", color="red", attrs=["bold"])
+            print(f"role '{role}' not found")
             sys.exit(1)
 
     # If the roles passed in are meant to be disabled instead of enabled then

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -29,7 +29,7 @@ def register(command):
         action="store",
         dest="enabled_roles",
         default=None,
-        help="Colon-separated list of roles to enable",
+        help="Colon-separated list of roles to enable. Pass 'all' to enable all.",
     )
 
     command.add_argument(
@@ -53,6 +53,7 @@ def run(interactive, enabled_roles, disabled_roles, args, **kwargs):
 
     # If specific roles are disabled, then we enable all of the others
     if disabled_roles:
+        disabled_roles = disabled_roles.strip()
         # roles are a colon separated list, so we split on that character
         disabled_roles = disabled_roles.split(":")
         cprint("Disabling all roles except these: ", end=" ", color="red", attrs=["bold"])
@@ -62,10 +63,15 @@ def run(interactive, enabled_roles, disabled_roles, args, **kwargs):
     # If specific roles are enabled **and** specific roles aren't disabled,
     # then we enable only the enabled_roles
     elif enabled_roles:
-        enabled_roles = enabled_roles.split(":")
-        cprint("Enabling all roles except these:", end=" ", color="green", attrs=["bold"])
-        cprint(str(enabled_roles), color="red", attrs=["bold"])
-        args += b.get_cmake_role_flags(enabled_roles, False)
+        enabled_roles = enabled_roles.strip()
+        if enabled_roles == "all":
+            cprint("Enabling all roles", color="green", attrs=["bold"])
+            args += b.get_cmake_role_flags("", True)
+        else:
+            enabled_roles = enabled_roles.split(":")
+            cprint("Enabling all roles except these:", end=" ", color="green", attrs=["bold"])
+            cprint(str(enabled_roles), color="red", attrs=["bold"])
+            args += b.get_cmake_role_flags(enabled_roles, False)
 
     # To pass arguments to the cmake command you put them after "--"
     # but "--"  isn't a valid argument for cmake, so we remove it here

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -20,21 +20,39 @@ def register(command):
         default=False,
         help="perform an interactive configuration using ccmake",
     )
+
+    command.add_argument(
+        "-r",
+        "--roles",
+        action="store",
+        dest="roles",
+        default=None,
+        help="Colon-separated list of roles to enable",
+    )
+
     command.add_argument("args", nargs="...", help="the arguments to pass through to cmake")
 
 
 @run_on_docker
-def run(interactive, args, **kwargs):
+def run(interactive, roles, args, **kwargs):
     pty = WrapPty()
 
-    # If interactive then run ccmake else just run cmake
+    # Change into the build directory
     os.chdir(os.path.join(b.project_dir, "..", "build"))
+
+    # If we have selected specific roles to enable, we do that
+    if roles:
+        # The roles are a colon separated list, so we split on that character
+        roles = roles.split(":")
+
+        args += b.get_cmake_role_flags(roles)
 
     # To pass arguments to the cmake command you put them after "--"
     # but "--"  isn't a valid argument for cmake, so we remove it here
     if "--" in args:
         args.remove("--")
 
+    # If interactive then run ccmake else just run cmake
     if interactive:
         exit(
             pty.spawn(["ccmake", "-GNinja", "-DCMAKE_TOOLCHAIN_FILE=/usr/local/toolchain.cmake", *args, b.project_dir])

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -2,6 +2,8 @@
 
 import os
 
+from termcolor import cprint
+
 import b
 from utility.dockerise import run_on_docker
 from utility.shell import WrapPty
@@ -23,29 +25,47 @@ def register(command):
 
     command.add_argument(
         "-r",
-        "--roles",
+        "--enable-roles",
         action="store",
-        dest="roles",
+        dest="enabled_roles",
         default=None,
         help="Colon-separated list of roles to enable",
+    )
+
+    command.add_argument(
+        "-R",
+        "--disable-roles",
+        action="store",
+        dest="disabled_roles",
+        default=None,
+        help="Colon-separated list of roles to disable. If '-R' is set, '-r' is ignored",
     )
 
     command.add_argument("args", nargs="...", help="the arguments to pass through to cmake")
 
 
 @run_on_docker
-def run(interactive, roles, args, **kwargs):
+def run(interactive, enabled_roles, disabled_roles, args, **kwargs):
     pty = WrapPty()
 
     # Change into the build directory
     os.chdir(os.path.join(b.project_dir, "..", "build"))
 
-    # If we have selected specific roles to enable, we do that
-    if roles:
-        # The roles are a colon separated list, so we split on that character
-        roles = roles.split(":")
+    # If specific roles are disabled, then we enable all of the others
+    if disabled_roles:
+        # roles are a colon separated list, so we split on that character
+        disabled_roles = disabled_roles.split(":")
+        cprint("Disabling all roles except these: ", end=" ", color="red", attrs=["bold"])
+        cprint(str(disabled_roles), color="green", attrs=["bold"])
+        args += b.get_cmake_role_flags(disabled_roles, True)
 
-        args += b.get_cmake_role_flags(roles)
+    # If specific roles are enabled **and** specific roles aren't disabled,
+    # then we enable only the enabled_roles
+    elif enabled_roles:
+        enabled_roles = enabled_roles.split(":")
+        cprint("Enabling all roles except these:", end=" ", color="green", attrs=["bold"])
+        cprint(str(enabled_roles), color="red", attrs=["bold"])
+        args += b.get_cmake_role_flags(enabled_roles, False)
 
     # To pass arguments to the cmake command you put them after "--"
     # but "--"  isn't a valid argument for cmake, so we remove it here


### PR DESCRIPTION
This PR resolves #651 - basically I am tired of running `./b configure -i` and spamming space to disable all roles except one.
The PR does that by using the role selecting capability @JosephusPaye wrote for `./b webots` - I moved that function into `b` itself.

This PR might be contentious because I moved the function into `b`. I am willing to budge on that of course @TrentHouliston; it just seemed like the most reasonable solution for a `b` tool utility function.

### Reviewers, note

To test, it's `./b configure -r <roles> # enables <roles>` or `./b configure -R <roles> # disables <roles>`, where `<roles>` is a colon-separated list of role names. You can also do `./b configure -r all` to enable all roles.