### PR TITLE
Disable/enable the walk on getup

### DIFF
--- a/module/behaviour/skills/Getup/README.md
+++ b/module/behaviour/skills/Getup/README.md
@@ -20,6 +20,8 @@ Include this module to allow the robot to get up after it has fallen over.
 - `extension::ExecuteScriptByName` to run getup and stand scripts
 - `message::motion::ExecuteGetup` instigates a getup
 - `message::motion::KillGetup` stops a getup
+- `message::motion::DisableWalkEngineCommand` stops the walk engine while getting up
+- `message::motion::EnableWalkEngineCommand` enables the walk engine when finished getting up
 - `utility::behaviour::ActionPriorities` signals when the module's priority changes
 - `utility::behaviour::RegisterAction` registers callbacks for starting or stopping getups
 

--- a/module/behaviour/skills/Getup/src/Getup.cpp
+++ b/module/behaviour/skills/Getup/src/Getup.cpp
@@ -27,6 +27,7 @@
 
 #include "message/behaviour/ServoCommand.hpp"
 #include "message/motion/GetupCommand.hpp"
+#include "message/motion/WalkCommand.hpp"
 #include "message/platform/RawSensors.hpp"
 
 #include "utility/behaviour/Action.hpp"
@@ -37,6 +38,8 @@ namespace module::behaviour::skills {
     using extension::Configuration;
     using extension::ExecuteScriptByName;
 
+    using message::motion::DisableWalkEngineCommand;
+    using message::motion::EnableWalkEngineCommand;
     using message::motion::ExecuteGetup;
     using message::motion::KillGetup;
     using message::platform::RawSensors;
@@ -87,6 +90,7 @@ namespace module::behaviour::skills {
 
         on<Trigger<ExecuteGetup>, Single>().then("Execute Getup", [this]() {
             gettingUp = true;
+            emit(std::make_unique<DisableWalkEngineCommand>(id));
 
             // Check with side we're getting up from
             if (isFront) {
@@ -104,6 +108,7 @@ namespace module::behaviour::skills {
 
         on<Trigger<KillGetup>>().then([this] {
             gettingUp = false;
+            emit(std::make_unique<EnableWalkEngineCommand>(id));
             updatePriority(0);
         });
 


### PR DESCRIPTION
When the get up happens, the walk engine just keeps running (although the servo commands aren't used). 
I think we should disable the walk engine while getting up, and reenable it when the get up is killed. This PR makes that change. 

While I don't see any affect on the QuinticWalk, this is useful for resetting the Static Walk when the get up is finished. 
I'm wondering if this could be achieve a different way if there's method to execute code when a module gains/loses control, or if that's just a Director thing. 
Regardless though it should add the benefit of improving performance from not running the walk when unnecessary?

Not 100% sure on this solution to the problem. 