### PR TITLE
Remove NUsight Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,6 @@ version: 2
 updates:
   # Required fields are `package-ecosystem`, `directory`, and `schedule.interval`
 
-  # Maintain dependencies for NUsight2
-  # Package ecosystem for yarn is npm
-  - package-ecosystem: npm
-    directory: /nusight2
-    labels:
-      - "-Dependencies"
-      - "P-NUsight2"
-      - "G-DevTools"
-    reviewers:
-      - "NUbots/nusight"
-    schedule:
-      interval: "monthly" # Checks on the first day of each month
-
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot currently spams PRs to update NUsight dependencies. This turns off Dependabot for NUsight dependencies, but keeps GitHub Actions. 

Reasons for turning it off
- Clutters the PRs list since there are a lot of dependencies
- We don't do anything with the PRs