### PR TITLE
Treat messages with id fields as distinct message types in NUsight packet filter

### DIFF
--- a/nusight2/.gitignore
+++ b/nusight2/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 # Generated protocol buffer files
 /src/shared/messages.js
 /src/shared/messages.d.ts
+src/shared/message_fields_index.ts
 
 # NBS recordings
 /recordings

--- a/nusight2/build_scripts/generate_messages.js
+++ b/nusight2/build_scripts/generate_messages.js
@@ -1,48 +1,243 @@
+const fs = require('fs')
 const path = require('path')
 const pbjs = require('protobufjs/cli/pbjs')
 const pbts = require('protobufjs/cli/pbts')
 
-const REPO_ROOT = path.resolve(__dirname, '..', '..');
-const NUSIGHT_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+const NUSIGHT_ROOT = path.resolve(__dirname, '..')
 
-const messagesDir = path.join(REPO_ROOT, 'shared/message')
-const nuclearMessagesDir = path.join(REPO_ROOT, 'nuclear/message/proto')
-const googleMessagesDir = path.join(NUSIGHT_ROOT, 'src/shared/proto')
+const messagesDir = path.resolve(REPO_ROOT, 'shared/message')
+const nuclearMessagesDir = path.resolve(REPO_ROOT, 'nuclear/message/proto')
+const googleMessagesDir = path.resolve(NUSIGHT_ROOT, 'src/shared/proto')
 
-const messagesOutputDir = path.join(NUSIGHT_ROOT, 'src/shared')
-const messagesFileJs = path.join(messagesOutputDir, 'messages.js')
-const messagesFileTs = path.join(messagesOutputDir, 'messages.d.ts')
+const messageSourceDirs = [messagesDir, nuclearMessagesDir, googleMessagesDir]
 
