### PR TITLE
Update the codebase to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,8 @@ add_compile_options(-Wall -Wpedantic -Wextra)
 # This is needed everywhere so that we can catch segmentation faults
 add_compile_options(-fnon-call-exceptions)
 
-# We use C++17
-add_compile_options(-std=c++17)
+# We use C++20
+add_compile_options(-std=c++20)
 
 # Make NUClear use the system clock, as we are syncing it with ptp
 add_compile_definitions(NUCLEAR_CLOCK_TYPE=std::chrono::steady_clock)

--- a/module/behaviour/tools/ScriptTuner/src/ScriptTuner.cpp
+++ b/module/behaviour/tools/ScriptTuner/src/ScriptTuner.cpp
@@ -353,7 +353,7 @@ namespace module::behaviour::tools {
     void ScriptTuner::toggleLockMotor() {
 
         // This finds if we have this particular motor stored in the frame
-        auto targetFinder = [=](const Script::Frame::Target& target) {
+        auto targetFinder = [=, this](const Script::Frame::Target& target) {
             return (static_cast<uint32_t>(target.id) + 2) % 20 == selection;
         };
 
@@ -472,7 +472,7 @@ namespace module::behaviour::tools {
                 double num = stod(result);
 
                 // This finds if we have this particular motor stored in the frame
-                auto targetFinder = [=](const Script::Frame::Target& target) {
+                auto targetFinder = [=, this](const Script::Frame::Target& target) {
                     return (static_cast<uint32_t>(target.id) + 2) % 20 == selection;
                 };
 


### PR DESCRIPTION
**Why are you updating?**

Because I want to use atomic pointers in #807. [Atomic shared_ptr](https://en.cppreference.com/w/cpp/memory/shared_ptr/atomic2) is only available in C++20.

**Why did you change script tuner?**

Because 

```
implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
```