### PR TITLE
Add clearing of filtered_sensors after each loop

### DIFF
--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -238,6 +238,8 @@ namespace module::input {
 
                         // Accumulator CoM readings
                         rMFt += calculateCentreOfMass(model, filtered_sensors->Htx).head<3>() + rTFt;
+
+                        filtered_sensors->servo.clear();
                     }
 
                     // Average all accumulated readings

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -210,34 +210,34 @@ namespace module::input {
                         for (uint32_t id = 0; id < 20; ++id) {
                             auto& original = utility::platform::getRawServo(id, *s);
                             // Add the sensor values to the system properly
-                            filtered_sensors->servo.push_back({0,
-                                                               id,
-                                                               original.torque_enabled,
-                                                               original.p_gain,
-                                                               original.i_gain,
-                                                               original.d_gain,
-                                                               original.goal_position,
-                                                               original.moving_speed,
-                                                               original.present_position,
-                                                               original.present_speed,
-                                                               original.load,
-                                                               original.voltage,
-                                                               static_cast<float>(original.temperature)});
+                            filtered_sensors.servo.push_back({0,
+                                                              id,
+                                                              original.torque_enabled,
+                                                              original.p_gain,
+                                                              original.i_gain,
+                                                              original.d_gain,
+                                                              original.goal_position,
+                                                              original.moving_speed,
+                                                              original.present_position,
+                                                              original.present_speed,
+                                                              original.load,
+                                                              original.voltage,
+                                                              static_cast<float>(original.temperature)});
                         }
 
                         // Calculate forward kinematics
-                        const auto Htx = calculateAllPositions(model, *filtered_sensors);
+                        const auto Htx = calculateAllPositions(model, filtered_sensors);
                         for (const auto& entry : Htx) {
-                            filtered_sensors->Htx[entry.first] = entry.second.matrix();
+                            filtered_sensors.Htx[entry.first] = entry.second.matrix();
                         }
 
                         // Calculate the average length of both legs from the torso and accumulate this measurement
-                        const Eigen::Affine3d Htr(filtered_sensors->Htx[ServoID::R_ANKLE_ROLL]);
-                        const Eigen::Affine3d Htl(filtered_sensors->Htx[ServoID::L_ANKLE_ROLL]);
+                        const Eigen::Affine3d Htr(filtered_sensors.Htx[ServoID::R_ANKLE_ROLL]);
+                        const Eigen::Affine3d Htl(filtered_sensors.Htx[ServoID::L_ANKLE_ROLL]);
                         const Eigen::Vector3d rTFt = (Htr.translation() + Htl.translation()) * 0.5;
 
                         // Accumulator CoM readings
-                        rMFt += calculateCentreOfMass(model, filtered_sensors->Htx).head<3>() + rTFt;
+                        rMFt += calculateCentreOfMass(model, filtered_sensors.Htx).head<3>() + rTFt;
                     }
 
                     // Average all accumulated readings

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -201,7 +201,7 @@ namespace module::input {
                     Eigen::Vector3d rMFt = Eigen::Vector3d::Zero();
 
                     for (const auto& s : sensors) {
-                        auto filtered_sensors = Sensors();
+                        Sensors filtered_sensors{};
 
                         // Accumulate accelerometer and gyroscope readings
                         acc += s->accelerometer.cast<double>();

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -201,8 +201,7 @@ namespace module::input {
                     Eigen::Vector3d rMFt = Eigen::Vector3d::Zero();
 
                     for (const auto& s : sensors) {
-
-                        auto filtered_sensors = std::make_unique<Sensors>();
+                        auto filtered_sensors = Sensors();
 
                         // Accumulate accelerometer and gyroscope readings
                         acc += s->accelerometer.cast<double>();

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -196,16 +196,17 @@ namespace module::input {
             [this](const std::list<std::shared_ptr<const RawSensors>>& sensors, const KinematicsModel& model) {
                 // If we need to reset the filter, do that here
                 if (reset_filter.load()) {
-                    Eigen::Vector3d acc   = Eigen::Vector3d::Zero();
-                    Eigen::Vector3d gyro  = Eigen::Vector3d::Zero();
-                    Eigen::Vector3d rMFt  = Eigen::Vector3d::Zero();
-                    auto filtered_sensors = std::make_unique<Sensors>();
+                    Eigen::Vector3d acc  = Eigen::Vector3d::Zero();
+                    Eigen::Vector3d gyro = Eigen::Vector3d::Zero();
+                    Eigen::Vector3d rMFt = Eigen::Vector3d::Zero();
 
                     for (const auto& s : sensors) {
+
+                        auto filtered_sensors = std::make_unique<Sensors>();
+
                         // Accumulate accelerometer and gyroscope readings
                         acc += s->accelerometer.cast<double>();
                         gyro += s->gyroscope.cast<double>();
-
                         // Make sure we have servo positions
                         for (uint32_t id = 0; id < 20; ++id) {
                             auto& original = utility::platform::getRawServo(id, *s);
@@ -238,8 +239,6 @@ namespace module::input {
 
                         // Accumulator CoM readings
                         rMFt += calculateCentreOfMass(model, filtered_sensors->Htx).head<3>() + rTFt;
-
-                        filtered_sensors->servo.clear();
                     }
 
                     // Average all accumulated readings


### PR DESCRIPTION
**Add clearing of filtered_sensors after each loop in sensor filter**
filtered sensors was not cleared after each loop through the sensors when resetting the sensor filter. This makes sure it is cleared after using it to calculate forward kinematics and averages on a iteration