### PR TITLE
Bump zlib and black versions

### DIFF
--- a/doc/Kinematics/Export_Step.py
+++ b/doc/Kinematics/Export_Step.py
@@ -50,9 +50,9 @@ def properties_run(context):
 
             d = np.asarray(
                 [
-                    [y ** 2 + z ** 2, -x * y, -x * z],
-                    [-x * y, x ** 2 + z ** 2, -y * z],
-                    [-x * z, -y * z, x ** 2 + y ** 2],
+                    [y**2 + z**2, -x * y, -x * z],
+                    [-x * y, x**2 + z**2, -y * z],
+                    [-x * z, -y * z, x**2 + y**2],
                 ]
             )
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -310,7 +310,7 @@ RUN install-package \
 RUN pip install --upgrade \
     cmake-format==0.6.13 \
     isort==5.7.0 \
-    black==20.8b1
+    black==22.3.0
 
 # Enable all the driver capabilities so we can use OpenCL in the container
 ENV NVIDIA_DRIVER_CAPABILITIES=all

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,7 +95,7 @@ COPY usr/local/toolchain/generate_${platform}_toolchain.py /usr/local/generate_t
 RUN python /usr/local/generate_toolchain.py --prefix /usr/local
 
 # zlib
-RUN install-from-source https://www.zlib.net/zlib-1.2.11.tar.gz
+RUN install-from-source https://www.zlib.net/zlib-1.2.12.tar.gz
 
 # LLVM and Clang
 RUN BUILD_FILE_DIR='llvm' install-cmake-from-source https://github.com/llvm/llvm-project/archive/llvmorg-12.0.1.tar.gz \

--- a/nuclear/roles/banner/ampscii.py
+++ b/nuclear/roles/banner/ampscii.py
@@ -273,17 +273,17 @@ colour_map = [
 # First two elements are the filled elements
 # The second two are the shape and its inverse
 tile_map = [
-    ((1, 1), (1, 1), u"\u2588", u"\u2588"),  # |█| Full block
-    ((0, 0), (1, 1), u"\u2584", u"\u2580"),  # |▄| Lower half block
-    ((0, 1), (0, 1), u"\u2590", u"\u258C"),  # |▐| Right half block
-    ((0, 1), (1, 0), u"\u259E", u"\u259A"),  # |▞| Quadrant upper right and lower left
-    ((0, 1), (1, 1), u"\u259F", u"\u2598"),  # |▟| Quadrant upper right and lower left and lower right
-    ((1, 0), (0, 1), u"\u259A", u"\u259E"),  # |▚| Quadrant upper left and lower right
-    ((1, 0), (1, 0), u"\u258C", u"\u2590"),  # |▌| Left half block
-    ((1, 0), (1, 1), u"\u2599", u"\u259D"),  # |▙| Quadrant upper left and lower left and lower right
-    ((1, 1), (0, 0), u"\u2580", u"\u2584"),  # |▀| Upper half block
-    ((1, 1), (0, 1), u"\u259C", u"\u2596"),  # |▜| Quadrant upper left and upper right and lower right
-    ((1, 1), (1, 0), u"\u259B", u"\u2597"),  # |▛| Quadrant upper left and upper right and lower left
+    ((1, 1), (1, 1), "\u2588", "\u2588"),  # |█| Full block
+    ((0, 0), (1, 1), "\u2584", "\u2580"),  # |▄| Lower half block
+    ((0, 1), (0, 1), "\u2590", "\u258C"),  # |▐| Right half block
+    ((0, 1), (1, 0), "\u259E", "\u259A"),  # |▞| Quadrant upper right and lower left
+    ((0, 1), (1, 1), "\u259F", "\u2598"),  # |▟| Quadrant upper right and lower left and lower right
+    ((1, 0), (0, 1), "\u259A", "\u259E"),  # |▚| Quadrant upper left and lower right
+    ((1, 0), (1, 0), "\u258C", "\u2590"),  # |▌| Left half block
+    ((1, 0), (1, 1), "\u2599", "\u259D"),  # |▙| Quadrant upper left and lower left and lower right
+    ((1, 1), (0, 0), "\u2580", "\u2584"),  # |▀| Upper half block
+    ((1, 1), (0, 1), "\u259C", "\u2596"),  # |▜| Quadrant upper left and upper right and lower right
+    ((1, 1), (1, 0), "\u259B", "\u2597"),  # |▛| Quadrant upper left and upper right and lower left
 ]
 
 
@@ -395,7 +395,7 @@ def ampscii(src, unicode=True):
         rows.append(row)
 
     # Now convert those rows into a string
-    output = u""
+    output = ""
 
     for l in rows:
         fg = None
@@ -405,12 +405,12 @@ def ampscii(src, unicode=True):
             # Change foreground colour
             if v[0] != fg:
                 fg = v[0]
-                output += u"\x1b[38;5;{}m".format(fg)
+                output += "\x1b[38;5;{}m".format(fg)
 
             # Change background colour
             if v[1] != bg:
                 bg = v[1]
-                output += u"\x1b[48;5;{}m".format(bg)
+                output += "\x1b[48;5;{}m".format(bg)
 
             # TODO check if we can flip the FG and BG colours to not change
 
@@ -421,6 +421,6 @@ def ampscii(src, unicode=True):
                 output += "#"
 
         # Reset and make a new line
-        output += u"\x1b[0m\n"
+        output += "\x1b[0m\n"
 
     return output

--- a/report/graph/build_role_graph.py
+++ b/report/graph/build_role_graph.py
@@ -183,7 +183,7 @@ class NUClearGraphBuilder:
             "overlap": "prism10000",
             "layout": "fdp",
             "epsilon": 0.01,
-            "start": int(random.random() * 2 ** 32),
+            "start": int(random.random() * 2**32),
         }
 
         graph = Dot(**graph)
