### PR TITLE
Removes Unused and Unnecessary PortAudio Dep

### DIFF
--- a/cmake/Modules/FindPortAudio.cmake
+++ b/cmake/Modules/FindPortAudio.cmake
@@ -1,6 +1,0 @@
-include(ToolchainLibraryFinder)
-ToolchainLibraryFinder(
-  NAME PortAudio
-  HEADER portaudio.h
-  LIBRARY portaudio
-)

--- a/cmake/Modules/FindeSpeak.cmake
+++ b/cmake/Modules/FindeSpeak.cmake
@@ -3,9 +3,6 @@ include(ToolchainLibraryFinder)
 # Find ALSA for eSpeak
 find_package(ALSA REQUIRED)
 
-# Find PortAudio for eSpeak
-find_package(PortAudio REQUIRED)
-
 ToolchainLibraryFinder(
   NAME eSpeak
   HEADER espeak/speak_lib.h

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -260,7 +260,6 @@ RUN install-from-source https://github.com/ianlancetaylor/libbacktrace/archive/m
 # Alsa and espeak
 RUN install-from-source ftp://ftp.alsa-project.org/pub/lib/alsa-lib-1.2.1.2.tar.bz2 \
     --without-debug
-RUN install-from-source https://github.com/espeak-ng/pcaudiolib/archive/1.1.tar.gz
 COPY usr/local/package/espeak.sh /usr/local/package/espeak.sh
 RUN /usr/local/package/espeak.sh https://github.com/espeak-ng/espeak-ng/releases/download/1.50/espeak-ng-1.50.tgz
 


### PR DESCRIPTION
### Removes PortAudio

This dependency may have been previously required by eSpeak. However, it has been superseded by `pcaudio`, which isn't required by the version of eSpeak we use.