### PR TITLE
Fix out of date sudoers line in arch install script for the robot

### DIFF
--- a/doc/ArchInstall/arch-chroot_install.sh
+++ b/doc/ArchInstall/arch-chroot_install.sh
@@ -39,8 +39,8 @@ EOF
 pacman -S --noconfirm --needed sudo
 
 # Setup users of the wheel group to be able to execute sudo commands with no password
-echo "%wheel ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/nubots_sudo
-chmod 440 /etc/sudoers.d/nubots_sudo
+echo "%wheel ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel_sudo
+chmod 440 /etc/sudoers.d/wheel_sudo
 
 # Get sudo to insult users when they type a password wrong
 echo "Defaults insults" > /etc/sudoers.d/insults

--- a/doc/ArchInstall/arch-chroot_install.sh
+++ b/doc/ArchInstall/arch-chroot_install.sh
@@ -39,7 +39,8 @@ EOF
 pacman -S --noconfirm --needed sudo
 
 # Setup users of the wheel group to be able to execute sudo commands with no password
-sed --in-place 's/^#\s*\(%wheel\s\+ALL=(ALL)\s\+NOPASSWD:\s\+ALL\)/\1/' /etc/sudoers
+echo "%wheel ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/nubots_sudo
+chmod 440 /etc/sudoers.d/nubots_sudo
 
 # Get sudo to insult users when they type a password wrong
 echo "Defaults insults" > /etc/sudoers.d/insults


### PR DESCRIPTION
Old line was out of date, it tried to uncomment something that used to be there but now is slightly different.
This PR makes a new file in the `etc/sudoers.d/` directory with the right line.

The purpose is to grant sudo access (without requiring a password) to anyone in the wheel group. `nubots` is in the wheel group.