### PR TITLE
Switch around nugus2 and nugus3 Camera config files after nuc swap

### DIFF
--- a/module/input/Camera/data/config/nugus2/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus2/Cameras/Left.yaml
@@ -1,4 +1,4 @@
-serial_number: 011885B0
+serial_number: 01188260
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,11 +15,11 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.34607022208588906
+  focal_length: 0.34767878619271286
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [-0.008429632815260277, 0.003767345048721181]
+  centre: [-0.01370165657132854, -0.013645629277120971]
   # The polynomial distortion coefficients for the lens
-  k: [0.4718296027381958, 0.22726744036437643]
+  k: [0.46673390301927425, 0.15017118169604132]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location

--- a/module/input/Camera/data/config/nugus2/Cameras/Right.yaml
+++ b/module/input/Camera/data/config/nugus2/Cameras/Right.yaml
@@ -1,4 +1,4 @@
-serial_number: 01188483
+serial_number: 0118847F
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,11 +15,11 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.3379603020878361
+  focal_length: 0.34407470485610553
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [-0.014463461390834174, -0.024161253939202938]
+  centre: [0.0037393686683910104, -0.007110721366947057]
   # The polynomial distortion coefficients for the lens
-  k: [0.5008855578146484, 0.25712627828352613]
+  k: [0.4739103438574755, 0.1549602920025024]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location

--- a/module/input/Camera/data/config/nugus3/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus3/Cameras/Left.yaml
@@ -1,4 +1,4 @@
-serial_number: 0115138C
+serial_number: 011885B0
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,11 +15,11 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.3483501377911852
+  focal_length: 0.34607022208588906
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [0.025083740294995292, 0.009478481033831665]
+  centre: [-0.008429632815260277, 0.003767345048721181]
   # The polynomial distortion coefficients for the lens
-  k: [0.436992840635348, 0.13151054190615985]
+  k: [0.4718296027381958, 0.22726744036437643]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location

--- a/module/input/Camera/data/config/nugus3/Cameras/Right.yaml
+++ b/module/input/Camera/data/config/nugus3/Cameras/Right.yaml
@@ -1,4 +1,4 @@
-serial_number: 011885A9
+serial_number: 01188483
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,11 +15,11 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.34668243830134987
+  focal_length: 0.3379603020878361
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [0.02070395328006253, 0.0010238129312947657]
+  centre: [-0.014463461390834174, -0.024161253939202938]
   # The polynomial distortion coefficients for the lens
-  k: [0.46102867909441303, 0.1464565980831643]
+  k: [0.5008855578146484, 0.25712627828352613]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location


### PR DESCRIPTION
The nucs were swapped around in the nugus' earlier this year. Camera config needs to be swapped around to the right nugus'. They have already had serial numbers checked and calibration performed. 