### PR TITLE
Update SimpleWalkPathPlanner into a switch case and functions

### DIFF
--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -183,7 +183,7 @@ namespace module::behaviour::planning {
 
                     // This line should be UNREACHABLE
                     default:
-                        log<NUClear::WARN>(fmt::format("Invalid walk path planning command {}.", latestCommand.type));
+                        log<NUClear::WARN>(fmt::format("Invalid walk path planning command {}.", latestCommand.type.value));
                         emit(std::make_unique<StopCommand>(subsumptionId));
                         return;
                 }

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -161,14 +161,14 @@ namespace module::behaviour::planning {
                         emit(std::make_unique<StopCommand>(subsumptionId));
                         return;
 
-                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walkDirectly(); return;
+                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: SimpleWalkPathPlanner::walkDirectly(); return;
 
                     case message::behaviour::MotionCommand::Type::BALL_APPROACH:
-                        determineSimpleWalkPath(&ball, &field, &sensors, &wantsTo, &kickPlan, &fieldDescription);
+                        SimpleWalkPathPlanner::determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
                         return;
 
                     case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
-                        determineSimpleWalkPath(&ball, &field, &sensors, &wantsTo, &kickPlan, &fieldDescription);
+                        SimpleWalkPathPlanner::determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
                         return;
 
                     // This line should be UNREACHABLE

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -76,7 +76,7 @@ namespace module::behaviour::planning {
 
         // do a little configurating
         on<Configuration>("SimpleWalkPathPlanner.yaml").then([this](const Configuration& file) {
-            // TODO(KipHamiltons): Make these all consistent with the other files. We don't use .config anywhere else
+            // TODO (KipHamiltons): Make these all consistent with the other files. We don't use .config anywhere else
             log_level = file.config["log_level"].as<NUClear::LogLevel>();
 
             turnSpeed            = file.config["turnSpeed"].as<float>();
@@ -125,11 +125,17 @@ namespace module::behaviour::planning {
 
         on<Trigger<VisionBalls>>().then([this](const VisionBalls& balls) {
             if (!balls.balls.empty()) {
-                timeBallLastSeen = NUClear::clock::now();
+                timeBallLastSeen =
+                    NUClear::clock::now();  // Used to maintain the time since the ball was last seen for a timeout
+                                            // period (could be implemented outside of the path planner and somewhere
+                                            // else in strategy to call a particular 'style' of path planning that is
+                                            // more likely to find the ball)
             }
         });
 
-        // Freq should be equal to the main loop in soccer strategy
+        // @brief - Freq should be equal to the main loop in soccer strategy. TODO (Bryce Tuppurainen): Potentially
+        // change this value to a define in an included header if this will be used again for added design cohesion if
+        // this will be something we change in future
         on<Every<30, Per<std::chrono::seconds>>,
            With<Ball>,
            With<Field>,
@@ -144,97 +150,132 @@ namespace module::behaviour::planning {
                          const WantsToKick& wantsTo,
                          const KickPlan& kickPlan,
                          const FieldDescription& fieldDescription) {
+                // TODO (Bryce Tuppurainen) Determine if this line is necessary. Could this be
+                // integrated into the switch?
                 if (wantsTo.kick) {
                     emit(std::make_unique<StopCommand>(subsumptionId));
                     return;
                 }
 
-                if (latestCommand.type == message::behaviour::MotionCommand::Type::STAND_STILL) {
-                    emit(std::make_unique<StopCommand>(subsumptionId));
-                    return;
+                // @details - Either calls a function and then continues past the switch statement, or an emit/function
+                // is followed by a return without a break to ensure that an unreachable code warning doesn't appear in
+                // future, and to ensure that only the required emits are called
+                switch (latestCommand.type) {
+                    case message::behaviour::MotionCommand::Type::STAND_STILL:
+                        emit(std::make_unique<StopCommand>(subsumptionId));
+                        return;
+
+                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walkDirectly(); return;
+
+                    case message::behaviour::MotionCommand::Type::BALL_APPROACH:
+                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
+                        return;
+
+                    case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
+                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
+                        return;
+
+                    // @warning - This line should be UNREACHABLE - TODO Throw or otherwise display some warning that
+                    // latestCommand.type was invalid which called the stop command
+                    default:
+                        log<NUClear::WARN>(fmt::format("Invalid walk path planning command {}.", latestCommand.type));
+                        emit(std::make_unique<StopCommand>(subsumptionId));
+                        return;
                 }
-                if (latestCommand.type == message::behaviour::MotionCommand::Type::DIRECT_COMMAND) {
-                    // TO DO, change to Bezier stuff
-                    std::unique_ptr<WalkCommand> command =
-                        std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
-                    emit(std::move(command));
-                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-                    return;
-                }
-
-                Eigen::Affine3d Htw(sensors.Htw);
-
-                auto now = NUClear::clock::now();
-                float timeSinceBallSeen =
-                    std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
-                    * (1.0f / std::nano::den);
-
-
-                Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
-                rBWw     = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
-                           Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
-                position = (Htw * rBWw).head<2>();
-
-                // Hack Planner:
-                float headingChange = 0;
-                float sideStep      = 0;
-                float speedFactor   = 1;
-                if (useLocalisation) {
-
-                    // Transform kick target to torso space
-                    auto fieldPosition = Eigen::Affine2d(field.position);
-                    Eigen::Affine3d Hfw;
-                    Hfw.translation() =
-                        Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
-                    Hfw.linear() = Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(),
-                                                     Eigen::Vector3d::UnitZ())
-                                       .toRotationMatrix();
-
-                    Eigen::Affine3d Htf        = Htw * Hfw.inverse();
-                    Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
-
-                    // //approach point:
-                    Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
-                    Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
-
-                    if (position.norm() > slowdown_distance) {
-                        position = kick_point;
-                    }
-                    else {
-                        speedFactor   = slow_approach_factor;
-                        headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
-                        sideStep      = 1;
-                    }
-                }
-
-
-                float angle = std::atan2(position.y(), position.x()) + headingChange;
-
-                angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
-
-
-                // Euclidean distance to ball
-                float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
-                float scaleF2           = angle / M_PI;
-                float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
-
-                float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
-                float scaleS2        = angle / M_PI;
-                float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep
-                                       * sideSpeed * scaleS * (1.0 - scaleS2);
-
-
-                std::unique_ptr<WalkCommand> command =
-                    std::make_unique<WalkCommand>(subsumptionId,
-                                                  Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
-
-                emit(std::move(command));
-                emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
             });
 
-        on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then([this](const MotionCommand& cmd) {
-            // save the plan
-            latestCommand = cmd;
-        });
+        // @brief - Save the plan cmd into latestCommand
+        on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(
+            [this](const MotionCommand& cmd) { latestCommand = cmd; });
+
+        //-------- UTILITY FUNCTIONS - Add extra behaviours for path planning here and in the switch case of this file
+
+        void walkDirectly() {
+            std::unique_ptr<WalkCommand> command = std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
+            emit(std::move(command));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+        }
+
+        void determineSimpleWalkPath(const Ball& ball,
+                                    const Field& field,
+                                    const Sensors& sensors,
+                                    const KickPlan& kickPlan,
+                                    const FieldDescription& fieldDescription) {
+            Eigen::Affine3d Htw(sensors.Htw);
+
+            auto now                = NUClear::clock::now();
+            float timeSinceBallSeen = std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
+                                    * (1.0f / std::nano::den);
+
+
+            Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
+            rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
+                    Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
+            position = (Htw * rBWw).head<2>();
+
+            // TODO Fix Hack Planner:
+            float headingChange = 0;
+            float sideStep      = 0;
+            float speedFactor   = 1;
+
+            if (useLocalisation) {
+
+                // Transform kick target to torso space
+                auto fieldPosition = Eigen::Affine2d(field.position);
+                Eigen::Affine3d Hfw;
+                Hfw.translation() = Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
+                Hfw.linear() =
+                    Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
+                        .toRotationMatrix();
+
+                Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+                Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
+
+                // approach point:
+                Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
+                Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
+
+                if (position.norm() > slowdown_distance) {
+                    position = kick_point;
+                }
+                else {
+                    speedFactor   = slow_approach_factor;
+                    headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
+                    sideStep      = 1;
+                }
+            }
+
+            // @detail - If the value of position was less than the slowdown_distance provided in the config file,
+            // headingChange is potentially non-zero. This causes the requested angle to turn in the move command at
+            // the end of this function to potentially be the in the same direction resultant of the vector between
+            // the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen - Can someone
+            // please confirm or clarify this with my in the PR, this was my understanding when going through this
+            // script initially)
+            float angle = std::atan2(position.y(), position.x()) + headingChange;
+
+            // If the angle is bound between the maximum provided turning
+            // speed use it. Otherwise, the appropriate maximum is used
+            angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
+
+
+            // @brief - Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
+            // respectively, angle is provided above as some float value in radians from the arc-tan, divding this
+            // by Pi )
+            float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
+            float scaleF2           = angle / M_PI;
+            float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
+
+            float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
+            float scaleS2        = angle / M_PI;
+            float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
+                                * scaleS * (1.0 - scaleS2);
+
+
+            std::unique_ptr<WalkCommand> command =
+                std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+
+            emit(std::move(command));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+        }
     }
 }  // namespace module::behaviour::planning

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -164,11 +164,8 @@ namespace module::behaviour::planning {
                     case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walkDirectly(); return;
 
                     case message::behaviour::MotionCommand::Type::BALL_APPROACH:
-                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
-                        return;
-
-                    case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
-                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
+                        [[fallthrough]] case message::behaviour::MotionCommand::Type::WALK_TO_STATE
+                            : determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
                         return;
 
                     // This line should be UNREACHABLE

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -76,7 +76,7 @@ namespace module::behaviour::planning {
 
         // do a little configurating
         on<Configuration>("SimpleWalkPathPlanner.yaml").then([this](const Configuration& file) {
-            // TODO (KipHamiltons): Make these all consistent with the other files. We don't use .config anywhere else
+            // TODO(KipHamiltons): Make these all consistent with the other files. We don't use .config anywhere else
             log_level = file.config["log_level"].as<NUClear::LogLevel>();
 
             turnSpeed            = file.config["turnSpeed"].as<float>();
@@ -132,7 +132,7 @@ namespace module::behaviour::planning {
             }
         });
 
-        // @brief - Freq should be equal to the main loop in soccer strategy. TODO (Bryce Tuppurainen): Potentially
+        // Freq should be equal to the main loop in soccer strategy. TODO (Bryce Tuppurainen): Potentially
         // change this value to a define in an included header if this will be used again for added design cohesion if
         // this will be something we change in future
         on<Every<30, Per<std::chrono::seconds>>,
@@ -149,17 +149,14 @@ namespace module::behaviour::planning {
                          const WantsToKick& wantsTo,
                          const KickPlan& kickPlan,
                          const FieldDescription& fieldDescription) {
-                // TODO (Bryce Tuppurainen) Determine if this line is necessary. Could this be
+                // TODO(Bryce Tuppurainen) Determine if this line is necessary. Could this be
                 // integrated into the switch?
                 if (wantsTo.kick) {
                     emit(std::make_unique<StopCommand>(subsumptionId));
                     return;
                 }
 
-                // @details - Either calls a function and then continues past the switch statement, or an emit/function
-                // is followed by a return without a break to ensure that an unreachable code warning doesn't appear in
-                // future, and to ensure that only the required emits are called
-                switch (latestCommand.type) {
+                switch (static_cast<int>(latestCommand.type)) {
                     case message::behaviour::MotionCommand::Type::STAND_STILL:
                         emit(std::make_unique<StopCommand>(subsumptionId));
                         return;
@@ -174,8 +171,7 @@ namespace module::behaviour::planning {
                         determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
                         return;
 
-                    // @warning - This line should be UNREACHABLE - TODO Throw or otherwise display some warning that
-                    // latestCommand.type was invalid which called the stop command
+                    // This line should be UNREACHABLE
                     default:
                         log<NUClear::WARN>(fmt::format("Invalid walk path planning command {}.", latestCommand.type));
                         emit(std::make_unique<StopCommand>(subsumptionId));
@@ -183,16 +179,14 @@ namespace module::behaviour::planning {
                 }
             });
 
-        // @brief - Save the plan cmd into latestCommand
+        // Save the plan cmd into latestCommand
         on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(
             [this](const MotionCommand& cmd) { latestCommand = cmd; });
 
         //-------- UTILITY FUNCTIONS - Add extra behaviours for path planning here and in the switch case of this file
 
         void walkDirectly() {
-            std::unique_ptr<WalkCommand> command =
-                std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
-            emit(std::move(command));
+            emit(std::move(std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command)));
             emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
         }
 
@@ -247,7 +241,7 @@ namespace module::behaviour::planning {
                 }
             }
 
-            // @detail - If the value of position was less than the slowdown_distance provided in the config file,
+            // If the value of position was less than the slowdown_distance provided in the config file,
             // headingChange is potentially non-zero. This causes the requested angle to turn in the move command at
             // the end of this function to potentially be the in the same direction resultant of the vector between
             // the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen - Can someone
@@ -260,7 +254,7 @@ namespace module::behaviour::planning {
             angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
 
 
-            // @brief - Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
+            // Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
             // respectively, angle is provided above as some float value in radians from the arc-tan, divding this
             // by Pi )
             float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -191,7 +191,7 @@ namespace module::behaviour::planning {
             emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
         }
 
-        void SimpleWalkPathPlanner::etermineSimpleWalkPath(const Ball& ball,
+        void SimpleWalkPathPlanner::determineSimpleWalkPath(const Ball& ball,
                                      const Field& field,
                                      const Sensors& sensors,
                                      const WantsToKick& wantsTo,

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -177,101 +177,103 @@ namespace module::behaviour::planning {
                         emit(std::make_unique<StopCommand>(subsumptionId));
                         return;
                 }
+
+
+                //-------- Add extra behaviours for path planning here and in the switch case of this file
+
+                void walkDirectly() {
+                    emit(std::move(std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command)));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+                }
+
+                void determineSimpleWalkPath() {
+
+                    Eigen::Affine3d Htw(sensors.Htw);
+
+                    auto now = NUClear::clock::now();
+                    float timeSinceBallSeen =
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
+                        * (1.0f / std::nano::den);
+
+
+                    Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
+
+                    rBWw = timeSinceBallSeen < search_timeout
+                               ? rBWw_temp
+                               : Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();
+
+                    position = (Htw * rBWw).head<2>();
+
+                    // TODO Fix Hack Planner:
+                    float headingChange = 0;
+                    float sideStep      = 0;
+                    float speedFactor   = 1;
+
+                    if (useLocalisation) {
+
+                        // Transform kick target to torso space
+                        auto fieldPosition = Eigen::Affine2d(field.position);
+                        Eigen::Affine3d Hfw;
+                        Hfw.translation() =
+                            Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
+                        Hfw.linear() = Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(),
+                                                         Eigen::Vector3d::UnitZ())
+                                           .toRotationMatrix();
+
+                        Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+                        Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
+
+                        // approach point:
+                        Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
+                        Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
+
+                        if (position.norm() > slowdown_distance) {
+                            position = kick_point;
+                        }
+                        else {
+                            speedFactor   = slow_approach_factor;
+                            headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
+                            sideStep      = 1;
+                        }
+                    }
+
+                    // If the value of position was less than the slowdown_distance provided in the config file,
+                    // headingChange is potentially non-zero. This causes the requested angle to turn in the move
+                    // command at the end of this function to potentially be the in the same direction resultant of the
+                    // vector between the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen
+                    // - Can someone please confirm or clarify this with my in the PR, this was my understanding when
+                    // going through this script initially)
+                    float angle = std::atan2(position.y(), position.x()) + headingChange;
+
+                    // If the angle is bound between the maximum provided turning
+                    // speed use it. Otherwise, the appropriate maximum is used
+                    angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
+
+
+                    // Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
+                    // respectively, angle is provided above as some float value in radians from the arc-tan, divding
+                    // this by Pi )
+                    float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
+                    float scaleF2           = angle / M_PI;
+                    float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
+
+                    float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
+                    float scaleS2        = angle / M_PI;
+                    float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep
+                                           * sideSpeed * scaleS * (1.0 - scaleS2);
+
+
+                    std::unique_ptr<WalkCommand> command =
+                        std::make_unique<WalkCommand>(subsumptionId,
+                                                      Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+
+                    emit(std::move(command));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+                }
             });
 
         // Save the plan cmd into latestCommand
         on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(
             [this](const MotionCommand& cmd) { latestCommand = cmd; });
-
-        //-------- UTILITY FUNCTIONS - Add extra behaviours for path planning here and in the switch case of this file
-
-        void walkDirectly() {
-            emit(std::move(std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command)));
-            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-        }
-
-        void determineSimpleWalkPath(const Ball& ball,
-                                     const Field& field,
-                                     const Sensors& sensors,
-                                     const KickPlan& kickPlan,
-                                     const FieldDescription& fieldDescription) {
-            Eigen::Affine3d Htw(sensors.Htw);
-
-            auto now = NUClear::clock::now();
-            float timeSinceBallSeen =
-                std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
-                * (1.0f / std::nano::den);
-
-
-            Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
-            rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
-                       Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
-            position = (Htw * rBWw).head<2>();
-
-            // TODO Fix Hack Planner:
-            float headingChange = 0;
-            float sideStep      = 0;
-            float speedFactor   = 1;
-
-            if (useLocalisation) {
-
-                // Transform kick target to torso space
-                auto fieldPosition = Eigen::Affine2d(field.position);
-                Eigen::Affine3d Hfw;
-                Hfw.translation() =
-                    Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
-                Hfw.linear() =
-                    Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
-                        .toRotationMatrix();
-
-                Eigen::Affine3d Htf        = Htw * Hfw.inverse();
-                Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
-
-                // approach point:
-                Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
-                Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
-
-                if (position.norm() > slowdown_distance) {
-                    position = kick_point;
-                }
-                else {
-                    speedFactor   = slow_approach_factor;
-                    headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
-                    sideStep      = 1;
-                }
-            }
-
-            // If the value of position was less than the slowdown_distance provided in the config file,
-            // headingChange is potentially non-zero. This causes the requested angle to turn in the move command at
-            // the end of this function to potentially be the in the same direction resultant of the vector between
-            // the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen - Can someone
-            // please confirm or clarify this with my in the PR, this was my understanding when going through this
-            // script initially)
-            float angle = std::atan2(position.y(), position.x()) + headingChange;
-
-            // If the angle is bound between the maximum provided turning
-            // speed use it. Otherwise, the appropriate maximum is used
-            angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
-
-
-            // Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
-            // respectively, angle is provided above as some float value in radians from the arc-tan, divding this
-            // by Pi )
-            float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
-            float scaleF2           = angle / M_PI;
-            float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
-
-            float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
-            float scaleS2        = angle / M_PI;
-            float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
-                                   * scaleS * (1.0 - scaleS2);
-
-
-            std::unique_ptr<WalkCommand> command =
-                std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
-
-            emit(std::move(command));
-            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-        }
     }
 }  // namespace module::behaviour::planning

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -168,11 +168,11 @@ namespace module::behaviour::planning {
                     case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walkDirectly(); return;
 
                     case message::behaviour::MotionCommand::Type::BALL_APPROACH:
-                        determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
+                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
                         return;
 
                     case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
-                        determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
+                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
                         return;
 
                     // @warning - This line should be UNREACHABLE - TODO Throw or otherwise display some warning that
@@ -187,97 +187,95 @@ namespace module::behaviour::planning {
         // @brief - Save the plan cmd into latestCommand
         on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(
             [this](const MotionCommand& cmd) { latestCommand = cmd; });
-    }
 
+        //-------- UTILITY FUNCTIONS - Add extra behaviours for path planning here and in the switch case of this file
 
-    //-------- UTILITY FUNCTIONS - Add extra behaviours for path planning here and in the switch case of this file
-
-    void walkDirectly() {
-        std::unique_ptr<WalkCommand> command = std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
-        emit(std::move(command));
-        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-    };
-
-    void determineSimpleWalkPath(const Ball& ball,
-                                 const Field& field,
-                                 const Sensors& sensors,
-                                 const WantsToKick& wantsTo,
-                                 const KickPlan& kickPlan,
-                                 const FieldDescription& fieldDescription) {
-        Eigen::Affine3d Htw(sensors.Htw);
-
-        auto now                = NUClear::clock::now();
-        float timeSinceBallSeen = std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
-                                  * (1.0f / std::nano::den);
-
-
-        Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
-        rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
-                   Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
-        position = (Htw * rBWw).head<2>();
-
-        // TODO Fix Hack Planner:
-        float headingChange = 0;
-        float sideStep      = 0;
-        float speedFactor   = 1;
-
-        if (useLocalisation) {
-
-            // Transform kick target to torso space
-            auto fieldPosition = Eigen::Affine2d(field.position);
-            Eigen::Affine3d Hfw;
-            Hfw.translation() = Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
-            Hfw.linear() =
-                Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
-                    .toRotationMatrix();
-
-            Eigen::Affine3d Htf        = Htw * Hfw.inverse();
-            Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
-
-            // approach point:
-            Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
-            Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
-
-            if (position.norm() > slowdown_distance) {
-                position = kick_point;
-            }
-            else {
-                speedFactor   = slow_approach_factor;
-                headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
-                sideStep      = 1;
-            }
+        void walkDirectly() {
+            std::unique_ptr<WalkCommand> command = std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
+            emit(std::move(command));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
         }
 
-        // @detail - If the value of position was less than the slowdown_distance provided in the config file,
-        // headingChange is potentially non-zero. This causes the requested angle to turn in the move command at
-        // the end of this function to potentially be the in the same direction resultant of the vector between
-        // the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen - Can someone
-        // please confirm or clarify this with my in the PR, this was my understanding when going through this
-        // script initially)
-        float angle = std::atan2(position.y(), position.x()) + headingChange;
+        void determineSimpleWalkPath(const Ball& ball,
+                                    const Field& field,
+                                    const Sensors& sensors,
+                                    const KickPlan& kickPlan,
+                                    const FieldDescription& fieldDescription) {
+            Eigen::Affine3d Htw(sensors.Htw);
 
-        // If the angle is bound between the maximum provided turning
-        // speed use it. Otherwise, the appropriate maximum is used
-        angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
-
-
-        // @brief - Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
-        // respectively, angle is provided above as some float value in radians from the arc-tan, divding this
-        // by Pi )
-        float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
-        float scaleF2           = angle / M_PI;
-        float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
-
-        float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
-        float scaleS2        = angle / M_PI;
-        float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
-                               * scaleS * (1.0 - scaleS2);
+            auto now                = NUClear::clock::now();
+            float timeSinceBallSeen = std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
+                                    * (1.0f / std::nano::den);
 
 
-        std::unique_ptr<WalkCommand> command =
-            std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+            Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
+            rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
+                    Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
+            position = (Htw * rBWw).head<2>();
 
-        emit(std::move(command));
-        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-    };
+            // TODO Fix Hack Planner:
+            float headingChange = 0;
+            float sideStep      = 0;
+            float speedFactor   = 1;
+
+            if (useLocalisation) {
+
+                // Transform kick target to torso space
+                auto fieldPosition = Eigen::Affine2d(field.position);
+                Eigen::Affine3d Hfw;
+                Hfw.translation() = Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
+                Hfw.linear() =
+                    Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
+                        .toRotationMatrix();
+
+                Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+                Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
+
+                // approach point:
+                Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
+                Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
+
+                if (position.norm() > slowdown_distance) {
+                    position = kick_point;
+                }
+                else {
+                    speedFactor   = slow_approach_factor;
+                    headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
+                    sideStep      = 1;
+                }
+            }
+
+            // @detail - If the value of position was less than the slowdown_distance provided in the config file,
+            // headingChange is potentially non-zero. This causes the requested angle to turn in the move command at
+            // the end of this function to potentially be the in the same direction resultant of the vector between
+            // the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen - Can someone
+            // please confirm or clarify this with my in the PR, this was my understanding when going through this
+            // script initially)
+            float angle = std::atan2(position.y(), position.x()) + headingChange;
+
+            // If the angle is bound between the maximum provided turning
+            // speed use it. Otherwise, the appropriate maximum is used
+            angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
+
+
+            // @brief - Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
+            // respectively, angle is provided above as some float value in radians from the arc-tan, divding this
+            // by Pi )
+            float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
+            float scaleF2           = angle / M_PI;
+            float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
+
+            float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
+            float scaleS2        = angle / M_PI;
+            float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
+                                * scaleS * (1.0 - scaleS2);
+
+
+            std::unique_ptr<WalkCommand> command =
+                std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+
+            emit(std::move(command));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+        }
+    }
 }  // namespace module::behaviour::planning

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -76,7 +76,7 @@ namespace module::behaviour::planning {
 
         // do a little configurating
         on<Configuration>("SimpleWalkPathPlanner.yaml").then([this](const Configuration& file) {
-            // TODO (KipHamiltons): Make these all consistent with the other files. We don't use .config anywhere else
+            // TODO(KipHamiltons): Make these all consistent with the other files. We don't use .config anywhere else
             log_level = file.config["log_level"].as<NUClear::LogLevel>();
 
             turnSpeed            = file.config["turnSpeed"].as<float>();
@@ -125,17 +125,11 @@ namespace module::behaviour::planning {
 
         on<Trigger<VisionBalls>>().then([this](const VisionBalls& balls) {
             if (!balls.balls.empty()) {
-                timeBallLastSeen =
-                    NUClear::clock::now();  // Used to maintain the time since the ball was last seen for a timeout
-                                            // period (could be implemented outside of the path planner and somewhere
-                                            // else in strategy to call a particular 'style' of path planning that is
-                                            // more likely to find the ball)
+                timeBallLastSeen = NUClear::clock::now();
             }
         });
 
-        // @brief - Freq should be equal to the main loop in soccer strategy. TODO (Bryce Tuppurainen): Potentially
-        // change this value to a define in an included header if this will be used again for added design cohesion if
-        // this will be something we change in future
+        // Freq should be equal to the main loop in soccer strategy
         on<Every<30, Per<std::chrono::seconds>>,
            With<Ball>,
            With<Field>,
@@ -150,132 +144,97 @@ namespace module::behaviour::planning {
                          const WantsToKick& wantsTo,
                          const KickPlan& kickPlan,
                          const FieldDescription& fieldDescription) {
-                // TODO (Bryce Tuppurainen) Determine if this line is necessary. Could this be
-                // integrated into the switch?
                 if (wantsTo.kick) {
                     emit(std::make_unique<StopCommand>(subsumptionId));
                     return;
                 }
 
-                // @details - Either calls a function and then continues past the switch statement, or an emit/function
-                // is followed by a return without a break to ensure that an unreachable code warning doesn't appear in
-                // future, and to ensure that only the required emits are called
-                switch ((int)latestCommand.type) {
-                    case message::behaviour::MotionCommand::Type::STAND_STILL:
-                        emit(std::make_unique<StopCommand>(subsumptionId));
-                        return;
-
-                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walkDirectly(); return;
-
-                    case message::behaviour::MotionCommand::Type::BALL_APPROACH:
-                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
-                        return;
-
-                    case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
-                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
-                        return;
-
-                    // @warning - This line should be UNREACHABLE - TODO Throw or otherwise display some warning that
-                    // latestCommand.type was invalid which called the stop command
-                    default:
-                        log<NUClear::WARN>(fmt::format("Invalid walk path planning command {}.", latestCommand.type));
-                        emit(std::make_unique<StopCommand>(subsumptionId));
-                        return;
+                if (latestCommand.type == message::behaviour::MotionCommand::Type::STAND_STILL) {
+                    emit(std::make_unique<StopCommand>(subsumptionId));
+                    return;
                 }
+                if (latestCommand.type == message::behaviour::MotionCommand::Type::DIRECT_COMMAND) {
+                    // TO DO, change to Bezier stuff
+                    std::unique_ptr<WalkCommand> command =
+                        std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
+                    emit(std::move(command));
+                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+                    return;
+                }
+
+                Eigen::Affine3d Htw(sensors.Htw);
+
+                auto now = NUClear::clock::now();
+                float timeSinceBallSeen =
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
+                    * (1.0f / std::nano::den);
+
+
+                Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
+                rBWw     = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
+                           Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
+                position = (Htw * rBWw).head<2>();
+
+                // Hack Planner:
+                float headingChange = 0;
+                float sideStep      = 0;
+                float speedFactor   = 1;
+                if (useLocalisation) {
+
+                    // Transform kick target to torso space
+                    auto fieldPosition = Eigen::Affine2d(field.position);
+                    Eigen::Affine3d Hfw;
+                    Hfw.translation() =
+                        Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
+                    Hfw.linear() = Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(),
+                                                     Eigen::Vector3d::UnitZ())
+                                       .toRotationMatrix();
+
+                    Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+                    Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
+
+                    // //approach point:
+                    Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
+                    Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
+
+                    if (position.norm() > slowdown_distance) {
+                        position = kick_point;
+                    }
+                    else {
+                        speedFactor   = slow_approach_factor;
+                        headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
+                        sideStep      = 1;
+                    }
+                }
+
+
+                float angle = std::atan2(position.y(), position.x()) + headingChange;
+
+                angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
+
+
+                // Euclidean distance to ball
+                float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
+                float scaleF2           = angle / M_PI;
+                float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
+
+                float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
+                float scaleS2        = angle / M_PI;
+                float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep
+                                       * sideSpeed * scaleS * (1.0 - scaleS2);
+
+
+                std::unique_ptr<WalkCommand> command =
+                    std::make_unique<WalkCommand>(subsumptionId,
+                                                  Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+
+                emit(std::move(command));
+                emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
             });
 
-        // @brief - Save the plan cmd into latestCommand
-        on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(
-            [this](const MotionCommand& cmd) { latestCommand = cmd; });
-
-        //-------- UTILITY FUNCTIONS - Add extra behaviours for path planning here and in the switch case of this file
-
-        void walkDirectly() {
-            std::unique_ptr<WalkCommand> command = std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
-            emit(std::move(command));
-            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-        }
-
-        void determineSimpleWalkPath(const Ball& ball,
-                                    const Field& field,
-                                    const Sensors& sensors,
-                                    const KickPlan& kickPlan,
-                                    const FieldDescription& fieldDescription) {
-            Eigen::Affine3d Htw(sensors.Htw);
-
-            auto now                = NUClear::clock::now();
-            float timeSinceBallSeen = std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
-                                    * (1.0f / std::nano::den);
-
-
-            Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
-            rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
-                    Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
-            position = (Htw * rBWw).head<2>();
-
-            // TODO Fix Hack Planner:
-            float headingChange = 0;
-            float sideStep      = 0;
-            float speedFactor   = 1;
-
-            if (useLocalisation) {
-
-                // Transform kick target to torso space
-                auto fieldPosition = Eigen::Affine2d(field.position);
-                Eigen::Affine3d Hfw;
-                Hfw.translation() = Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
-                Hfw.linear() =
-                    Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
-                        .toRotationMatrix();
-
-                Eigen::Affine3d Htf        = Htw * Hfw.inverse();
-                Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
-
-                // approach point:
-                Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
-                Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
-
-                if (position.norm() > slowdown_distance) {
-                    position = kick_point;
-                }
-                else {
-                    speedFactor   = slow_approach_factor;
-                    headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
-                    sideStep      = 1;
-                }
-            }
-
-            // @detail - If the value of position was less than the slowdown_distance provided in the config file,
-            // headingChange is potentially non-zero. This causes the requested angle to turn in the move command at
-            // the end of this function to potentially be the in the same direction resultant of the vector between
-            // the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen - Can someone
-            // please confirm or clarify this with my in the PR, this was my understanding when going through this
-            // script initially)
-            float angle = std::atan2(position.y(), position.x()) + headingChange;
-
-            // If the angle is bound between the maximum provided turning
-            // speed use it. Otherwise, the appropriate maximum is used
-            angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
-
-
-            // @brief - Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
-            // respectively, angle is provided above as some float value in radians from the arc-tan, divding this
-            // by Pi )
-            float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
-            float scaleF2           = angle / M_PI;
-            float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
-
-            float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
-            float scaleS2        = angle / M_PI;
-            float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
-                                * scaleS * (1.0 - scaleS2);
-
-
-            std::unique_ptr<WalkCommand> command =
-                std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
-
-            emit(std::move(command));
-            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-        }
+        on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then([this](const MotionCommand& cmd) {
+            // save the plan
+            latestCommand = cmd;
+        });
     }
 }  // namespace module::behaviour::planning

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -182,99 +182,102 @@ namespace module::behaviour::planning {
         // Save the plan cmd into latestCommand
         on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(
             [this](const MotionCommand& cmd) { latestCommand = cmd; });
-    }
 
 
-    //-------- Add extra behaviours for path planning here and in the switch case of this file
+        //-------- Add extra behaviours for path planning here and in the switch case of this file
 
-    void SimpleWalkPathPlanner::walkDirectly() {
-        emit(std::move(std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command)));
-        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-    }
-
-    void SimpleWalkPathPlanner::determineSimpleWalkPath(const Ball& ball,
-                         const Field& field,
-                         const Sensors& sensors,
-                         const WantsToKick& wantsTo,
-                         const KickPlan& kickPlan,
-                         const FieldDescription& fieldDescription) {
-
-        Eigen::Affine3d Htw(sensors.Htw);
-
-        auto now                = NUClear::clock::now();
-        float timeSinceBallSeen = std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
-                                  * (1.0f / std::nano::den);
-
-
-        Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
-
-        rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp
-                                                  : Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();
-
-        position = (Htw * rBWw).head<2>();
-
-        // TODO Fix Hack Planner:
-        float headingChange = 0;
-        float sideStep      = 0;
-        float speedFactor   = 1;
-
-        if (useLocalisation) {
-
-            // Transform kick target to torso space
-            auto fieldPosition = Eigen::Affine2d(field.position);
-            Eigen::Affine3d Hfw;
-            Hfw.translation() = Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
-            Hfw.linear() =
-                Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
-                    .toRotationMatrix();
-
-            Eigen::Affine3d Htf        = Htw * Hfw.inverse();
-            Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
-
-            // approach point:
-            Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
-            Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
-
-            if (position.norm() > slowdown_distance) {
-                position = kick_point;
-            }
-            else {
-                speedFactor   = slow_approach_factor;
-                headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
-                sideStep      = 1;
-            }
+        void SimpleWalkPathPlanner::walkDirectly() {
+            emit(std::move(std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command)));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
         }
 
-        // If the value of position was less than the slowdown_distance provided in the config file,
-        // headingChange is potentially non-zero. This causes the requested angle to turn in the move
-        // command at the end of this function to potentially be the in the same direction resultant of the
-        // vector between the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen
-        // - Can someone please confirm or clarify this with my in the PR, this was my understanding when
-        // going through this script initially)
-        float angle = std::atan2(position.y(), position.x()) + headingChange;
+        void SimpleWalkPathPlanner::etermineSimpleWalkPath(const Ball& ball,
+                                     const Field& field,
+                                     const Sensors& sensors,
+                                     const WantsToKick& wantsTo,
+                                     const KickPlan& kickPlan,
+                                     const FieldDescription& fieldDescription) {
 
-        // If the angle is bound between the maximum provided turning
-        // speed use it. Otherwise, the appropriate maximum is used
-        angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
+            Eigen::Affine3d Htw(sensors.Htw);
 
-
-        // Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
-        // respectively, angle is provided above as some float value in radians from the arc-tan, divding
-        // this by Pi )
-        float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
-        float scaleF2           = angle / M_PI;
-        float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
-
-        float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
-        float scaleS2        = angle / M_PI;
-        float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
-                               * scaleS * (1.0 - scaleS2);
+            auto now = NUClear::clock::now();
+            float timeSinceBallSeen =
+                std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
+                * (1.0f / std::nano::den);
 
 
-        std::unique_ptr<WalkCommand> command =
-            std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+            Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
 
-        emit(std::move(command));
-        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+            rBWw = timeSinceBallSeen < search_timeout
+                       ? rBWw_temp
+                       : Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();
+
+            position = (Htw * rBWw).head<2>();
+
+            // TODO Fix Hack Planner:
+            float headingChange = 0;
+            float sideStep      = 0;
+            float speedFactor   = 1;
+
+            if (useLocalisation) {
+
+                // Transform kick target to torso space
+                auto fieldPosition = Eigen::Affine2d(field.position);
+                Eigen::Affine3d Hfw;
+                Hfw.translation() =
+                    Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
+                Hfw.linear() =
+                    Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
+                        .toRotationMatrix();
+
+                Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+                Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
+
+                // approach point:
+                Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
+                Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
+
+                if (position.norm() > slowdown_distance) {
+                    position = kick_point;
+                }
+                else {
+                    speedFactor   = slow_approach_factor;
+                    headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
+                    sideStep      = 1;
+                }
+            }
+
+            // If the value of position was less than the slowdown_distance provided in the config file,
+            // headingChange is potentially non-zero. This causes the requested angle to turn in the move
+            // command at the end of this function to potentially be the in the same direction resultant of the
+            // vector between the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen
+            // - Can someone please confirm or clarify this with my in the PR, this was my understanding when
+            // going through this script initially)
+            float angle = std::atan2(position.y(), position.x()) + headingChange;
+
+            // If the angle is bound between the maximum provided turning
+            // speed use it. Otherwise, the appropriate maximum is used
+            angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
+
+
+            // Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
+            // respectively, angle is provided above as some float value in radians from the arc-tan, divding
+            // this by Pi )
+            float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
+            float scaleF2           = angle / M_PI;
+            float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
+
+            float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
+            float scaleS2        = angle / M_PI;
+            float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
+                                   * scaleS * (1.0 - scaleS2);
+
+
+            std::unique_ptr<WalkCommand> command =
+                std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+
+            emit(std::move(command));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+        }
     }
 }  // namespace module::behaviour::planning

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -164,11 +164,11 @@ namespace module::behaviour::planning {
                     case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: SimpleWalkPathPlanner::walkDirectly(); return;
 
                     case message::behaviour::MotionCommand::Type::BALL_APPROACH:
-                        SimpleWalkPathPlanner::determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
+                        SimpleWalkPathPlanner::determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
                         return;
 
                     case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
-                        SimpleWalkPathPlanner::determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
+                        SimpleWalkPathPlanner::determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
                         return;
 
                     // This line should be UNREACHABLE
@@ -194,7 +194,6 @@ namespace module::behaviour::planning {
         void SimpleWalkPathPlanner::determineSimpleWalkPath(const Ball& ball,
                                      const Field& field,
                                      const Sensors& sensors,
-                                     const WantsToKick& wantsTo,
                                      const KickPlan& kickPlan,
                                      const FieldDescription& fieldDescription) {
 

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -156,19 +156,29 @@ namespace module::behaviour::planning {
                     return;
                 }
 
-                switch (static_cast<int>(latestCommand.type)) {
+                switch (static_cast<int>(latestCommand.type.value)) {
                     case message::behaviour::MotionCommand::Type::STAND_STILL:
                         emit(std::make_unique<StopCommand>(subsumptionId));
                         return;
 
-                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: SimpleWalkPathPlanner::walkDirectly(); return;
+                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND:
+                        walkDirectly();
+                        return;
 
                     case message::behaviour::MotionCommand::Type::BALL_APPROACH:
-                        SimpleWalkPathPlanner::determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
+                        determineSimpleWalkPath(ball,
+                                                                       field,
+                                                                       sensors,
+                                                                       kickPlan,
+                                                                       fieldDescription);
                         return;
 
                     case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
-                        SimpleWalkPathPlanner::determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
+                        determineSimpleWalkPath(ball,
+                                                                       field,
+                                                                       sensors,
+                                                                       kickPlan,
+                                                                       fieldDescription);
                         return;
 
                     // This line should be UNREACHABLE
@@ -182,101 +192,97 @@ namespace module::behaviour::planning {
         // Save the plan cmd into latestCommand
         on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(
             [this](const MotionCommand& cmd) { latestCommand = cmd; });
+    }
+
+    //-------- Add extra behaviours for path planning here and in the switch case of this file
+
+    void SimpleWalkPathPlanner::walkDirectly() {
+        emit(std::move(std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command)));
+        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+    }
+
+    void SimpleWalkPathPlanner::determineSimpleWalkPath(const Ball& ball,
+                                                        const Field& field,
+                                                        const Sensors& sensors,
+                                                        const KickPlan& kickPlan,
+                                                        const FieldDescription& fieldDescription) {
+
+        Eigen::Affine3d Htw(sensors.Htw);
+
+        auto now                = NUClear::clock::now();
+        float timeSinceBallSeen = std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
+                                  * (1.0f / std::nano::den);
 
 
-        //-------- Add extra behaviours for path planning here and in the switch case of this file
+        Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
 
-        void SimpleWalkPathPlanner::walkDirectly() {
-            emit(std::move(std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command)));
-            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-        }
+        rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp
+                                                  : Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();
 
-        void SimpleWalkPathPlanner::determineSimpleWalkPath(const Ball& ball,
-                                     const Field& field,
-                                     const Sensors& sensors,
-                                     const KickPlan& kickPlan,
-                                     const FieldDescription& fieldDescription) {
+        position = (Htw * rBWw).head<2>();
 
-            Eigen::Affine3d Htw(sensors.Htw);
+        // TODO Fix Hack Planner:
+        float headingChange = 0;
+        float sideStep      = 0;
+        float speedFactor   = 1;
 
-            auto now = NUClear::clock::now();
-            float timeSinceBallSeen =
-                std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
-                * (1.0f / std::nano::den);
+        if (useLocalisation) {
 
+            // Transform kick target to torso space
+            auto fieldPosition = Eigen::Affine2d(field.position);
+            Eigen::Affine3d Hfw;
+            Hfw.translation() = Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
+            Hfw.linear() =
+                Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
+                    .toRotationMatrix();
 
-            Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
+            Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+            Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
 
-            rBWw = timeSinceBallSeen < search_timeout
-                       ? rBWw_temp
-                       : Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();
+            // approach point:
+            Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
+            Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
 
-            position = (Htw * rBWw).head<2>();
-
-            // TODO Fix Hack Planner:
-            float headingChange = 0;
-            float sideStep      = 0;
-            float speedFactor   = 1;
-
-            if (useLocalisation) {
-
-                // Transform kick target to torso space
-                auto fieldPosition = Eigen::Affine2d(field.position);
-                Eigen::Affine3d Hfw;
-                Hfw.translation() =
-                    Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
-                Hfw.linear() =
-                    Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
-                        .toRotationMatrix();
-
-                Eigen::Affine3d Htf        = Htw * Hfw.inverse();
-                Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
-
-                // approach point:
-                Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
-                Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
-
-                if (position.norm() > slowdown_distance) {
-                    position = kick_point;
-                }
-                else {
-                    speedFactor   = slow_approach_factor;
-                    headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
-                    sideStep      = 1;
-                }
+            if (position.norm() > slowdown_distance) {
+                position = kick_point;
             }
-
-            // If the value of position was less than the slowdown_distance provided in the config file,
-            // headingChange is potentially non-zero. This causes the requested angle to turn in the move
-            // command at the end of this function to potentially be the in the same direction resultant of the
-            // vector between the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen
-            // - Can someone please confirm or clarify this with my in the PR, this was my understanding when
-            // going through this script initially)
-            float angle = std::atan2(position.y(), position.x()) + headingChange;
-
-            // If the angle is bound between the maximum provided turning
-            // speed use it. Otherwise, the appropriate maximum is used
-            angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
-
-
-            // Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
-            // respectively, angle is provided above as some float value in radians from the arc-tan, divding
-            // this by Pi )
-            float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
-            float scaleF2           = angle / M_PI;
-            float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
-
-            float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
-            float scaleS2        = angle / M_PI;
-            float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
-                                   * scaleS * (1.0 - scaleS2);
-
-
-            std::unique_ptr<WalkCommand> command =
-                std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
-
-            emit(std::move(command));
-            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+            else {
+                speedFactor   = slow_approach_factor;
+                headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
+                sideStep      = 1;
+            }
         }
+
+        // If the value of position was less than the slowdown_distance provided in the config file,
+        // headingChange is potentially non-zero. This causes the requested angle to turn in the move
+        // command at the end of this function to potentially be the in the same direction resultant of the
+        // vector between the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen
+        // - Can someone please confirm or clarify this with my in the PR, this was my understanding when
+        // going through this script initially)
+        float angle = std::atan2(position.y(), position.x()) + headingChange;
+
+        // If the angle is bound between the maximum provided turning
+        // speed use it. Otherwise, the appropriate maximum is used
+        angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
+
+
+        // Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
+        // respectively, angle is provided above as some float value in radians from the arc-tan, divding
+        // this by Pi )
+        float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
+        float scaleF2           = angle / M_PI;
+        float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
+
+        float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
+        float scaleS2        = angle / M_PI;
+        float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
+                               * scaleS * (1.0 - scaleS2);
+
+
+        std::unique_ptr<WalkCommand> command =
+            std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+
+        emit(std::move(command));
+        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
     }
 }  // namespace module::behaviour::planning

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -164,11 +164,11 @@ namespace module::behaviour::planning {
                     case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walkDirectly(); return;
 
                     case message::behaviour::MotionCommand::Type::BALL_APPROACH:
-                        determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
+                        determineSimpleWalkPath(&ball, &field, &sensors, &wantsTo, &kickPlan, &fieldDescription);
                         return;
 
                     case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
-                        determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
+                        determineSimpleWalkPath(&ball, &field, &sensors, &wantsTo, &kickPlan, &fieldDescription);
                         return;
 
                     // This line should be UNREACHABLE

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -161,29 +161,20 @@ namespace module::behaviour::planning {
                         emit(std::make_unique<StopCommand>(subsumptionId));
                         return;
 
-                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND:
-                        walkDirectly();
-                        return;
+                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walkDirectly(); return;
 
                     case message::behaviour::MotionCommand::Type::BALL_APPROACH:
-                        determineSimpleWalkPath(ball,
-                                                                       field,
-                                                                       sensors,
-                                                                       kickPlan,
-                                                                       fieldDescription);
+                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
                         return;
 
                     case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
-                        determineSimpleWalkPath(ball,
-                                                                       field,
-                                                                       sensors,
-                                                                       kickPlan,
-                                                                       fieldDescription);
+                        determineSimpleWalkPath(ball, field, sensors, kickPlan, fieldDescription);
                         return;
 
                     // This line should be UNREACHABLE
                     default:
-                        log<NUClear::WARN>(fmt::format("Invalid walk path planning command {}.", latestCommand.type.value));
+                        log<NUClear::WARN>(
+                            fmt::format("Invalid walk path planning command {}.", latestCommand.type.value));
                         emit(std::make_unique<StopCommand>(subsumptionId));
                         return;
                 }

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -150,8 +150,9 @@ namespace module::behaviour::planning {
                          const WantsToKick& wantsTo,
                          const KickPlan& kickPlan,
                          const FieldDescription& fieldDescription) {
-                if (wantsTo.kick) {  // TODO (Bryce Tuppurainen) Determine if this line necessary. Could this be
-                                     // integrated into the switch?
+                // TODO (Bryce Tuppurainen) Determine if this line is necessary. Could this be
+                // integrated into the switch?
+                if (wantsTo.kick) {
                     emit(std::make_unique<StopCommand>(subsumptionId));
                     return;
                 }
@@ -159,113 +160,124 @@ namespace module::behaviour::planning {
                 // @details - Either calls a function and then continues past the switch statement, or an emit/function
                 // is followed by a return without a break to ensure that an unreachable code warning doesn't appear in
                 // future, and to ensure that only the required emits are called
-                switch (latestCommand.type) {
+                switch ((int)latestCommand.type) {
                     case message::behaviour::MotionCommand::Type::STAND_STILL:
                         emit(std::make_unique<StopCommand>(subsumptionId));
                         return;
 
-                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walk_directly(); return;
+                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walkDirectly(); return;
+
+                    case message::behaviour::MotionCommand::Type::BALL_APPROACH:
+                        determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
+                        return;
+
+                    case message::behaviour::MotionCommand::Type::WALK_TO_STATE:
+                        determineSimpleWalkPath(ball, field, sensors, wantsTo, kickPlan, fieldDescription);
+                        return;
 
                     // @warning - This line should be UNREACHABLE - TODO Throw or otherwise display some warning that
-                    // lastestCommand.type was invalid which called the stop command
-                    default: emit(std::make_unique<StopCommand>(subsumptionId)); return;
+                    // latestCommand.type was invalid which called the stop command
+                    default:
+                        log<NUClear::WARN>(fmt::format("Invalid walk path planning command {}.", latestCommand.type));
+                        emit(std::make_unique<StopCommand>(subsumptionId));
+                        return;
                 }
-
-                determine_simple_walk_path();
             });
 
         // @brief - Save the plan cmd into latestCommand
         on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(
             [this](const MotionCommand& cmd) { latestCommand = cmd; });
-
-        //-------- UTILITY FUNCTIONS - Add extra behaviours for path planning here and in the switch case of this file
-
-        void walk_directly() {
-            std::unique_ptr<WalkCommand> command =
-                std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
-            emit(std::move(command));
-            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-        };
-
-        void determine_simple_walk_path() {
-            Eigen::Affine3d Htw(sensors.Htw);
-
-            auto now = NUClear::clock::now();
-            float timeSinceBallSeen =
-                std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
-                * (1.0f / std::nano::den);
-
-
-            Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
-            rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
-                       Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
-            position = (Htw * rBWw).head<2>();
-
-            // TODO Fix Hack Planner:
-            float headingChange = 0;
-            float sideStep      = 0;
-            float speedFactor   = 1;
-
-            if (useLocalisation) {
-
-                // Transform kick target to torso space
-                auto fieldPosition = Eigen::Affine2d(field.position);
-                Eigen::Affine3d Hfw;
-                Hfw.translation() =
-                    Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
-                Hfw.linear() =
-                    Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
-                        .toRotationMatrix();
-
-                Eigen::Affine3d Htf        = Htw * Hfw.inverse();
-                Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
-
-                // //approach point:
-                Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
-                Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
-
-                if (position.norm() > slowdown_distance) {
-                    position = kick_point;
-                }
-                else {
-                    speedFactor   = slow_approach_factor;
-                    headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
-                    sideStep      = 1;
-                }
-            }
-
-            // @detail - If the value of position was less than the slowdown_distance provided in the config file,
-            // headingChange is potentially non-zero. This causes the requested angle to turn in the move command at
-            // the end of this function to potentially be the in the same direction resultant of the vector between
-            // the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen - Can someone
-            // please confirm or clarify this with my in the PR, this was my understanding when going through this
-            // script initially)
-            float angle = std::atan2(position.y(), position.x()) + headingChange;
-
-            angle =
-                std::min(turnSpeed,
-                         std::max(angle, -turnSpeed));  // If the angle is bound between the maximum provided turning
-                                                        // speed use it. Otherwise, the appropriate maximum is used
-
-
-            // @brief - Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
-            // respectively, angle is provided above as some float value in radians from the arc-tan, divding this
-            // by Pi )
-            float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
-            float scaleF2           = angle / M_PI;
-            float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
-
-            float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
-            float scaleS2        = angle / M_PI;
-            float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
-                                   * scaleS * (1.0 - scaleS2);
-
-
-            std::unique_ptr<WalkCommand> command =
-                std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
-
-            emit(std::move(command));
-            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-        };
     }
+
+
+    //-------- UTILITY FUNCTIONS - Add extra behaviours for path planning here and in the switch case of this file
+
+    void walkDirectly() {
+        std::unique_ptr<WalkCommand> command = std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
+        emit(std::move(command));
+        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+    };
+
+    void determineSimpleWalkPath(const Ball& ball,
+                                 const Field& field,
+                                 const Sensors& sensors,
+                                 const WantsToKick& wantsTo,
+                                 const KickPlan& kickPlan,
+                                 const FieldDescription& fieldDescription) {
+        Eigen::Affine3d Htw(sensors.Htw);
+
+        auto now                = NUClear::clock::now();
+        float timeSinceBallSeen = std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
+                                  * (1.0f / std::nano::den);
+
+
+        Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
+        rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
+                   Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
+        position = (Htw * rBWw).head<2>();
+
+        // TODO Fix Hack Planner:
+        float headingChange = 0;
+        float sideStep      = 0;
+        float speedFactor   = 1;
+
+        if (useLocalisation) {
+
+            // Transform kick target to torso space
+            auto fieldPosition = Eigen::Affine2d(field.position);
+            Eigen::Affine3d Hfw;
+            Hfw.translation() = Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
+            Hfw.linear() =
+                Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
+                    .toRotationMatrix();
+
+            Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+            Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
+
+            // approach point:
+            Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
+            Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
+
+            if (position.norm() > slowdown_distance) {
+                position = kick_point;
+            }
+            else {
+                speedFactor   = slow_approach_factor;
+                headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
+                sideStep      = 1;
+            }
+        }
+
+        // @detail - If the value of position was less than the slowdown_distance provided in the config file,
+        // headingChange is potentially non-zero. This causes the requested angle to turn in the move command at
+        // the end of this function to potentially be the in the same direction resultant of the vector between
+        // the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen - Can someone
+        // please confirm or clarify this with my in the PR, this was my understanding when going through this
+        // script initially)
+        float angle = std::atan2(position.y(), position.x()) + headingChange;
+
+        // If the angle is bound between the maximum provided turning
+        // speed use it. Otherwise, the appropriate maximum is used
+        angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
+
+
+        // @brief - Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
+        // respectively, angle is provided above as some float value in radians from the arc-tan, divding this
+        // by Pi )
+        float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
+        float scaleF2           = angle / M_PI;
+        float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
+
+        float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
+        float scaleS2        = angle / M_PI;
+        float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
+                               * scaleS * (1.0 - scaleS2);
+
+
+        std::unique_ptr<WalkCommand> command =
+            std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+
+        emit(std::move(command));
+        emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+    };
 }  // namespace module::behaviour::planning

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -76,7 +76,7 @@ namespace module::behaviour::planning {
 
         // do a little configurating
         on<Configuration>("SimpleWalkPathPlanner.yaml").then([this](const Configuration& file) {
-            // TODO(KipHamiltons): Make these all consistent with the other files. We don't use .config anywhere else
+            // TODO (KipHamiltons): Make these all consistent with the other files. We don't use .config anywhere else
             log_level = file.config["log_level"].as<NUClear::LogLevel>();
 
             turnSpeed            = file.config["turnSpeed"].as<float>();
@@ -125,11 +125,17 @@ namespace module::behaviour::planning {
 
         on<Trigger<VisionBalls>>().then([this](const VisionBalls& balls) {
             if (!balls.balls.empty()) {
-                timeBallLastSeen = NUClear::clock::now();
+                timeBallLastSeen =
+                    NUClear::clock::now();  // Used to maintain the time since the ball was last seen for a timeout
+                                            // period (could be implemented outside of the path planner and somewhere
+                                            // else in strategy to call a particular 'style' of path planning that is
+                                            // more likely to find the ball)
             }
         });
 
-        // Freq should be equal to the main loop in soccer strategy
+        // @brief - Freq should be equal to the main loop in soccer strategy. TODO (Bryce Tuppurainen): Potentially
+        // change this value to a define in an included header if this will be used again for added design cohesion if
+        // this will be something we change in future
         on<Every<30, Per<std::chrono::seconds>>,
            With<Ball>,
            With<Field>,
@@ -144,97 +150,122 @@ namespace module::behaviour::planning {
                          const WantsToKick& wantsTo,
                          const KickPlan& kickPlan,
                          const FieldDescription& fieldDescription) {
-                if (wantsTo.kick) {
+                if (wantsTo.kick) {  // TODO (Bryce Tuppurainen) Determine if this line necessary. Could this be
+                                     // integrated into the switch?
                     emit(std::make_unique<StopCommand>(subsumptionId));
                     return;
                 }
 
-                if (latestCommand.type == message::behaviour::MotionCommand::Type::STAND_STILL) {
-                    emit(std::make_unique<StopCommand>(subsumptionId));
-                    return;
-                }
-                if (latestCommand.type == message::behaviour::MotionCommand::Type::DIRECT_COMMAND) {
-                    // TO DO, change to Bezier stuff
-                    std::unique_ptr<WalkCommand> command =
-                        std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
-                    emit(std::move(command));
-                    emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
-                    return;
-                }
+                // @details - Either calls a function and then continues past the switch statement, or an emit/function
+                // is followed by a return without a break to ensure that an unreachable code warning doesn't appear in
+                // future, and to ensure that only the required emits are called
+                switch (latestCommand.type) {
+                    case message::behaviour::MotionCommand::Type::STAND_STILL:
+                        emit(std::make_unique<StopCommand>(subsumptionId));
+                        return;
 
-                Eigen::Affine3d Htw(sensors.Htw);
+                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walk_directly(); return;
 
-                auto now = NUClear::clock::now();
-                float timeSinceBallSeen =
-                    std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
-                    * (1.0f / std::nano::den);
-
-
-                Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
-                rBWw     = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
-                           Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
-                position = (Htw * rBWw).head<2>();
-
-                // Hack Planner:
-                float headingChange = 0;
-                float sideStep      = 0;
-                float speedFactor   = 1;
-                if (useLocalisation) {
-
-                    // Transform kick target to torso space
-                    auto fieldPosition = Eigen::Affine2d(field.position);
-                    Eigen::Affine3d Hfw;
-                    Hfw.translation() =
-                        Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
-                    Hfw.linear() = Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(),
-                                                     Eigen::Vector3d::UnitZ())
-                                       .toRotationMatrix();
-
-                    Eigen::Affine3d Htf        = Htw * Hfw.inverse();
-                    Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
-
-                    // //approach point:
-                    Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
-                    Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
-
-                    if (position.norm() > slowdown_distance) {
-                        position = kick_point;
-                    }
-                    else {
-                        speedFactor   = slow_approach_factor;
-                        headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
-                        sideStep      = 1;
-                    }
+                    // @warning - This line should be UNREACHABLE - TODO Throw or otherwise display some warning that
+                    // lastestCommand.type was invalid which called the stop command
+                    default: emit(std::make_unique<StopCommand>(subsumptionId)); return;
                 }
 
-
-                float angle = std::atan2(position.y(), position.x()) + headingChange;
-
-                angle = std::min(turnSpeed, std::max(angle, -turnSpeed));
-
-
-                // Euclidean distance to ball
-                float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
-                float scaleF2           = angle / M_PI;
-                float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
-
-                float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
-                float scaleS2        = angle / M_PI;
-                float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep
-                                       * sideSpeed * scaleS * (1.0 - scaleS2);
-
-
-                std::unique_ptr<WalkCommand> command =
-                    std::make_unique<WalkCommand>(subsumptionId,
-                                                  Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
-
-                emit(std::move(command));
-                emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+                determine_simple_walk_path();
             });
 
-        on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then([this](const MotionCommand& cmd) {
-            // save the plan
-            latestCommand = cmd;
-        });
+        // @brief - Save the plan cmd into latestCommand
+        on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(
+            [this](const MotionCommand& cmd) { latestCommand = cmd; });
+
+        //-------- UTILITY FUNCTIONS - Add extra behaviours for path planning here and in the switch case of this file
+
+        void walk_directly() {
+            std::unique_ptr<WalkCommand> command =
+                std::make_unique<WalkCommand>(subsumptionId, latestCommand.walk_command);
+            emit(std::move(command));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+        };
+
+        void determine_simple_walk_path() {
+            Eigen::Affine3d Htw(sensors.Htw);
+
+            auto now = NUClear::clock::now();
+            float timeSinceBallSeen =
+                std::chrono::duration_cast<std::chrono::nanoseconds>(now - timeBallLastSeen).count()
+                * (1.0f / std::nano::den);
+
+
+            Eigen::Vector3d rBWw_temp(ball.position.x(), ball.position.y(), fieldDescription.ball_radius);
+            rBWw = timeSinceBallSeen < search_timeout ? rBWw_temp :                         // Place last seen
+                       Htw.inverse().linear().leftCols<1>() + Htw.inverse().translation();  // In front of the robot
+            position = (Htw * rBWw).head<2>();
+
+            // TODO Fix Hack Planner:
+            float headingChange = 0;
+            float sideStep      = 0;
+            float speedFactor   = 1;
+
+            if (useLocalisation) {
+
+                // Transform kick target to torso space
+                auto fieldPosition = Eigen::Affine2d(field.position);
+                Eigen::Affine3d Hfw;
+                Hfw.translation() =
+                    Eigen::Vector3d(fieldPosition.translation().x(), fieldPosition.translation().y(), 0);
+                Hfw.linear() =
+                    Eigen::AngleAxisd(Eigen::Rotation2Dd(fieldPosition.rotation()).angle(), Eigen::Vector3d::UnitZ())
+                        .toRotationMatrix();
+
+                Eigen::Affine3d Htf        = Htw * Hfw.inverse();
+                Eigen::Vector3d kickTarget = Htf * Eigen::Vector3d(kickPlan.target.x(), kickPlan.target.y(), 0);
+
+                // //approach point:
+                Eigen::Vector2d ballToTarget = (kickTarget.head<2>() - position).normalized();
+                Eigen::Vector2d kick_point   = position - ballToTarget * ball_approach_dist;
+
+                if (position.norm() > slowdown_distance) {
+                    position = kick_point;
+                }
+                else {
+                    speedFactor   = slow_approach_factor;
+                    headingChange = std::atan2(ballToTarget.y(), ballToTarget.x());
+                    sideStep      = 1;
+                }
+            }
+
+            // @detail - If the value of position was less than the slowdown_distance provided in the config file,
+            // headingChange is potentially non-zero. This causes the requested angle to turn in the move command at
+            // the end of this function to potentially be the in the same direction resultant of the vector between
+            // the robot and the ball, as well as the vector from ball to goal (Bryce Tuppurainen - Can someone
+            // please confirm or clarify this with my in the PR, this was my understanding when going through this
+            // script initially)
+            float angle = std::atan2(position.y(), position.x()) + headingChange;
+
+            angle =
+                std::min(turnSpeed,
+                         std::max(angle, -turnSpeed));  // If the angle is bound between the maximum provided turning
+                                                        // speed use it. Otherwise, the appropriate maximum is used
+
+
+            // @brief - Euclidean distance to ball (scaleF, scaleF2, scaleS, scaleS2 for Forward and Side
+            // respectively, angle is provided above as some float value in radians from the arc-tan, divding this
+            // by Pi )
+            float scaleF            = 2.0 / (1.0 + std::exp(-a * std::fabs(position.x()) + b)) - 1.0;
+            float scaleF2           = angle / M_PI;
+            float finalForwardSpeed = speedFactor * forwardSpeed * scaleF * (1.0 - scaleF2);
+
+            float scaleS         = 2.0 / (1.0 + std::exp(-a * std::fabs(position.y()) + b)) - 1.0;
+            float scaleS2        = angle / M_PI;
+            float finalSideSpeed = -speedFactor * ((0.0 < position.y()) - (position.y() < 0.0)) * sideStep * sideSpeed
+                                   * scaleS * (1.0 - scaleS2);
+
+
+            std::unique_ptr<WalkCommand> command =
+                std::make_unique<WalkCommand>(subsumptionId, Eigen::Vector3d(finalForwardSpeed, finalSideSpeed, angle));
+
+            emit(std::move(command));
+            emit(std::make_unique<ActionPriorities>(ActionPriorities{subsumptionId, {40, 11}}));
+        };
     }
 }  // namespace module::behaviour::planning

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
@@ -64,12 +64,7 @@ namespace module::behaviour::planning {
         float ball_approach_dist = 0.2;
         float slowdown_distance  = 0.2;
         bool useLocalisation     = true;
-
-        //----------- Utility Functions - Designed to allow for the overall behaviour of the robots path planning to be adjusted at a higher level ----
-
-        void walk_directly();
-        void determine_simple_walk_path();
-
+        
     public:
         explicit SimpleWalkPathPlanner(std::unique_ptr<NUClear::Environment> environment);
     };

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
@@ -49,7 +49,7 @@ namespace module::behaviour::planning {
         float b                    = 0;
         float search_timeout       = 3;
 
-        //-----------non-config variables (not defined in WalkPathPlanner.yaml)-----------
+        //----------- non-config variables (not defined in WalkPathPlanner.yaml)----
 
         // info for the current walk
         Eigen::Vector2d currentTargetPosition;
@@ -64,6 +64,11 @@ namespace module::behaviour::planning {
         float ball_approach_dist = 0.2;
         float slowdown_distance  = 0.2;
         bool useLocalisation     = true;
+
+        //----------- Utility Functions - Designed to allow for the overall behaviour of the robots path planning to be adjusted at a higher level ----
+
+        void walk_directly();
+        void determine_simple_walk_path();
 
     public:
         explicit SimpleWalkPathPlanner(std::unique_ptr<NUClear::Environment> environment);

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
@@ -64,7 +64,14 @@ namespace module::behaviour::planning {
         float ball_approach_dist = 0.2;
         float slowdown_distance  = 0.2;
         bool useLocalisation     = true;
-        
+
+        void walkDirectly();
+        void determineSimpleWalkPath(const Ball& ball,
+                                     const Field& field,
+                                     const Sensors& sensors,
+                                     const KickPlan& kickPlan,
+                                     const FieldDescription& fieldDescription);
+
     public:
         explicit SimpleWalkPathPlanner(std::unique_ptr<NUClear::Environment> environment);
     };

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
@@ -28,10 +28,26 @@
 
 #include "message/behaviour/KickPlan.hpp"
 #include "message/behaviour/MotionCommand.hpp"
+#include "message/input/Sensors.hpp"
+#include "message/localisation/Ball.hpp"
+#include "message/localisation/Field.hpp"
+#include "message/motion/KickCommand.hpp"
+#include "message/motion/WalkCommand.hpp"
+#include "message/support/FieldDescription.hpp"
+#include "message/vision/Ball.hpp"
 
 namespace module::behaviour::planning {
 
     // using namespace message;
+
+    using message::behaviour::KickPlan;
+    using message::behaviour::MotionCommand;
+    using message::behaviour::WantsToKick;
+    using message::input::Sensors;
+    using message::localisation::Ball;
+    using message::localisation::Field;
+    using message::support::FieldDescription;
+
     /**
      * Executes a getup script if the robot falls over.
      *
@@ -66,13 +82,13 @@ namespace module::behaviour::planning {
         bool useLocalisation     = true;
 
         void walkDirectly();
-        
+
         void determineSimpleWalkPath(const Ball& ball,
-                         const Field& field,
-                         const Sensors& sensors,
-                         const WantsToKick& wantsTo,
-                         const KickPlan& kickPlan,
-                         const FieldDescription& fieldDescription);
+                                     const Field& field,
+                                     const Sensors& sensors,
+                                     const WantsToKick& wantsTo,
+                                     const KickPlan& kickPlan,
+                                     const FieldDescription& fieldDescription);
 
     public:
         explicit SimpleWalkPathPlanner(std::unique_ptr<NUClear::Environment> environment);

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
@@ -86,7 +86,6 @@ namespace module::behaviour::planning {
         void determineSimpleWalkPath(const Ball& ball,
                                      const Field& field,
                                      const Sensors& sensors,
-                                     const WantsToKick& wantsTo,
                                      const KickPlan& kickPlan,
                                      const FieldDescription& fieldDescription);
 

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
@@ -65,6 +65,15 @@ namespace module::behaviour::planning {
         float slowdown_distance  = 0.2;
         bool useLocalisation     = true;
 
+        void walkDirectly();
+        
+        void determineSimpleWalkPath(const Ball& ball,
+                         const Field& field,
+                         const Sensors& sensors,
+                         const WantsToKick& wantsTo,
+                         const KickPlan& kickPlan,
+                         const FieldDescription& fieldDescription);
+
     public:
         explicit SimpleWalkPathPlanner(std::unique_ptr<NUClear::Environment> environment);
     };

--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.hpp
@@ -65,13 +65,6 @@ namespace module::behaviour::planning {
         float slowdown_distance  = 0.2;
         bool useLocalisation     = true;
 
-        void walkDirectly();
-        void determineSimpleWalkPath(const Ball& ball,
-                                     const Field& field,
-                                     const Sensors& sensors,
-                                     const KickPlan& kickPlan,
-                                     const FieldDescription& fieldDescription);
-
     public:
         explicit SimpleWalkPathPlanner(std::unique_ptr<NUClear::Environment> environment);
     };


### PR DESCRIPTION
Updated SimpleWalkPathPlanner to use a switch case and a couple of void utility functions to tidy up the code and make it simpler to make changes to the behavior of the path planning at a higher level. I also added some extra content and documentation hooks.

I expect I've made a few mistakes or implemented it incorrectly, please let me know here so I can fix them up and learn best practices. Thanks!