### PR TITLE
Emit vision balls even if there are no balls

### DIFF
--- a/module/vision/BallDetector/src/BallDetector.cpp
+++ b/module/vision/BallDetector/src/BallDetector.cpp
@@ -117,167 +117,169 @@ namespace module::vision {
 
                 log<NUClear::DEBUG>(fmt::format("Found {} clusters below green horizon", clusters.size()));
 
-                if (clusters.size() > 0) {
-                    auto balls = std::make_unique<Balls>();
-                    balls->balls.reserve(clusters.size());
+                auto balls = std::make_unique<Balls>();
+                balls->balls.reserve(clusters.size());
 
-                    balls->id        = horizon.id;
-                    balls->timestamp = horizon.timestamp;
-                    balls->Hcw       = horizon.Hcw;
+                balls->id        = horizon.id;
+                balls->timestamp = horizon.timestamp;
+                balls->Hcw       = horizon.Hcw;
 
-                    for (auto& cluster : clusters) {
-                        Ball b;
+                for (auto& cluster : clusters) {
+                    Ball b;
 
-                        // Average the cluster to get the cones axis
-                        Eigen::Vector3f axis = Eigen::Vector3f::Zero();
-                        for (const auto& idx : cluster) {
-                            axis += rays.col(idx);
-                        }
-                        axis /= cluster.size();
-                        axis.normalize();
+                    // Average the cluster to get the cones axis
+                    Eigen::Vector3f axis = Eigen::Vector3f::Zero();
+                    for (const auto& idx : cluster) {
+                        axis += rays.col(idx);
+                    }
+                    axis /= cluster.size();
+                    axis.normalize();
 
-                        // Find the ray with the greatest distance from the axis
-                        // Should we use the average distance instead?
-                        float radius = 1.0f;
-                        for (const auto& idx : cluster) {
-                            const Eigen::Vector3f& ray(rays.col(idx));
-                            if (axis.dot(ray) < radius) {
-                                radius = axis.dot(ray);
-                            }
-                        }
-
-                        // Ball cam space info
-                        b.cone.axis   = horizon.Hcw.topLeftCorner<3, 3>().cast<float>() * axis;
-                        b.cone.radius = radius;
-
-                        // https://en.wikipedia.org/wiki/Angular_diameter
-                        float distance = field.ball_radius / std::sqrt(1.0f - radius * radius);
-
-                        // Attach the measurement to the object (distance from camera to ball)
-                        b.measurements.push_back(Ball::Measurement());
-
-                        // Spherical Reciprocal Coordinates (1/distance, phi, theta)
-                        b.measurements.back().srBCc      = cartesianToReciprocalSpherical(b.cone.axis * distance);
-                        b.measurements.back().covariance = config.ball_angular_cov.asDiagonal();
-
-                        // Angular positions from the camera
-                        b.screen_angular = cartesianToSpherical(axis).tail<2>();
-                        b.angular_size   = Eigen::Vector2f::Constant(std::acos(radius));
-
-                        /***********************************************
-                         *                  THROWOUTS                  *
-                         ***********************************************/
-
-                        log<NUClear::DEBUG>("**************************************************");
-                        log<NUClear::DEBUG>("*                    THROWOUTS                   *");
-                        log<NUClear::DEBUG>("**************************************************");
-                        bool keep = true;
-                        b.colour.fill(1.0f);
-
-                        // CALCULATE DEGREE OF FIT
-                        // Degree of fit defined as the standard deviation of angle between every rays on the
-                        // cluster / and the cone axis. If the standard deviation exceeds a given threshold then we
-                        // have a bad fit
-                        std::vector<float> angles;
-                        float mean             = 0.0f;
-                        const float max_radius = std::acos(radius);
-                        for (const auto& idx : cluster) {
-                            const float angle = std::acos(axis.dot(rays.col(idx))) / max_radius;
-                            angles.emplace_back(angle);
-                            mean += angle;
-                        }
-                        mean /= angles.size();
-                        float deviation = 0.0f;
-                        for (const auto& angle : angles) {
-                            deviation += (mean - angle) * (mean - angle);
-                        }
-                        deviation = std::sqrt(deviation / (angles.size() - 1));
-
-                        if (deviation > config.maximum_deviation) {
-
-                            log<NUClear::DEBUG>(fmt::format("Ball discarded: deviation ({}) > maximum_deviation ({})",
-                                                            deviation,
-                                                            config.maximum_deviation));
-                            log<NUClear::DEBUG>("--------------------------------------------------");
-                            b.colour = keep ? message::conversion::math::fvec4(0.0f, 1.0f, 0.0f, 1.0f) : b.colour;
-                            keep     = false;
-                        }
-
-                        // DISTANCE IS TOO CLOSE
-                        if (distance < config.minimum_ball_distance) {
-
-                            log<NUClear::DEBUG>(
-                                fmt::format("Ball discarded: distance ({}) < minimum_ball_distance ({})",
-                                            distance,
-                                            config.minimum_ball_distance));
-                            log<NUClear::DEBUG>("--------------------------------------------------");
-                            b.colour = keep ? message::conversion::math::fvec4(1.0f, 0.0f, 0.0f, 1.0f) : b.colour;
-                            keep     = false;
-                        }
-
-                        // IF THE DISAGREEMENT BETWEEN THE ANGULAR AND PROJECTION BASED DISTANCES ARE TOO LARGE
-                        // Intersect cone axis vector with a plane midway through the ball with normal vector (0, 0,
-                        // 1) Do this in world space, not camera space!
-                        // https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection#Algebraic_form
-                        // Plane normal = (0, 0, 1)
-                        // Point in plane = (0, 0, field.ball_radius)
-                        // Line direction = axis
-                        // Point on line = camera = Hcw.topRightCorner<3, 1>()
-                        Eigen::Affine3f Hcw(horizon.Hcw.cast<float>());
-                        const float d = (Hcw.inverse().translation().z() - field.ball_radius) / std::abs(axis.z());
-                        const Eigen::Vector3f srBCc     = axis * d;
-                        const float projection_distance = srBCc.norm();
-                        const float max_distance        = std::max(projection_distance, distance);
-
-                        if ((std::abs(projection_distance - distance) / max_distance) > config.distance_disagreement) {
-
-                            log<NUClear::DEBUG>(
-                                fmt::format("Ball discarded: Width and proj distance disagree too much: width = "
-                                            "{}, proj = {}",
-                                            distance,
-                                            projection_distance));
-                            log<NUClear::DEBUG>("--------------------------------------------------");
-                            b.colour = keep ? message::conversion::math::fvec4(0.0f, 0.0f, 1.0f, 1.0f) : b.colour;
-                            keep     = false;
-                        }
-
-                        // IF THE BALL IS FURTHER THAN THE LENGTH OF THE FIELD
-                        if (distance > field.dimensions.field_length) {
-
-                            log<NUClear::DEBUG>(
-                                fmt::format("Ball discarded: Distance to ball greater than field length: distance = "
-                                            "{}, field length = {}",
-                                            distance,
-                                            field.dimensions.field_length));
-                            log<NUClear::DEBUG>("--------------------------------------------------");
-
-                            b.colour = keep ? message::conversion::math::fvec4(1.0f, 0.0f, 1.0f, 1.0f) : b.colour;
-                            keep     = false;
-                        }
-
-                        log<NUClear::DEBUG>(fmt::format("Camera {}", balls->id));
-                        log<NUClear::DEBUG>(fmt::format("radius {}", b.cone.radius));
-                        log<NUClear::DEBUG>(fmt::format("Axis {}", b.cone.axis.transpose()));
-                        log<NUClear::DEBUG>(
-                            fmt::format("Distance {} - srBCc {}", distance, b.measurements.back().srBCc.transpose()));
-                        log<NUClear::DEBUG>(fmt::format("screen_angular {} - angular_size {}",
-                                                        b.screen_angular.transpose(),
-                                                        b.angular_size.transpose()));
-                        log<NUClear::DEBUG>(fmt::format("Projection Distance {}", projection_distance));
-                        log<NUClear::DEBUG>(fmt::format("Distance Throwout {}",
-                                                        std::abs(projection_distance - distance) / max_distance));
-                        log<NUClear::DEBUG>("**************************************************");
-
-                        if (!keep) {
-                            b.measurements.clear();
-                        }
-                        if (log_level <= NUClear::DEBUG || keep) {
-                            balls->balls.push_back(std::move(b));
+                    // Find the ray with the greatest distance from the axis
+                    // Should we use the average distance instead?
+                    float radius = 1.0f;
+                    for (const auto& idx : cluster) {
+                        const Eigen::Vector3f& ray(rays.col(idx));
+                        if (axis.dot(ray) < radius) {
+                            radius = axis.dot(ray);
                         }
                     }
-                    emit(std::move(balls));
+
+                    // Ball cam space info
+                    b.cone.axis   = horizon.Hcw.topLeftCorner<3, 3>().cast<float>() * axis;
+                    b.cone.radius = radius;
+
+                    // https://en.wikipedia.org/wiki/Angular_diameter
+                    float distance = field.ball_radius / std::sqrt(1.0f - radius * radius);
+
+                    // Attach the measurement to the object (distance from camera to ball)
+                    b.measurements.push_back(Ball::Measurement());
+
+                    // Spherical Reciprocal Coordinates (1/distance, phi, theta)
+                    b.measurements.back().srBCc      = cartesianToReciprocalSpherical(b.cone.axis * distance);
+                    b.measurements.back().covariance = config.ball_angular_cov.asDiagonal();
+
+                    // Angular positions from the camera
+                    b.screen_angular = cartesianToSpherical(axis).tail<2>();
+                    b.angular_size   = Eigen::Vector2f::Constant(std::acos(radius));
+
+                    /***********************************************
+                     *                  THROWOUTS                  *
+                     ***********************************************/
+
+                    log<NUClear::DEBUG>("**************************************************");
+                    log<NUClear::DEBUG>("*                    THROWOUTS                   *");
+                    log<NUClear::DEBUG>("**************************************************");
+                    bool keep = true;
+                    b.colour.fill(1.0f);
+
+                    // CALCULATE DEGREE OF FIT
+                    // Degree of fit defined as the standard deviation of angle between every rays on the
+                    // cluster / and the cone axis. If the standard deviation exceeds a given threshold then we
+                    // have a bad fit
+                    std::vector<float> angles;
+                    float mean             = 0.0f;
+                    const float max_radius = std::acos(radius);
+                    for (const auto& idx : cluster) {
+                        const float angle = std::acos(axis.dot(rays.col(idx))) / max_radius;
+                        angles.emplace_back(angle);
+                        mean += angle;
+                    }
+                    mean /= angles.size();
+                    float deviation = 0.0f;
+                    for (const auto& angle : angles) {
+                        deviation += (mean - angle) * (mean - angle);
+                    }
+                    deviation = std::sqrt(deviation / (angles.size() - 1));
+
+                    if (deviation > config.maximum_deviation) {
+
+                        log<NUClear::DEBUG>(fmt::format("Ball discarded: deviation ({}) > maximum_deviation ({})",
+                                                        deviation,
+                                                        config.maximum_deviation));
+                        log<NUClear::DEBUG>("--------------------------------------------------");
+                        b.colour = keep ? message::conversion::math::fvec4(0.0f, 1.0f, 0.0f, 1.0f) : b.colour;
+                        keep     = false;
+                    }
+
+                    // DISTANCE IS TOO CLOSE
+                    if (distance < config.minimum_ball_distance) {
+
+                        log<NUClear::DEBUG>(fmt::format("Ball discarded: distance ({}) < minimum_ball_distance ({})",
+                                                        distance,
+                                                        config.minimum_ball_distance));
+                        log<NUClear::DEBUG>("--------------------------------------------------");
+                        b.colour = keep ? message::conversion::math::fvec4(1.0f, 0.0f, 0.0f, 1.0f) : b.colour;
+                        keep     = false;
+                    }
+
+                    // IF THE DISAGREEMENT BETWEEN THE ANGULAR AND PROJECTION BASED DISTANCES ARE TOO LARGE
+                    // Intersect cone axis vector with a plane midway through the ball with normal vector (0, 0,
+                    // 1) Do this in world space, not camera space!
+                    // https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection#Algebraic_form
+                    // Plane normal = (0, 0, 1)
+                    // Point in plane = (0, 0, field.ball_radius)
+                    // Line direction = axis
+                    // Point on line = camera = Hcw.topRightCorner<3, 1>()
+                    Eigen::Affine3f Hcw(horizon.Hcw.cast<float>());
+                    const float d = (Hcw.inverse().translation().z() - field.ball_radius) / std::abs(axis.z());
+                    const Eigen::Vector3f srBCc     = axis * d;
+                    const float projection_distance = srBCc.norm();
+                    const float max_distance        = std::max(projection_distance, distance);
+
+                    if ((std::abs(projection_distance - distance) / max_distance) > config.distance_disagreement) {
+
+                        log<NUClear::DEBUG>(
+                            fmt::format("Ball discarded: Width and proj distance disagree too much: width = "
+                                        "{}, proj = {}",
+                                        distance,
+                                        projection_distance));
+                        log<NUClear::DEBUG>("--------------------------------------------------");
+                        b.colour = keep ? message::conversion::math::fvec4(0.0f, 0.0f, 1.0f, 1.0f) : b.colour;
+                        keep     = false;
+                    }
+
+                    // IF THE BALL IS FURTHER THAN THE LENGTH OF THE FIELD
+                    if (distance > field.dimensions.field_length) {
+
+                        log<NUClear::DEBUG>(
+                            fmt::format("Ball discarded: Distance to ball greater than field length: distance = "
+                                        "{}, field length = {}",
+                                        distance,
+                                        field.dimensions.field_length));
+                        log<NUClear::DEBUG>("--------------------------------------------------");
+
+                        b.colour = keep ? message::conversion::math::fvec4(1.0f, 0.0f, 1.0f, 1.0f) : b.colour;
+                        keep     = false;
+                    }
+
+                    log<NUClear::DEBUG>(fmt::format("Camera {}", balls->id));
+                    log<NUClear::DEBUG>(fmt::format("radius {}", b.cone.radius));
+                    log<NUClear::DEBUG>(fmt::format("Axis {}", b.cone.axis.transpose()));
+                    log<NUClear::DEBUG>(
+                        fmt::format("Distance {} - srBCc {}", distance, b.measurements.back().srBCc.transpose()));
+                    log<NUClear::DEBUG>(fmt::format("screen_angular {} - angular_size {}",
+                                                    b.screen_angular.transpose(),
+                                                    b.angular_size.transpose()));
+                    log<NUClear::DEBUG>(fmt::format("Projection Distance {}", projection_distance));
+                    log<NUClear::DEBUG>(
+                        fmt::format("Distance Throwout {}", std::abs(projection_distance - distance) / max_distance));
+                    log<NUClear::DEBUG>("**************************************************");
+
+                    if (!keep) {
+                        b.measurements.clear();
+                    }
+                    if (log_level <= NUClear::DEBUG || keep) {
+                        balls->balls.push_back(std::move(b));
+                    }
                 }
-                else {
+
+                // We still emit if there are no balls otherwise other modules are not aware that we can no longer see a
+                // ball, and they will keep using the last message sent. See head behaviour, where we use 'with' balls
+                // and react based on that last balls message.
+                emit(std::move(balls));
+
+                if (balls.balls.size() == 0) {
                     log<NUClear::DEBUG>("Found no balls.");
                 }
             });

--- a/module/vision/BallDetector/src/BallDetector.cpp
+++ b/module/vision/BallDetector/src/BallDetector.cpp
@@ -279,7 +279,7 @@ namespace module::vision {
                 // and react based on that last balls message.
                 emit(std::move(balls));
 
-                if (balls.balls.size() == 0) {
+                if (balls.balls.empty()) {
                     log<NUClear::DEBUG>("Found no balls.");
                 }
             });


### PR DESCRIPTION
At the moment we skip emitting a `vision::balls` message in `BallDetector` if there are no balls found. The rest of the codebase seems to assume otherwise - that we still send `vision::balls` when there are no balls. Examples in the codebase:
- Head behaviour gets vision balls on a 'with' statement, and it updates based on the last balls message. This ends up with behaviour chasing a ball that it can no longer see since it never gets the update that balls are gone. 
- Soccer strategy has an update that triggers when a balls message comes in. It already checks that the balls message is empty before continuing on and acting on that balls message.