### PR TITLE
Add pacman config to the sim Dockerfile

### DIFF
--- a/docker/Dockerfile.nugus_sim
+++ b/docker/Dockerfile.nugus_sim
@@ -4,6 +4,7 @@ WORKDIR /home/nubots/NUbots
 
 # Add a script that installs packages
 COPY /usr/local/bin/install-package /usr/local/bin/install-package
+COPY etc/pacman/pacman.latest.conf /etc/pacman.latest.conf
 
 # Install base packages needed for building general toolchain
 # If you have a tool that's needed for a specific module install it before that module


### PR DESCRIPTION
In #779 `etc/pacman/pacman.latest.conf` and `/etc/pacman.latest.conf` were added in the Docker container to be used by `install_script` when updating keys. 
`install_script` is also used by `Dockerfile.nugus_sim`. `Dockerfile.nugus_sim` wasn't changed to add the previously mentioned config files.
This results in an error when building because it can't find the config file.
Adding in the copy line results in a successful build. 