### PR TITLE
Update robocup ecr url and set env vars correctly

### DIFF
--- a/docker/nugus_sim/run.py
+++ b/docker/nugus_sim/run.py
@@ -10,8 +10,9 @@ import ruamel.yaml
 DEFAULT_BINARIES_DIR = os.path.abspath(os.path.join(os.sep, "home", "nubots", "NUbots", "binaries"))
 DEFAULT_CONFIG_DIR = os.path.join(DEFAULT_BINARIES_DIR, "config")
 
-REQUIRED_ENV_VARS = ("ROBOCUP_ROBOT_ID", "ROBOCUP_TEAM_ID", "ROBOCUP_TEAM_COLOR", "ROBOCUP_SIMULATOR_ADDR")
+REQUIRED_ENV_VARS = ("ROBOCUP_ROBOT_ID", "ROBOCUP_TEAM_COLOR", "ROBOCUP_SIMULATOR_ADDR")
 OPTIONAL_ENV_VARS = (
+    "ROBOCUP_TEAM_ID",
     "ROBOCUP_TEAM_PLAYER1_IP",
     "ROBOCUP_TEAM_PLAYER2_IP",
     "ROBOCUP_TEAM_PLAYER3_IP",
@@ -88,10 +89,9 @@ def update_config_files(args: dict) -> None:
     # Change into the config directory
     os.chdir(args["config_dir"])
 
-    # Set `player_id` and `team_id` in GlobalConfig.yaml from ROBOCUP_ROBOT_ID and ROBOCUP_TEAM_ID
+    # Set `player_id` in GlobalConfig.yaml from ROBOCUP_ROBOT_ID
     global_config = read_config("GlobalConfig.yaml")
     global_config["player_id"] = int(env_vars["ROBOCUP_ROBOT_ID"])
-    global_config["team_id"] = int(env_vars["ROBOCUP_TEAM_ID"])
     write_config("GlobalConfig.yaml", global_config)
 
     # Set `player_id` in GameController.yaml from ROBOCUP_ROBOT_ID
@@ -108,6 +108,12 @@ def update_config_files(args: dict) -> None:
     webots_config["server_address"] = address
     webots_config["port"] = int(port)
     write_config("webots.yaml", webots_config)
+
+    # Set `team_id` if it is provided
+    if "ROBOCUP_TEAM_ID" in env_vars:
+        global_config = read_config("GlobalConfig.yaml")
+        global_config["team_id"] = int(env_vars["ROBOCUP_TEAM_ID"])
+        write_config("GlobalConfig.yaml", global_config)
 
     # Configure logging to /robocup-logs if it exists
     if os.path.exists("/robocup-logs"):

--- a/tools/webots.py
+++ b/tools/webots.py
@@ -23,7 +23,7 @@ random.seed(datetime.now())
 # The docker image details for Robocup
 ROBOCUP_IMAGE_NAME = "robocup-vhsc-nubots"  # Provided by the TC and shouldn't be changed
 ROBOCUP_IMAGE_TAG = "robocup2021"  # Submitted in our team_config.json, shouldn't be changed here unless changed there
-ROBOCUP_IMAGE_REGISTRY = "834282931378.dkr.ecr.us-east-1.amazonaws.com/cbr2021-nubots"  # Provided by the TC
+ROBOCUP_IMAGE_REGISTRY = "047817357099.dkr.ecr.us-east-2.amazonaws.com/hl-vs-nubots"  # Provided by the TC
 
 # NUbots RoboCup team ID
 NUBOTS_TEAM_ID = 12


### PR DESCRIPTION
 - Update the ECR URL with the one provided by TC
 - Only set `ROBOCUP_TEAM_ID` env var if it is provided