@@ -319,7 +319,7 @@ class NUClearGraphBuilder:
             overlap="prism10000",
             layout="fdp",
             epsilon=0.01,
-            start=int(random.random() * 2 ** 32),
+            start=int(random.random() * 2**32),
         )
 
         for m1 in compressed_modules:

--- a/report/graph/info/symbol_parser.py
+++ b/report/graph/info/symbol_parser.py
@@ -137,20 +137,25 @@ class SymbolParser:
         parensGroup = pp.Suppress("(") + pp.Group(nsType) + pp.Suppress(")")
 
         # Fill ns type (which is made up of several types separated by ::)
-        nsType << locator + pp.delimitedList(
-            pp.Suppress(typeModifiers)
-            + (lambdaType | fundamentalType | operatorType | cType | parensGroup)
-            + pp.Suppress(typeModifiers)
-            + pp.Optional(templateType)
-            + pp.Suppress(typeModifiers)
-            + pp.Optional(funcOrArrayModifier)
-            + pp.Suppress(typeModifiers)
-            + pp.Optional(arrayType)
-            + pp.Suppress(typeModifiers)
-            + pp.Optional(funcCall)
-            + pp.Suppress(typeModifiers),
-            pp.Literal("::") | pp.Literal("."),
-        ) + locator
+        (
+            nsType
+            << locator
+            + pp.delimitedList(
+                pp.Suppress(typeModifiers)
+                + (lambdaType | fundamentalType | operatorType | cType | parensGroup)
+                + pp.Suppress(typeModifiers)
+                + pp.Optional(templateType)
+                + pp.Suppress(typeModifiers)
+                + pp.Optional(funcOrArrayModifier)
+                + pp.Suppress(typeModifiers)
+                + pp.Optional(arrayType)
+                + pp.Suppress(typeModifiers)
+                + pp.Optional(funcCall)
+                + pp.Suppress(typeModifiers),
+                pp.Literal("::") | pp.Literal("."),
+            )
+            + locator
+        )
 
         self.parser = pp.OneOrMore(pp.Group(nsType)) + trailingInfo + pp.StringEnd()
         self.locate = False


### PR DESCRIPTION
Bump the zlib version from `1.2.11` to `1.2.12` as the old version is no longer hosted, preventing the docker build.

Bump the black version as they pin `click>=7.0` but that had breaking changes in `8.1`, which was fixed in a later black version.