### PR TITLE
Add Log Level to Webots DataLogging

### DIFF
--- a/module/support/logging/DataLogging/data/config/webotsrobocup/DataLogging.yaml
+++ b/module/support/logging/DataLogging/data/config/webotsrobocup/DataLogging.yaml
@@ -1,3 +1,5 @@
+log_level: WARN
+
 output:
   directory: log
   split_size: 5 * GiB


### PR DESCRIPTION
### Add Log Level to Webots DataLogging

Fixes YAML expression error from DataLogging due to missing field
