### PR TITLE
Updated PS3 controller button codes.

### DIFF
--- a/module/behaviour/strategy/PS3Walk/src/PS3Walk.hpp
+++ b/module/behaviour/strategy/PS3Walk/src/PS3Walk.hpp
@@ -33,31 +33,28 @@ namespace module::behaviour::strategy {
         // axes
         static constexpr uint AXIS_LEFT_JOYSTICK_HORIZONTAL  = 0;
         static constexpr uint AXIS_LEFT_JOYSTICK_VERTICAL    = 1;
-        static constexpr uint AXIS_RIGHT_JOYSTICK_HORIZONTAL = 2;
-        static constexpr uint AXIS_RIGHT_JOYSTICK_VERTICAL   = 3;
-        static constexpr uint AXIS_L2                        = 12;
-        static constexpr uint AXIS_R2                        = 13;
-        static constexpr uint AXIS_ACCEL_Y                   = 23;
-        static constexpr uint AXIS_ACCEL_X                   = 24;
-        static constexpr uint AXIS_ACCEL_Z                   = 25;
+        static constexpr uint AXIS_RIGHT_JOYSTICK_HORIZONTAL = 3;
+        static constexpr uint AXIS_RIGHT_JOYSTICK_VERTICAL   = 4;
+        static constexpr uint AXIS_L2                        = 2;
+        static constexpr uint AXIS_R2                        = 5;
 
         // buttons
-        static constexpr uint BUTTON_SELECT         = 0;
-        static constexpr uint BUTTON_LEFT_JOYSTICK  = 1;
-        static constexpr uint BUTTON_RIGHT_JOYSTICK = 2;
-        static constexpr uint BUTTON_START          = 3;
-        static constexpr uint BUTTON_DPAD_UP        = 4;
-        static constexpr uint BUTTON_DPAD_RIGHT     = 5;
-        static constexpr uint BUTTON_DPAD_DOWN      = 6;
-        static constexpr uint BUTTON_DPAD_LEFT      = 7;
-        static constexpr uint BUTTON_L2             = 8;
-        static constexpr uint BUTTON_R2             = 9;
-        static constexpr uint BUTTON_L1             = 10;
-        static constexpr uint BUTTON_R1             = 11;
-        static constexpr uint BUTTON_TRIANGLE       = 12;
-        static constexpr uint BUTTON_CIRCLE         = 13;
-        static constexpr uint BUTTON_CROSS          = 14;
-        static constexpr uint BUTTON_SQUARE         = 15;
+        static constexpr uint BUTTON_SELECT         = 8;
+        static constexpr uint BUTTON_LEFT_JOYSTICK  = 11;
+        static constexpr uint BUTTON_RIGHT_JOYSTICK = 12;
+        static constexpr uint BUTTON_START          = 9;
+        static constexpr uint BUTTON_DPAD_UP        = 13;
+        static constexpr uint BUTTON_DPAD_RIGHT     = 16;
+        static constexpr uint BUTTON_DPAD_DOWN      = 14;
+        static constexpr uint BUTTON_DPAD_LEFT      = 15;
+        static constexpr uint BUTTON_L2             = 6;
+        static constexpr uint BUTTON_R2             = 7;
+        static constexpr uint BUTTON_L1             = 4;
+        static constexpr uint BUTTON_R1             = 5;
+        static constexpr uint BUTTON_TRIANGLE       = 2;
+        static constexpr uint BUTTON_CIRCLE         = 1;
+        static constexpr uint BUTTON_CROSS          = 0;
+        static constexpr uint BUTTON_SQUARE         = 3;
 
         /// @brief Called by the powerplant to build and setup the PS3Walk reactor.
         explicit PS3Walk(std::unique_ptr<NUClear::Environment> environment);


### PR DESCRIPTION
The controller codes in the lab were incorrectly mapped. I'm not sure why. The model numbers for the N1158 PS3 controllers are: CECHZC2E (grey) and CECHZC2A (black).

The controllers in the lab have been verified to send the same event codes. Although NUbook documentation is not required, the related documentation [is here](https://github.com/NUbots/NUbook/pull/214).