### PR TITLE
Stop extra kick in webots_keyboardwalk and add in a kick timeout

### DIFF
--- a/module/behaviour/skills/KickScript/README.md
+++ b/module/behaviour/skills/KickScript/README.md
@@ -1,13 +1,23 @@
-Kick Script
-===========
+# Kick Script
 
 ## Description
 
+Executes a scripted style kick based on a specified type (normal/penalty).
+
+For a normal type kick, the kicking leg (left/right) can also be specified.
 
 ## Usage
 
+Include this module to allow the robot to execute scripted kicks.
 
 ## Emits
 
+- `extension::ExecuteScriptByName` to run scripted kick scripts
+- `FinishKick` to signal kick to finish
+- `message::motion::KickFinished` to signal that kick has finished
+- `utility::behaviour::ActionPriorities` signals when the module's priority changes
+- `utility::behaviour::RegisterAction` registers callbacks for executing or finishing kicks
 
 ## Dependencies
+
+- The Script Engine module is required to execute the kick scripts

--- a/module/behaviour/skills/KickScript/data/config/KickScript.yaml
+++ b/module/behaviour/skills/KickScript/data/config/KickScript.yaml
@@ -1,3 +1,4 @@
 log_level: WARN
 
 "KICK_PRIORITY": 50
+message_timeout: 3000

--- a/module/behaviour/skills/KickScript/data/config/KickScript.yaml
+++ b/module/behaviour/skills/KickScript/data/config/KickScript.yaml
@@ -1,4 +1,3 @@
 log_level: WARN
 
 "KICK_PRIORITY": 50
-"EXECUTION_PRIORITY": 50

--- a/module/behaviour/skills/KickScript/data/config/KickScript.yaml
+++ b/module/behaviour/skills/KickScript/data/config/KickScript.yaml
@@ -1,4 +1,6 @@
 log_level: WARN
 
-"KICK_PRIORITY": 50
+# Priority set when wanting to kick
+kick_priority: 40
+# Time between kick command message and kicking before kick is discarded
 message_timeout: 3000

--- a/module/behaviour/skills/KickScript/data/config/KickScript.yaml
+++ b/module/behaviour/skills/KickScript/data/config/KickScript.yaml
@@ -1,6 +1,6 @@
 log_level: WARN
 
-# Priority set when wanting to kick
+# Value that priority is set to when wanting to kick
 kick_priority: 40
-# Time between kick command message and kicking before kick is discarded
+# Time between kick command message and kicking before kick is discarded (milliseconds)
 message_timeout: 3000

--- a/module/behaviour/skills/KickScript/src/KickScript.cpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.cpp
@@ -62,7 +62,7 @@ namespace module::behaviour::skills {
         });
 
         on<Trigger<KickScriptCommand>>().then([this](const KickScriptCommand& cmd) {
-            kickCommand        = std::make_shared<KickScriptCommand>(cmd);
+            kick_command       = std::make_shared<KickScriptCommand>(cmd);
             time_since_message = NUClear::clock::now();
             updatePriority(kick_priority);
         });
