### PR TITLE
Stops the robot from freezing after trying to get up twice

### DIFF
--- a/module/behaviour/skills/Getup/src/Getup.cpp
+++ b/module/behaviour/skills/Getup/src/Getup.cpp
@@ -67,7 +67,7 @@ namespace module::behaviour::skills {
             EXECUTION_PRIORITY = config["EXECUTION_PRIORITY"].as<float>();
         });
 
-        fallenCheck = on<Last<20, Trigger<RawSensors>>, Single>().then(
+        on<Last<20, Trigger<RawSensors>>, Single>().then(
             "Getup Fallen Check",
             [this](const std::list<std::shared_ptr<const RawSensors>>& sensors) {
                 Eigen::Vector3d acc_reading = Eigen::Vector3d::Zero();
@@ -84,11 +84,10 @@ namespace module::behaviour::skills {
                     isFront = (M_PI_2 - std::acos(Eigen::Vector3d::UnitX().dot(acc_reading)) <= 0.0);
 
                     updatePriority(GETUP_PRIORITY);
-                    getUp.enable();
                 }
             });
 
-        getUp = on<Trigger<ExecuteGetup>, Single>().then("Execute Getup", [this]() {
+        on<Trigger<ExecuteGetup>, Single>().then("Execute Getup", [this]() {
             gettingUp = true;
 
             // Check with side we're getting up from
@@ -108,7 +107,6 @@ namespace module::behaviour::skills {
         on<Trigger<KillGetup>>().then([this] {
             gettingUp = false;
             updatePriority(0);
-            getUp.disable();
         });
 
         emit<Scope::INITIALIZE>(std::make_unique<RegisterAction>(RegisterAction{

--- a/module/behaviour/skills/Getup/src/Getup.cpp
+++ b/module/behaviour/skills/Getup/src/Getup.cpp
@@ -51,8 +51,6 @@ namespace module::behaviour::skills {
         , id(size_t(this) * size_t(this) - size_t(this))
         , isFront(true)
         , gettingUp(false)
-        , fallenCheck()
-        , getUp()
         , FALLEN_ANGLE(M_PI_2)
         , GETUP_PRIORITY(0.0f)
         , EXECUTION_PRIORITY(0.0f) {

--- a/module/behaviour/skills/Getup/src/Getup.hpp
+++ b/module/behaviour/skills/Getup/src/Getup.hpp
@@ -37,8 +37,6 @@ namespace module::behaviour::skills {
         bool isFront;
 
         bool gettingUp;
-        ReactionHandle fallenCheck;
-        ReactionHandle getUp;
 
         /// config settings
         float FALLEN_ANGLE;


### PR DESCRIPTION
This PR removes the ReactionHandles in Getup to prevent a race condition that resulted in Getup taking control and never giving it up. 

The problem was
- Get up is detected, priority is increased :arrow_up: 
- Because priority is increased, Getup gets control and ExecuteGetup is emitted :envelope: 
- getUp reactor is enabled by default so it runs fine :+1: 
- KillGetup runs after get up finishes and disables the getUp reactor :x: 
- Get up is detected, priority is increased :arrow_up: 
- Because priority is increased, Getup gets control and ExecuteGetup is emitted :envelope: 
- getUp reactor was disabled, so it doesn't run :x: 
- getUp reactor is enabled, but ExecuteGetup has already disappeared :cry: 