-const argsJs = [
-  '--target', 'static-module',
-  '--wrap', 'commonjs',
-  '--out', messagesFileJs,
-  '--path', messagesDir,
-  '--path', nuclearMessagesDir,
-  '--path', googleMessagesDir,
+const messageSourceFiles = [
   `${messagesDir}/**/*.proto`,
   `${nuclearMessagesDir}/**/*.proto`,
   `${googleMessagesDir}/**/*.proto`,
 ]
 
-const argsTs = [
-  messagesFileJs,
-  '--out', messagesFileTs,
-  '--name',
-]
+function generateMessagesJs(outputFilePath) {
+  // prettier-ignore
+  const args = [
+    '--target', 'static-module',
+    '--wrap', 'commonjs',
+    '--out', outputFilePath,
+    ...messageSourceDirs.map(dir => ['--path', dir]).flat(),
+    ...messageSourceFiles
+  ]
 
-pbjs.main(argsJs, (err, output) => {
-  if (err) {
-    console.error(err)
-  } else {
-    console.log(`Generated JS: ${messagesFileJs}`)
-
-    pbts.main(argsTs, (err, output) => {
+  return new Promise((resolve, reject) => {
+    pbjs.main(args, err => {
       if (err) {
-        console.error(err)
+        reject(err)
       } else {
-        console.log(`Generated TS: ${messagesFileTs}`)
+        console.log(`Generated JS: ${outputFilePath}`)
+        resolve()
       }
     })
+  })
+}
+
+function generateMessagesTs(inputFilePath, outputFilePath) {
+  // prettier-ignore
+  const args = [
+    inputFilePath,
+    '--out', outputFilePath,
+    '--name', '',
+  ]
+
+  return new Promise((resolve, reject) => {
+    pbts.main(args, err => {
+      if (err) {
+        reject(err)
+      } else {
+        console.log(`Generated TS: ${outputFilePath}`)
+        resolve()
+      }
+    })
+  })
+}
+
+function generateMessageFields() {
+  // prettier-ignore
+  const args = [
+    '--target', 'json',
+    ...messageSourceDirs.map(dir => ['--path', dir]).flat(),
+    ...messageSourceFiles
+  ]
+
+  return new Promise((resolve, reject) => {
+    pbjs.main(args, function (err, output) {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(JSON.parse(output))
+      }
+    })
+  })
+}
+
+async function generateMessageFieldsIndex(outputFilePath) {
+  const messageFieldsDesc = await generateMessageFields()
+
+  const index = indexMessageFields(messageFieldsDesc, ['id'])
+
+  const types = `
+export interface MessageField {
+  wireType: number
+  type: string
+  id: number
+}
+
+export interface MessageFieldsIndex {
+  [messageName: string]: {
+    [fieldName: string]: MessageField
   }
-})
+}
+  `.trim()
+
+  const file =
+    types +
+    '\n\n' +
+    'export const messageFieldsIndex: MessageFieldsIndex = ' +
+    JSON.stringify(index, null, '  ')
+
+  await fs.promises.writeFile(outputFilePath, file)
+
+  console.log(`Generated message fields index: ${outputFilePath}`)
+}
+
+function indexMessageFields(messagesDesc, fieldsToIndex) {
+  const index = {}
+
+  processIndex(messagesDesc, index, {
+    parentKey: '',
+    messagePath: '',
+    fieldsToIndex,
+  })
+
+  return index
+}
+
+// Data types to protobuf wire types
+const protobufWireTypes = {
+  // Varint fields
+  int32: 0,
+  int64: 0,
+  uint32: 0,
+  uint64: 0,
+  sint32: 0,
+  sint64: 0,
+  bool: 0,
+  enum: 0,
+
+  // 64-bit fields
+  fixed64: 1,
+  sfixed64: 1,
+  double: 1,
+
+  // Length-delimited fields
+  string: 2,
+  bytes: 2,
+
+  // Note: wire types for composite fields (i.e. embedded messages, groups, packed repeated fields)
+  // are omitted from this list
+
+  // 32-bit fields
+  fixed32: 5,
+  sfixed32: 5,
+  float: 5,
+}
+
+/**
+ * The protobuf.js JSON description object has the following shape:
+ *    {
+ *      "nested": {
+ *        "namespaceA": {
+ *          "nested": {
+ *            "namespaceB": {
+ *              "nested": {
+ *                "MessageTypeA": {
+ *                  "fields": {
+ *                    "fieldA": {
+ *                      "type": "double",
+ *                      "id": 1
+ *                    },
+ *                    "fieldB": {
+ *                      "type": "uint32",
+ *                      "id": 2
+ *                    }
+ *                  },
+ *                  "nested": {
+ *                    "SubMessageA": {...},
+ *                    "SubMessageB": {...}
+ *                  }
+ *                },
+ *                "MessageTypeB": {...}
+ *              }
+ *            }
+ *          }
+ *        }
+ *      }
+ *    }
+ *
+ * This function walks the description and flattens it into an index object where the keys are
+ * fully-qualified message names, and the values are descriptions of the indexed fields.
+ */
+function processIndex(descNode, index, { parentKey, messagePath, fieldsToIndex }) {
+  for (const [nodeKey, nodeValue] of Object.entries(descNode)) {
+    // If the key is 'fields', we've arrived at the fields for a message
+    if (nodeKey === 'fields') {
+      for (const [fieldName, fieldDesc] of Object.entries(nodeValue)) {
+        // Skip to the next field if this field is not in the list of fields to index
+        if (!fieldsToIndex.includes(fieldName)) {
+          continue
+        }
+        // Otherwise add the field to the message it belongs to in the index
+        else {
+          const indexEntry = index[messagePath] ?? {}
+
+          indexEntry[fieldName] = fieldDesc
+          indexEntry[fieldName].wireType = protobufWireTypes[fieldDesc.type] ?? -1
+
+          index[messagePath] = indexEntry
+        }
+      }
+    }
+
+    // We've arrived at a node that has nested nodes. This could be a namespace,
+    // or a message that has sub messages: process it recursively.
+    else if (nodeKey === 'nested') {
+      processIndex(nodeValue, index, { messagePath, parentKey: nodeKey, fieldsToIndex })
+    }
+
+    // The description node we're processing came from the key 'nested', so it will have
+    // messages as its direct children. Process them here recursively, appending the
+    // current node's key to the message path.
+    else if (parentKey === 'nested') {
+      processIndex(nodeValue, index, {
+        messagePath: messagePath.length === 0 ? nodeKey : `${messagePath}.${nodeKey}`,
+        parentKey: nodeKey,
+        fieldsToIndex,
+      })
+    }
+  }
+}
+
+async function main() {
+  const messagesOutputDir = path.resolve(NUSIGHT_ROOT, 'src/shared')
+
+  const messagesJsFile = path.join(messagesOutputDir, 'messages.js')
+  const messagesTsFile = path.join(messagesOutputDir, 'messages.d.ts')
+  const messagesIndexFile = path.join(messagesOutputDir, 'message_fields_index.ts')
+
+  generateMessagesJs(messagesJsFile).then(() => {
+    generateMessagesTs(messagesJsFile, messagesTsFile)
+  })
+
+  await generateMessageFieldsIndex(messagesIndexFile)
+}
+
+main()


### PR DESCRIPTION
This updates the NUsight server-side packet filter to handle messages with `id` fields by treating the same message types with different `id`s the same way it treats different message types.

This allows the LRU packet processor to handle every message of the same type with different IDs fairly, without getting stuck forwarding packets with one specific ID based on the arrival timing.

Fixes #653.

### Comparison

This comparison shows the packets we get in the browser on the vision tab, before and after the changes in this PR.

![Comparison image](https://user-images.githubusercontent.com/5924865/132502486-f2ee7f23-6bfd-42e5-a486-d7c4224e1e83.png)

### Performance impact

I did the following optimisations to reduce the overhead introduced by decoding the id, since this is done for every unreliable packet:

- Generate an index of all protobuf messages with ID fields at compile time, via `yarn protobuf`
- Use the index at runtime to quickly skip any messages without an `id` field, without attempting to decode
- Decode just the `id` field instead of the whole proto, by making direct use of the optimised [Reader class from protobuf.js](https://github.com/protobufjs/protobuf.js/blob/v6.9.0/src/reader.js). I initially wrote my own reader, but I found it was just naively duplicating functions from that class.

The overhead of the decode step is roughly **0.007** to **0.029 ms** from my measurements (on a laptop with Intel i5-8400 2.80 Ghz).

<details>
<summary>View timings of sample runs</summary>

```
decodePacketId: 0.02ms
decodePacketId: 0.008ms
decodePacketId: 0.008ms
decodePacketId: 0.007ms
decodePacketId: 0.007ms
decodePacketId: 0.017ms
decodePacketId: 0.017ms
decodePacketId: 0.01ms
decodePacketId: 0.009ms
decodePacketId: 0.016ms
decodePacketId: 0.008ms
decodePacketId: 0.018ms
decodePacketId: 0.033ms
decodePacketId: 0.011ms
decodePacketId: 0.01ms
decodePacketId: 0.01ms
decodePacketId: 0.008ms
decodePacketId: 0.016ms
decodePacketId: 0.039ms
decodePacketId: 0.015ms
decodePacketId: 0.011ms
decodePacketId: 0.008ms
decodePacketId: 0.007ms
decodePacketId: 0.018ms
decodePacketId: 0.029ms
decodePacketId: 0.02ms
decodePacketId: 0.011ms
decodePacketId: 0.011ms
decodePacketId: 0.009ms
decodePacketId: 0.018ms
decodePacketId: 0.025ms
decodePacketId: 0.014ms
decodePacketId: 0.011ms
decodePacketId: 0.009ms
decodePacketId: 0.008ms
decodePacketId: 0.016ms
decodePacketId: 0.039ms
decodePacketId: 0.013ms
decodePacketId: 0.009ms
decodePacketId: 0.007ms
decodePacketId: 0.007ms
decodePacketId: 0.025ms
decodePacketId: 0.014ms
decodePacketId: 0.011ms
decodePacketId: 0.012ms
decodePacketId: 0.011ms
decodePacketId: 0.009ms
decodePacketId: 0.038ms
decodePacketId: 0.035ms
decodePacketId: 0.025ms
decodePacketId: 0.022ms
decodePacketId: 0.025ms
decodePacketId: 0.021ms
decodePacketId: 0.021ms
decodePacketId: 0.02ms
decodePacketId: 0.01ms
decodePacketId: 0.016ms
decodePacketId: 0.009ms
decodePacketId: 0.013ms
decodePacketId: 0.015ms
decodePacketId: 0.04ms
decodePacketId: 0.012ms
decodePacketId: 0.009ms
decodePacketId: 0.007ms
decodePacketId: 0.007ms
decodePacketId: 0.018ms
decodePacketId: 0.011ms
decodePacketId: 0.012ms
decodePacketId: 0.01ms
decodePacketId: 0.009ms
decodePacketId: 0.008ms
decodePacketId: 0.018ms
decodePacketId: 0.029ms
decodePacketId: 0.015ms
decodePacketId: 0.014ms
decodePacketId: 0.018ms
decodePacketId: 0.01ms
decodePacketId: 0.016ms
decodePacketId: 0.022ms
decodePacketId: 0.013ms
decodePacketId: 0.01ms
decodePacketId: 0.009ms
decodePacketId: 0.008ms
decodePacketId: 0.018ms
decodePacketId: 0.028ms
decodePacketId: 0.011ms
decodePacketId: 0.012ms
decodePacketId: 0.009ms
decodePacketId: 0.008ms
decodePacketId: 0.016ms
decodePacketId: 0.03ms
decodePacketId: 0.019ms
decodePacketId: 0.008ms
decodePacketId: 0.007ms
decodePacketId: 0.007ms
decodePacketId: 0.025ms
decodePacketId: 0.02ms
decodePacketId: 0.009ms
decodePacketId: 0.009ms
decodePacketId: 0.008ms
decodePacketId: 0.007ms
decodePacketId: 0.02ms
decodePacketId: 0.023ms
decodePacketId: 0.015ms
decodePacketId: 0.015ms
decodePacketId: 0.011ms
decodePacketId: 0.009ms
decodePacketId: 0.018ms
decodePacketId: 0.039ms
decodePacketId: 0.011ms
decodePacketId: 0.009ms
decodePacketId: 0.008ms
decodePacketId: 0.01ms
decodePacketId: 0.017ms
decodePacketId: 0.04ms
decodePacketId: 0.014ms
decodePacketId: 0.009ms
decodePacketId: 0.008ms
decodePacketId: 0.008ms
decodePacketId: 0.02ms
decodePacketId: 0.019ms
decodePacketId: 0.011ms
decodePacketId: 0.009ms
decodePacketId: 0.017ms
decodePacketId: 0.01ms
```
</details>