### PR TITLE
Add in platform-specific configuration and set the hostname in docker to 'webots' if the role contains the word 'webots'

### DIFF
--- a/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
@@ -1,10 +1,5 @@
-log_level: ERROR
-
-buttons:
-  debounce_threshold: 7
-
 foot_down:
-  method: Z_HEIGHT
+  method: FSR
   known_methods:
     - name: FSR # Literal FSR
       certainty_threshold: 30 # Webots uses a bool sensor, this could be anything > 0. Normal robot uses FSR which is non bool

--- a/module/motion/QuinticWalk/data/config/webots/QuinticWalk.yaml
+++ b/module/motion/QuinticWalk/data/config/webots/QuinticWalk.yaml
@@ -3,23 +3,23 @@ log_level: WARN
 walk:
   # Full walk cycle frequency (how long it takes in seconds for a left + right steps)
   # (in Hz, > 0)
-  freq: 0.7
+  freq: 2.75
   # Length of double support phase in half cycle (how long both legs should be on the ground, as a ratio of how long it takes for a single step)
   # (ratio, [0:1])
-  double_support_ratio: 0.55
+  double_support_ratio: 0.1
   # Give extra swing to first step for better start
   # (in ?, [0:10])
   first_step_swing_factor: 0.8 #1.0
   foot:
     # Lateral distance between the feet center (how spread apart the feet should be)
     # (in m, >= 0)
-    distance: 0.28 #0.28
+    distance: 0.18 #0.28
     # Maximum flying foot height (how high we lift a foot from the ground)
     # (in m, >= 0)
-    rise: 0.15 #0.1
+    rise: 0.2 #0.1
     # Pause of Z movement on highest point (how long we hold a foot at the top, as a ratio of how long we're standing on one foot)
     # (single support cycle ratio, [0,1])
-    z_pause: 0.08 #0.04
+    z_pause: 0.0 #0.04
     put_down:
       # Let the foot's downward trajectory end above the ground
       # this is helpful if the support leg bends
@@ -95,7 +95,7 @@ walk:
 max_step:
   # Maximal step length in X
   # (in m, [0:1])
-  x: 0.04
+  x: 0.1
   # Maximal step length in Y
   # (in m, [0:1])
   y: 0.04
@@ -123,9 +123,9 @@ gains:
   arms: 13
 
 arms:
-  right_shoulder_pitch: 1.98
-  left_shoulder_pitch: 2.05
+  right_shoulder_pitch: 2.25
+  left_shoulder_pitch: 2.25
   right_shoulder_roll: -0.176
-  left_shoulder_roll: 0.135
-  right_elbow: -1.57
-  left_elbow: -1.57
+  left_shoulder_roll: 0.176
+  right_elbow: -1
+  left_elbow: -1

--- a/module/vision/VisualMesh/data/config/VisualMesh.yaml
+++ b/module/vision/VisualMesh/data/config/VisualMesh.yaml
@@ -1,5 +1,6 @@
 log_level: WARN
 
+# When making a visualmesh config file for a new platform, specify the cameras as follows:
 # The settings for each camera
 # CameraName:
 #   concurrent: How many engines to make available to concurrently execute networks
@@ -7,22 +8,3 @@ log_level: WARN
 #   spotlight:
 #     distance: the distance range for the spotlight mesh to be generated for
 #     radius: the search radius to do at that distance (NOT THE RADIUS OF THE OBJECT)
-
-cameras:
-  Left:
-   concurrent: 2
-   network: config/networks/RobocupNetwork.yaml
-   engine: opencl
-   classifier:
-     height: [0.5, 1.0]
-     max_distance: 15
-     intersection_tolerance: 0.25
-
- Right:
-   concurrent: 2
-   network: config/networks/RobocupNetwork.yaml
-   engine: opencl
-   classifier:
-     height: [0.5, 1.0]
-     max_distance: 15
-     intersection_tolerance: 0.25

--- a/module/vision/VisualMesh/data/config/nugus/VisualMesh.yaml
+++ b/module/vision/VisualMesh/data/config/nugus/VisualMesh.yaml
@@ -1,5 +1,3 @@
-log_level: WARN
-
 # The settings for each camera
 # CameraName:
 #   concurrent: How many engines to make available to concurrently execute networks