@@ -70,7 +70,7 @@ namespace module::behaviour::skills {
         on<Trigger<ExecuteKick>>().then([this] {
             // Don't kick if there is no command
             // This may happen if we get priority initially with 0 priority and no KickScriptCommand
-            if (kickCommand == nullptr) {
+            if (kick_command == nullptr) {
                 updatePriority(0);
                 return;
             }
@@ -83,11 +83,10 @@ namespace module::behaviour::skills {
                 return;
             }
 
-            // auto direction = kickCommand.direction;
-            LimbID leg = kickCommand->leg;
+            LimbID leg = kick_command->leg;
 
             // Execute the penalty kick if the type is PENALTY
-            if (kickCommand->type == KickCommandType::PENALTY) {
+            if (kick_command->type == KickCommandType::PENALTY) {
                 emit(std::make_unique<ExecuteScriptByName>(id, std::vector<std::string>({"KickPenalty.yaml"})));
             }
             else {
@@ -96,7 +95,7 @@ namespace module::behaviour::skills {
                         id,
                         std::vector<std::string>({"Stand.yaml", "KickRight.yaml", "Stand.yaml"})));
                 }
-                else {  // if (leg == LimbID::LEFT_LEG) {
+                else {  // LEFT_LEG
                     emit(std::make_unique<ExecuteScriptByName>(
                         id,
                         std::vector<std::string>({"Stand.yaml", "KickLeft.yaml", "Stand.yaml"})));

--- a/module/behaviour/skills/KickScript/src/KickScript.cpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.cpp
@@ -55,7 +55,6 @@ namespace module::behaviour::skills {
             log_level = config["log_level"].as<NUClear::LogLevel>();
 
             KICK_PRIORITY = config["KICK_PRIORITY"].as<float>();
-            EXECUTION_PRIORITY = config["EXECUTION_PRIORITY"].as<float>();
         });
 
         on<Trigger<KickScriptCommand>>().then([this](const KickScriptCommand& cmd) {

--- a/module/behaviour/skills/KickScript/src/KickScript.cpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.cpp
@@ -121,7 +121,7 @@ namespace module::behaviour::skills {
             }}));
     }
 
-    void KickScript::updatePriority(const float& priority) {
+    void KickScript::update_priority(const float& priority) {
         emit(std::make_unique<ActionPriorities>(ActionPriorities{id, {priority}}));
     }
 

--- a/module/behaviour/skills/KickScript/src/KickScript.cpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.cpp
@@ -64,14 +64,14 @@ namespace module::behaviour::skills {
         on<Trigger<KickScriptCommand>>().then([this](const KickScriptCommand& cmd) {
             kick_command       = std::make_shared<KickScriptCommand>(cmd);
             time_since_message = NUClear::clock::now();
-            updatePriority(kick_priority);
+            update_priority(kick_priority);
         });
 
         on<Trigger<ExecuteKick>>().then([this] {
             // Don't kick if there is no command
             // This may happen if we get priority initially with 0 priority and no KickScriptCommand
             if (kick_command == nullptr) {
-                updatePriority(0);
+                update_priority(0);
                 return;
             }
 
@@ -79,7 +79,7 @@ namespace module::behaviour::skills {
             if (std::chrono::duration_cast<std::chrono::milliseconds>(NUClear::clock::now() - time_since_message)
                     .count()
                 > message_timeout) {
-                updatePriority(0);
+                update_priority(0);
                 return;
             }
 
@@ -105,7 +105,7 @@ namespace module::behaviour::skills {
 
         on<Trigger<FinishKick>>().then([this] {
             emit(std::make_unique<KickFinished>());
-            updatePriority(0);
+            update_priority(0);
         });
 
         emit<Scope::INITIALIZE>(std::make_unique<RegisterAction>(RegisterAction{

--- a/module/behaviour/skills/KickScript/src/KickScript.cpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.cpp
@@ -57,14 +57,14 @@ namespace module::behaviour::skills {
         on<Configuration>("KickScript.yaml").then([this](const Configuration& config) {
             log_level = config["log_level"].as<NUClear::LogLevel>();
 
-            KICK_PRIORITY   = config["KICK_PRIORITY"].as<float>();
+            kick_priority   = config["kick_priority"].as<float>();
             message_timeout = config["message_timeout"].as<Expression>();
         });
 
         on<Trigger<KickScriptCommand>>().then([this](const KickScriptCommand& cmd) {
             kickCommand        = std::make_shared<KickScriptCommand>(cmd);
             time_since_message = NUClear::clock::now();
-            updatePriority(KICK_PRIORITY);
+            updatePriority(kick_priority);
         });
 
         on<Trigger<ExecuteKick>>().then([this] {

--- a/module/behaviour/skills/KickScript/src/KickScript.hpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.hpp
@@ -36,6 +36,8 @@ namespace module::behaviour::skills {
 
         float KICK_PRIORITY      = 0.0f;
         float EXECUTION_PRIORITY = 0.0f;
+        int message_timeout = 0;
+        NUClear::clock::time_point time_since_message{NUClear::clock::now()};
 
         std::shared_ptr<message::motion::KickScriptCommand> kickCommand{nullptr};
 

--- a/module/behaviour/skills/KickScript/src/KickScript.hpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.hpp
@@ -32,14 +32,19 @@ namespace module::behaviour::skills {
         explicit KickScript(std::unique_ptr<NUClear::Environment> environment);
 
     private:
+        /// @brief The id registered in the subsumption system for this module
         const size_t id{size_t(this) * size_t(this) - size_t(this)};
-
+        /// @brief Value that priority is set to when wanting to kick
         float kick_priority = 0.0f;
+        /// @brief Time between kick command message and kicking before kick is discarded
         int message_timeout = 0;
+        /// @brief Time since the last kick command message was received
         NUClear::clock::time_point time_since_message{NUClear::clock::now()};
-
+        /// @brief The last kick command received, nullptr if none received yet
         std::shared_ptr<message::motion::KickScriptCommand> kickCommand{nullptr};
 
+        /// @brief Updates the priority of the module by emitting an ActionPriorities message
+        /// @param priority The priority used in the ActionPriorities message
         void updatePriority(const float& priority);
     };
 }  // namespace module::behaviour::skills

--- a/module/behaviour/skills/KickScript/src/KickScript.hpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.hpp
@@ -45,7 +45,7 @@ namespace module::behaviour::skills {
 
         /// @brief Updates the priority of the module by emitting an ActionPriorities message
         /// @param priority The priority used in the ActionPriorities message
-        void updatePriority(const float& priority);
+        void update_priority(const float& priority);
     };
 }  // namespace module::behaviour::skills
 

--- a/module/behaviour/skills/KickScript/src/KickScript.hpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.hpp
@@ -37,7 +37,7 @@ namespace module::behaviour::skills {
         float KICK_PRIORITY      = 0.0f;
         float EXECUTION_PRIORITY = 0.0f;
 
-        message::motion::KickScriptCommand kickCommand{};
+        std::shared_ptr<message::motion::KickScriptCommand> kickCommand{nullptr};
 
         void updatePriority(const float& priority);
     };

--- a/module/behaviour/skills/KickScript/src/KickScript.hpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.hpp
@@ -36,12 +36,12 @@ namespace module::behaviour::skills {
         const size_t id{size_t(this) * size_t(this) - size_t(this)};
         /// @brief Value that priority is set to when wanting to kick
         float kick_priority = 0.0f;
-        /// @brief Time between kick command message and kicking before kick is discarded
+        /// @brief Time between kick command message and kicking before kick is discarded (milliseconds)
         int message_timeout = 0;
-        /// @brief Time since the last kick command message was received
+        /// @brief Time when the last kick command message was received
         NUClear::clock::time_point time_since_message{NUClear::clock::now()};
         /// @brief The last kick command received, nullptr if none received yet
-        std::shared_ptr<message::motion::KickScriptCommand> kickCommand{nullptr};
+        std::shared_ptr<message::motion::KickScriptCommand> kick_command{nullptr};
 
         /// @brief Updates the priority of the module by emitting an ActionPriorities message
         /// @param priority The priority used in the ActionPriorities message

--- a/module/behaviour/skills/KickScript/src/KickScript.hpp
+++ b/module/behaviour/skills/KickScript/src/KickScript.hpp
@@ -34,8 +34,7 @@ namespace module::behaviour::skills {
     private:
         const size_t id{size_t(this) * size_t(this) - size_t(this)};
 
-        float KICK_PRIORITY      = 0.0f;
-        float EXECUTION_PRIORITY = 0.0f;
+        float kick_priority = 0.0f;
         int message_timeout = 0;
         NUClear::clock::time_point time_since_message{NUClear::clock::now()};
 

--- a/roles/webots_keyboard.role
+++ b/roles/webots_keyboard.role
@@ -17,6 +17,7 @@ nuclear_role(
   # Behaviour
   behaviour::Controller
   behaviour::skills::Getup
+  behaviour::skills::Stand
   behaviour::skills::KickScript
   behaviour::skills::DirectWalkController
   behaviour::strategy::KeyboardWalk


### PR DESCRIPTION
Alternative to #842.

- Adds Stand module to `webots_keyboardwalk.role` inline with other motion roles
- Makes kick priority lower than get up priority
- Uses shared pointer to check kick command exists
- Adds a timeout so that the kick isn't executed too long after a kick command (since we probably are no longer necessarily in a good position to kick)
- Fill in module readme
- Add document directives