### PR TITLE
Add a mutex to the clock to prevent race condition

### DIFF
--- a/shared/clock/clock.cpp
+++ b/shared/clock/clock.cpp
@@ -2,6 +2,7 @@
 #include "clock.hpp"
 
 #include <chrono>
+#include <mutex>
 
 namespace utility::clock {
 
@@ -10,13 +11,15 @@ namespace utility::clock {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     NUClear::base_clock::time_point last_update = NUClear::base_clock::now();
     NUClear::base_clock::time_point state       = last_update;
-
+    std::mutex mutex;
 }  // namespace utility::clock
 
 namespace NUClear {
     clock::time_point clock::now() {
+        // Prevent another instance of this function running at the same time
+        std::lock_guard<std::mutex> lock(utility::clock::mutex);
 
-        // now is multiplied by the real time factor to sync
+        // Now is multiplied by the real time factor to sync
         // NUClear with the simulation time
         auto now   = NUClear::base_clock::now();
         auto delta = std::chrono::duration_cast<std::chrono::steady_clock::duration>((now - utility::clock::last_update)


### PR DESCRIPTION
The real robot cannot walk properly on the main branch. The clock change from RoboCup has broken the walk. The walk uses the difference between now and the last time update, but this difference was becoming increasingly large over time until after around 1-2 seconds it was too large and the QuinticWalk refuses to do anything more. 

The problem is that there is a race condition in the clock. I put in a mutex and now it's working on the real robot.
I've checked Webots and its still working fine there too.