--- a/module/vision/VisualMesh/data/config/nugus/VisualMesh.yaml
+++ b/module/vision/VisualMesh/data/config/nugus/VisualMesh.yaml
@@ -1,0 +1,27 @@
+log_level: WARN
+
+# The settings for each camera
+# CameraName:
+#   concurrent: How many engines to make available to concurrently execute networks
+#   engine: Which engine to use (opencl, cpu)
+#   spotlight:
+#     distance: the distance range for the spotlight mesh to be generated for
+#     radius: the search radius to do at that distance (NOT THE RADIUS OF THE OBJECT)
+
+cameras:
+  Left:
+    concurrent: 2
+    network: config/networks/RobocupNetwork.yaml
+    engine: opencl
+    classifier:
+      height: [0.5, 1.0]
+      max_distance: 15
+      intersection_tolerance: 0.25
+  Right:
+    concurrent: 2
+    network: config/networks/RobocupNetwork.yaml
+    engine: opencl
+    classifier:
+      height: [0.5, 1.0]
+      max_distance: 15
+      intersection_tolerance: 0.25

--- a/module/vision/VisualMesh/data/config/webots/VisualMesh.yaml
+++ b/module/vision/VisualMesh/data/config/webots/VisualMesh.yaml
@@ -1,5 +1,3 @@
-log_level: WARN
-
 # The settings for each camera
 # CameraName:
 #   concurrent: How many engines to make available to concurrently execute networks

--- a/module/vision/VisualMesh/data/config/webots/VisualMesh.yaml
+++ b/module/vision/VisualMesh/data/config/webots/VisualMesh.yaml
@@ -9,20 +9,11 @@ log_level: WARN
 #     radius: the search radius to do at that distance (NOT THE RADIUS OF THE OBJECT)
 
 cameras:
-  Left:
-   concurrent: 2
-   network: config/networks/RobocupNetwork.yaml
-   engine: opencl
-   classifier:
-     height: [0.5, 1.0]
-     max_distance: 15
-     intersection_tolerance: 0.25
-
- Right:
-   concurrent: 2
-   network: config/networks/RobocupNetwork.yaml
-   engine: opencl
-   classifier:
-     height: [0.5, 1.0]
-     max_distance: 15
-     intersection_tolerance: 0.25
+  left_camera:
+    concurrent: 2
+    network: config/networks/WebotsNetwork.yaml
+    engine: cpu
+    classifier:
+      height: [0.5, 1.0]
+      max_distance: 15
+      intersection_tolerance: 0.25

