### PR TITLE
Fix the NUsight docker container

### DIFF
--- a/nusight2/docker-compose.yml
+++ b/nusight2/docker-compose.yml
@@ -3,9 +3,9 @@ services:
   nusight:
     image: node:14
     volumes:
-      - .:/var/www/NUsight2
-      - node_modules_volume:/var/www/NUsight2/node_modules
-    working_dir: /var/www/NUsight2
+      - ../:/var/www/NUbots
+      - node_modules_volume:/var/www/NUbots/nusight2/node_modules
+    working_dir: /var/www/NUbots/nusight2
 networks:
   default:
     external:


### PR DESCRIPTION
Currently, the [`generate_messages.js`](https://github.com/NUbots/NUbots/blob/main/nusight2/build_scripts/generate_messages.js) script can't find the proto files in the docker container, since only the `nusight2`folder is mounted. This mounts the top-level NUbots folder as well, which fixes the issue.

The change to mono repo broke the script and we didn't notice.