### PR TITLE
Removes second function that does the same thing in head kinematics.

### DIFF
--- a/module/behaviour/skills/HeadBehaviourSoccer/src/HeadBehaviourSoccer.cpp
+++ b/module/behaviour/skills/HeadBehaviourSoccer/src/HeadBehaviourSoccer.cpp
@@ -58,7 +58,7 @@ namespace module::behaviour::skills {
     using utility::input::ServoID;
     using utility::math::coordinates::sphericalToCartesian;
     using utility::math::geometry::Quad;
-    using utility::motion::kinematics::calculateCameraLookJoints;
+    using utility::motion::kinematics::calculateHeadJoints;
     using utility::support::Expression;
 
     inline Eigen::Vector2d screenAngularFromObjectDirection(const Eigen::Vector3d& v) {
@@ -479,7 +479,7 @@ namespace module::behaviour::skills {
         // Rotate target angles to World space
         Eigen::Vector3d lookVector = headToIMUSpace * lookVectorFromHead;
         // Compute inverse kinematics for head direction angles
-        std::vector<std::pair<ServoID, double>> goalAngles = calculateCameraLookJoints(lookVector);
+        std::vector<std::pair<ServoID, float>> goalAngles = calculateHeadJoints(lookVector);
 
         Eigen::Vector2d result;
         for (auto& angle : goalAngles) {

--- a/shared/utility/motion/InverseKinematics.cpp
+++ b/shared/utility/motion/InverseKinematics.cpp
@@ -337,22 +337,13 @@ namespace utility::motion::kinematics {
         joints.insert(joints.end(), joints2.begin(), joints2.end());
         return joints;
     }
-    std::vector<std::pair<ServoID, double>> calculateCameraLookJoints(const Eigen::Vector3d& cameraUnitVector) {
-        std::vector<std::pair<ServoID, double>> positions;
-        positions.push_back(std::make_pair(ServoID::HEAD_YAW, std::atan2(cameraUnitVector.y(), cameraUnitVector.x())));
+    std::vector<std::pair<ServoID, float>> calculateHeadJoints(const Eigen::Vector3f& cameraUnitVector) {
+        std::vector<std::pair<ServoID, float>> positions;
+        positions.push_back(std::make_pair(ServoID::HEAD_YAW, atan2(cameraUnitVector.y(), cameraUnitVector.x())));
         positions.push_back(std::make_pair(ServoID::HEAD_PITCH,
                                            std::atan2(-cameraUnitVector.z(),
                                                       std::sqrt(cameraUnitVector.x() * cameraUnitVector.x()
                                                                 + cameraUnitVector.y() * cameraUnitVector.y()))));
-        return positions;
-    }
-    std::vector<std::pair<ServoID, float>> calculateHeadJoints(Eigen::Vector3f cameraUnitVector) {
-        std::vector<std::pair<ServoID, float>> positions;
-        positions.push_back(std::make_pair(ServoID::HEAD_YAW, atan2(cameraUnitVector[1], cameraUnitVector[0])));
-        positions.push_back(std::make_pair(
-            ServoID::HEAD_PITCH,
-            atan2(-cameraUnitVector[2],
-                  std::sqrt(cameraUnitVector[0] * cameraUnitVector[0] + cameraUnitVector[1] * cameraUnitVector[1]))));
         return positions;
     }
 

--- a/shared/utility/motion/InverseKinematics.hpp
+++ b/shared/utility/motion/InverseKinematics.hpp
@@ -68,10 +68,7 @@ namespace utility::motion::kinematics {
         const Eigen::Affine3f& leftTarget,
         const Eigen::Affine3f& rightTarget);
 
-    [[nodiscard]] std::vector<std::pair<ServoID, double>> calculateCameraLookJoints(
-        const Eigen::Vector3d& cameraUnitVector);
-
-    [[nodiscard]] std::vector<std::pair<ServoID, float>> calculateHeadJoints(Eigen::Vector3f cameraUnitVector);
+    [[nodiscard]] std::vector<std::pair<ServoID, float>> calculateHeadJoints(const Eigen::Vector3f& cameraUnitVector);
 
 }  // namespace utility::motion::kinematics
 


### PR DESCRIPTION
So pretty sure both `calculateCameraLookJoints` and `calculateHeadJoints` are the same functions but one is float and the other is double, although they have some strange stylistic differences as well.
This just removes `calculateCameraLookJoints` and changes so we just use `calculateHeadJoints` in place of that.

Please tell me if this is good or if I need to sleep 😬 