--- a/shared/extension/Configuration.hpp
+++ b/shared/extension/Configuration.hpp
@@ -41,13 +41,13 @@ namespace extension {
     struct [[nodiscard]] Configuration {
         // Rules:
         // 1) Default config file should define a value for every node.
-        // 2) Per-robot config overrides default config values. This file need only override the values that nee to be
-        // overriden.
-        // 3) Per-binary config overrides per-robot and default config values. This file need only override the values
-        // that need to be overriden.
+        // 2) Platform config overrides default config values.
+        // 2) Per-robot config overrides default and platform config values. This file need only override the values
+        // that need to be overriden. 3) Per-binary config overrides per-robot, platform and default config values. This
+        // file need only override the values that need to be overriden.
         //
-        // Per-robot and per-binary files need not exist.
-        // Per-robot and per-binary files can add new nodes to the file, but this is probably unwise.
+        // Per-robot, per-platform and per-binary files need not exist.
+        // Per-robot, per-platform and per-binary files can add new nodes to the file, but this is probably unwise.
         //
         // We have to merge the YAML trees to account for situations where a sub-node is not defined in a higher
         // priority tree.
@@ -55,24 +55,41 @@ namespace extension {
         fs::path fileName{};
         std::string hostname{};
         std::string binary{};
+        std::string platform{};
         YAML::Node config{};
 
         Configuration() = default;
         Configuration(const std::string& fileName,
                       const std::string& hostname,
                       const std::string& binary,
+                      const std::string& platform,
                       const YAML::Node& config)
-            : fileName(fileName), hostname(hostname), binary(binary), config(config) {}
+            : fileName(fileName), hostname(hostname), binary(binary), platform(platform), config(config) {}
 
         /// @brief Constructor without config node given. The correct config file has to be deduced from the params
-        Configuration(const std::string& fileName, const std::string& hostname, const std::string& binary)
-            : fileName(fileName), hostname(hostname), binary(binary) {
+        Configuration(const std::string& fileName,
+                      const std::string& hostname,
+                      const std::string& binary,
+                      const std::string& platform)
+            : fileName(fileName), hostname(hostname), binary(binary), platform(platform) {
             bool loaded = false;
 
             // Load the default config file.
             if (fs::exists(fs::path("config") / fileName)) {
                 config = YAML::LoadFile(fs::path("config") / fileName);
                 loaded = true;
+            }
+
+            // If the same file exists in this platform's per-platform config directory then load and merge
+            if (fs::exists(fs::path("config") / platform / fileName)) {
+                if (loaded) {
+                    config = merge_yaml_nodes(config, YAML::LoadFile(fs::path("config") / platform / fileName));
+                }
+
+                else {
+                    config = YAML::LoadFile(fs::path("config") / platform / fileName);
+                    loaded = true;
+                }
             }
 
             // If the same file exists in this robots per-robot config directory then load and merge.
@@ -150,36 +167,56 @@ namespace extension {
             return ret;
         }
 
+        static inline std::string getPlatform(const std::string& hostname) {
+            // It is assumed that all hostnames are in the format <platform name><robot number>,
+            // such that the regular expression
+            // [a-z]+[0-9]+?
+            // will match all hostnames
+            std::regex re("([a-z]+)([0-9]+)?");
+            std::smatch match;
+
+            if (std::regex_match(hostname, match, re)) {
+                // match[0] will be the full string
+                // match[1] the first match (platform name)
+                // match[2] the second match (robot number)
+                return match[1].str();
+            }
+
+            throw std::system_error(-1,
+                                    std::system_category(),
+                                    ("Failed to extract platform name from '" + hostname + "'."));
+        }
+
         [[nodiscard]] Configuration operator[](const std::string& key) {
-            return Configuration(fileName, hostname, binary, config[key]);
+            return Configuration(fileName, hostname, binary, platform, config[key]);
         }
 
         [[nodiscard]] Configuration operator[](const std::string& key) const {
-            return Configuration(fileName, hostname, binary, config[key]);
+            return Configuration(fileName, hostname, binary, platform, config[key]);
         }
 
         [[nodiscard]] Configuration operator[](const char* key) {
-            return Configuration(fileName, hostname, binary, config[key]);
+            return Configuration(fileName, hostname, binary, platform, config[key]);
         }
 
         [[nodiscard]] Configuration operator[](const char* key) const {
-            return Configuration(fileName, hostname, binary, config[key]);
+            return Configuration(fileName, hostname, binary, platform, config[key]);
         }
 
         [[nodiscard]] Configuration operator[](size_t index) {
-            return Configuration(fileName, hostname, binary, config[index]);
+            return Configuration(fileName, hostname, binary, platform, config[index]);
         }
 
         [[nodiscard]] Configuration operator[](size_t index) const {
-            return Configuration(fileName, hostname, binary, config[index]);
+            return Configuration(fileName, hostname, binary, platform, config[index]);
         }
 
         [[nodiscard]] Configuration operator[](int index) {
-            return Configuration(fileName, hostname, binary, config[index]);
+            return Configuration(fileName, hostname, binary, platform, config[index]);
         }
 
         [[nodiscard]] Configuration operator[](int index) const {
-            return Configuration(fileName, hostname, binary, config[index]);
+            return Configuration(fileName, hostname, binary, platform, config[index]);
         }
 
         template <typename T, typename... Args>
@@ -258,6 +295,7 @@ namespace NUClear::dsl {
 
                 // Get hostname so we can find the correct per-robot config directory.
                 const std::string hostname = utility::support::getHostname();
+                const std::string platform(::extension::Script::getPlatform(hostname));
 
                 // Check if there is a default config. If there isn't, try to make one
                 const fs::path defaultConfig = fs::path("config") / filename;
@@ -286,6 +324,12 @@ namespace NUClear::dsl {
                 const fs::path robotConfig = fs::path("config") / hostname / filename;
                 if (fs::exists(robotConfig)) {
                     DSLProxy<::extension::FileWatch>::bind<DSL>(reaction, robotConfig, flags);
+                }
+
+                // Bind our robot specific config file if it exists
+                const fs::path platformConfig = fs::path("config") / platform / filename;
+                if (fs::exists(platformConfig)) {
+                    DSLProxy<::extension::FileWatch>::bind<DSL>(reaction, platformConfig, flags);
                 }
 
                 // If there were command line arguments, we can get the binary name, and check for a binary config
@@ -320,6 +364,7 @@ namespace NUClear::dsl {
                     try {
                         // Get hostname so we can find the correct per-robot config directory.
                         const std::string hostname = utility::support::getHostname();
+                        const std::string platform(::extension::Script::getPlatform(hostname));
 
                         const auto binaryName = get_first_command_line_arg();
 
@@ -329,7 +374,8 @@ namespace NUClear::dsl {
                         bool flag = false;
                         for (const auto& component : components) {
                             // Ignore the hostname/binary name if they are present.
-                            if (flag && (component != hostname) && (component != binaryName)) {
+                            if (flag && (component != hostname) && (component != binaryName)
+                                && (component != platform)) {
                                 relativePath = relativePath / component;
                             }
 
@@ -339,7 +385,10 @@ namespace NUClear::dsl {
                             }
                         }
 
-                        return std::make_shared<::extension::Configuration>(relativePath, hostname, binaryName);
+                        return std::make_shared<::extension::Configuration>(relativePath,
+                                                                            hostname,
+                                                                            binaryName,
+                                                                            platform);
                     }
                     catch (const YAML::ParserException& e) {
                         throw std::runtime_error(watch.path + " " + std::string(e.what()));

--- a/shared/extension/Configuration.hpp
+++ b/shared/extension/Configuration.hpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <nuclear>
+#include <regex>
 #include <utility>
 #include <yaml-cpp/yaml.h>
 
@@ -295,7 +296,7 @@ namespace NUClear::dsl {
 
                 // Get hostname so we can find the correct per-robot config directory.
                 const std::string hostname = utility::support::getHostname();
-                const std::string platform(::extension::Script::getPlatform(hostname));
+                const std::string platform(::extension::Configuration::getPlatform(hostname));
 
                 // Check if there is a default config. If there isn't, try to make one
                 const fs::path defaultConfig = fs::path("config") / filename;
@@ -364,7 +365,7 @@ namespace NUClear::dsl {
                     try {
                         // Get hostname so we can find the correct per-robot config directory.
                         const std::string hostname = utility::support::getHostname();
-                        const std::string platform(::extension::Script::getPlatform(hostname));
+                        const std::string platform(::extension::Configuration::getPlatform(hostname));
 
                         const auto binaryName = get_first_command_line_arg();
 

--- a/tools/utility/dockerise/run.py
+++ b/tools/utility/dockerise/run.py
@@ -73,6 +73,11 @@ def run(func, image):
             func(**kwargs)
             exit(0)
 
+        # Set hostname to webots if the binary contains the word webots
+        # Else set it to docker
+        # This is for configuration purposes
+        # hostname = webots if (binary regex contains 'webots') else docker
+
         # Docker arguments
         docker_args = [
             "docker",
@@ -87,7 +92,7 @@ def run(func, image):
             "--attach",
             "stderr",
             "--hostname",
-            "docker",
+            hostname,
             "--interactive",
             "--env",
             "EDITOR={}".format(os.environ.get("EDITOR", "nano")),

--- a/tools/utility/dockerise/run.py
+++ b/tools/utility/dockerise/run.py
@@ -73,10 +73,15 @@ def run(func, image):
             func(**kwargs)
             exit(0)
 
-        # Set hostname to webots if the binary contains the word webots
-        # Else set it to docker
-        # This is for configuration purposes
-        # hostname = webots if (binary regex contains 'webots') else docker
+        # If this is the run command, then use the binary name to determine if
+        # the hostname should be docker or webots
+        # Binaries containing 'webots' should be given the hostname 'webots'
+        # to ensure the config files are chosen correctly
+        if kwargs["command"] == "run":
+            binary = kwargs["args"][0]  # the binary name is the first argument in the run command
+            hostname = "webots" if re.search("webots", binary) else "docker"
+        else:
+            hostname = "docker"
 
         # Docker arguments
         docker_args = [


### PR DESCRIPTION
- Updates the Configuration extension to allow platform-specific configuration files
- Update the docker run command to use 'webots' as the hostname if the user is using `./b run` and their binary contains the word `webots`
- Updates the QuinticWalk config - in Webots, the default config was used and there was no way to run with the config in the already-existing QuinticWalk `webots` config directory. With these changes, the Webots platform should run with the config file in the QuinticWalk `webots` config directory. Updates this config to the same values as the default config so the webots robot will use the right values.
- Added two platform config files for the visualmesh module, one for the nugus and one for webots. The default file only contains the log level, since each platform should implement it's own camera config values. Having the real robot config as the default does not work, since the merging method for config files means that the webots file will contain config values for the real Left and Right camera.

This is tested and it seems to work fine.

[NUbook PR here.](https://github.com/NUbots/NUbook/pull/223)