### PR TITLE
Always restore tty settings

### DIFF
--- a/tools/utility/shell/wrap_pty.py
+++ b/tools/utility/shell/wrap_pty.py
@@ -14,6 +14,13 @@ import tty
 class WrapPty:
     def __init__(self):
         self.fd = None
+        self.mode = None
+
+        # Old signal handlers
+        self.old_winch = None
+        self.old_abort = None
+        self.old_int = None
+        self.old_term = None
 
     def _set_pty_size(self):
         buf = array.array("h", [0, 0, 0, 0])
@@ -25,6 +32,31 @@ class WrapPty:
         Signal handler for SIGWINCH - window size has changed.
         """
         self._set_pty_size()
+        
+    def _signal_int(self, signum, frame):
+        """
+        Signal handler for
+            SIGABRT - Abort signal
+            SIGINT - Interrupt from keyboard (Ctrl + C)
+            SIGKILL - Kill signal
+            SIGTERM - Termination signal
+        Reset the terminal mode and undo signal handlers, then quit
+        """
+        if self.mode:
+            try:
+                tty.tcsetattr(pty.STDIN_FILENO, tty.TCSAFLUSH, self.mode)
+                self.mode = None
+            except tty.error:  # This is the same as termios.error
+                pass
+        os.close(self.fd)
+
+        # Reset signal handlers
+        if sys.stdout.isatty():
+            signal.signal(signal.SIGWINCH, self.old_winch)
+
+        signal.signal(signal.SIGABRT, self.old_abort)
+        signal.signal(signal.SIGINT, self.old_int)
+        signal.signal(signal.SIGTERM, self.old_term)
 
     def spawn(self, args, env=os.environ):
         pid, self.fd = pty.fork()
@@ -36,29 +68,42 @@ class WrapPty:
             # If no arguments run bash
             os.execlpe(args[0], *args, env)
 
+        # Catch important signals
+        self.old_abort = signal.signal(signal.SIGABRT, self._signal_int)
+        self.old_int = signal.signal(signal.SIGINT, self._signal_int)
+        self.old_term = signal.signal(signal.SIGTERM, self._signal_int)
+
         if sys.stdout.isatty():
-            old_handler = signal.signal(signal.SIGWINCH, self._signal_winch)
+            self.old_winch = signal.signal(signal.SIGWINCH, self._signal_winch)
 
         try:
-            mode = tty.tcgetattr(pty.STDIN_FILENO)
+            self.mode = tty.tcgetattr(pty.STDIN_FILENO)
             tty.setraw(pty.STDIN_FILENO)
-            restore = True
         except tty.error:  # This is the same as termios.error
-            restore = False
-
+            pass
+        
         if sys.stdout.isatty():
             self._set_pty_size()
 
         try:
             pty._copy(self.fd)
         except (IOError, OSError):
-            if restore:
-                tty.tcsetattr(pty.STDIN_FILENO, tty.TCSAFLUSH, mode)
+            pass
+        
+        # Restore the terminals original settings
+        if self.mode:
+            tty.tcsetattr(pty.STDIN_FILENO, tty.TCSAFLUSH, self.mode)
+            self.mode = None
 
         os.close(self.fd)
 
+        # Reset signal handlers
         if sys.stdout.isatty():
-            signal.signal(signal.SIGWINCH, old_handler)
+            signal.signal(signal.SIGWINCH, self.old_winch)
+
+        signal.signal(signal.SIGABRT, self.old_abort)
+        signal.signal(signal.SIGINT, self.old_int)
+        signal.signal(signal.SIGTERM, self.old_term)
 
         self.fd = None
         return os.waitpid(pid, 0)[1] >> 8

--- a/tools/utility/shell/wrap_pty.py
+++ b/tools/utility/shell/wrap_pty.py
@@ -32,7 +32,7 @@ class WrapPty:
         Signal handler for SIGWINCH - window size has changed.
         """
         self._set_pty_size()
-        
+
     def _signal_int(self, signum, frame):
         """
         Signal handler for
@@ -81,7 +81,7 @@ class WrapPty:
             tty.setraw(pty.STDIN_FILENO)
         except tty.error:  # This is the same as termios.error
             pass
-        
+
         if sys.stdout.isatty():
             self._set_pty_size()
 
@@ -89,7 +89,7 @@ class WrapPty:
             pty._copy(self.fd)
         except (IOError, OSError):
             pass
-        
+
         # Restore the terminals original settings
         if self.mode:
             tty.tcsetattr(pty.STDIN_FILENO, tty.TCSAFLUSH, self.mode)


### PR DESCRIPTION
This PR prevents your terminal from going insane after running a `./b` command by
- overriding signal more signal handlers
- resetting TTY (terminal) settings when a signal is caught or when the script ends

