### PR TITLE
Add to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ tags
 .idea
 *.sublime-workspace
 \.vscode/ipch
+.ccls-cache


### PR DESCRIPTION
I've started using `ccls` which needs a cache folder, we don't want this on git :stuck_out_tongue: