### PR TITLE
Replaces stand up back with rollover/stand up front

### DIFF
--- a/module/behaviour/skills/Getup/src/Getup.cpp
+++ b/module/behaviour/skills/Getup/src/Getup.cpp
@@ -95,7 +95,7 @@ namespace module::behaviour::skills {
             else {
                 emit(std::make_unique<ExecuteScriptByName>(
                     id,
-                    std::vector<std::string>({"StandUpBack.yaml", "Stand.yaml"})));
+                    std::vector<std::string>({"RollOverBack.yaml", "StandUpFront.yaml", "Stand.yaml"})));
             }
             updatePriority(EXECUTION_PRIORITY);
         });

--- a/module/motion/ScriptEngine/data/scripts/nugus/RollOverBack.yaml
+++ b/module/motion/ScriptEngine/data/scripts/nugus/RollOverBack.yaml
@@ -1,0 +1,656 @@
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 10
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 10
+      torque: 100
+    - id: R_ELBOW
+      position: -0.154969901
+      gain: 10
+      torque: 100
+    - id: L_ELBOW
+      position: 0.124282785
+      gain: 10
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0168779101
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: -0.0368245281
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0245496854
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0260840412
+      gain: 20
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.0355201364
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.00157351582
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.0797864795
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.177985221
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.147
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.80747068
+      gain: 10
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.14710632
+      gain: 10
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.73075283
+      gain: 10
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 10
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 10
+      torque: 100
+    - id: R_ELBOW
+      position: -0.154969901
+      gain: 10
+      torque: 100
+    - id: L_ELBOW
+      position: 0.124282785
+      gain: 10
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0168779101
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: -0.0368245281
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0245496854
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0260840412
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.00157351582
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.0797864795
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.177985221
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.147
+      gain: 10
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 3.11013842
+      gain: 10
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.550603628
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.148640677
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.62948537
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 10
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 10
+      torque: 100
+    - id: R_ELBOW
+      position: -0.154969901
+      gain: 10
+      torque: 100
+    - id: L_ELBOW
+      position: 0.124282785
+      gain: 10
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.0168779101
+      gain: 20
+      torque: 100
+    - id: L_HIP_YAW
+      position: -0.0368245281
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0245496854
+      gain: 20
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0260840412
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.00157351582
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.0797864795
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.177985221
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.147
+      gain: 10
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.14710632
+      gain: 10
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 3.11013842
+      gain: 10
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 1.4267205
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.36557627
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 10
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 10
+      torque: 100
+    - id: R_ELBOW
+      position: -0.154969901
+      gain: 10
+      torque: 100
+    - id: L_ELBOW
+      position: 0.124282785
+      gain: 10
+      torque: 100
+    - id: L_HIP_YAW
+      position: -0.0368245281
+      gain: 20
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0245496854
+      gain: 20
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -0.00157351582
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.0797864795
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.177985221
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.147
+      gain: 10
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.14710632
+      gain: 10
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 1.4267205
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.072114706
+      gain: 10
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.313008487
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.36250758
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.805536568
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 10
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 10
+      torque: 100
+    - id: R_ELBOW
+      position: -0.154969901
+      gain: 10
+      torque: 100
+    - id: L_ELBOW
+      position: 0.124282785
+      gain: 10
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0245496854
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.0797864795
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.177985221
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.147
+      gain: 10
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.14710632
+      gain: 10
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 1.4267205
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.072114706
+      gain: 10
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.313008487
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.36250758
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.805536568
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: -0.428085148
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.750260651
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 10
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 10
+      torque: 100
+    - id: R_ELBOW
+      position: -0.154969901
+      gain: 10
+      torque: 100
+    - id: L_ELBOW
+      position: 0.124282785
+      gain: 10
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0245496854
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.0797864795
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.177985221
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.147
+      gain: 10
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.14710632
+      gain: 10
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.072114706
+      gain: 10
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.313008487
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.36250758
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: -0.428085148
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.750260651
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.332955122
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 1.38068986
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 10
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 10
+      torque: 100
+    - id: R_ELBOW
+      position: -0.154969901
+      gain: 10
+      torque: 100
+    - id: L_ELBOW
+      position: 0.124282785
+      gain: 10
+      torque: 100
+    - id: R_HIP_ROLL
+      position: 0.0245496854
+      gain: 20
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.0797864795
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.177985221
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.147
+      gain: 10
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.14710632
+      gain: 10
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.072114706
+      gain: 10
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.313008487
+      gain: 20
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.36250758
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: -0.428085148
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.750260651
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: -0.332955122
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.190490037
+      gain: 30
+      torque: 100
+- duration: 1000
+  targets:
+    - id: HEAD_YAW
+      position: 0
+      gain: 10
+      torque: 100
+    - id: HEAD_PITCH
+      position: 0
+      gain: 10
+      torque: 100
+    - id: R_ELBOW
+      position: -0.154969901
+      gain: 10
+      torque: 100
+    - id: L_ELBOW
+      position: 0.124282785
+      gain: 10
+      torque: 100
+    - id: R_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_KNEE
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: 0
+      gain: 20
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: -0.0797864795
+      gain: 20
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.177985221
+      gain: 20
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.147
+      gain: 10
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.14710632
+      gain: 10
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.6954627
+      gain: 30
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 1.57271433
+      gain: 30
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0.0782521218
+      gain: 30
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.116611011
+      gain: 30
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0322214626
+      gain: 30
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.027618397
+      gain: 30
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.33425951
+      gain: 30
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.374343544
+      gain: 30
+      torque: 100

--- a/module/motion/ScriptEngine/data/scripts/nugus1/StandUpFront.yaml
+++ b/module/motion/ScriptEngine/data/scripts/nugus1/StandUpFront.yaml
@@ -154,12 +154,12 @@
       position: 2.5
       gain: 10
       torque: 100
-    - id: R_SHOULDER_ROLL
-      position: 0.100000001
+    - id: L_SHOULDER_ROLL
+      position: -0
       gain: 10
       torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0
+    - id: R_SHOULDER_ROLL
+      position: -0.00747998245
       gain: 10
       torque: 100
 - duration: 1000
@@ -493,55 +493,55 @@
 - duration: 3000
   targets:
     - id: R_HIP_YAW
-      position: -0.02915275
+      position: -0.0291527491
       gain: 30
       torque: 100
     - id: L_HIP_YAW
-      position: 0.01994662
+      position: 0.0199466199
       gain: 30
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.1503668
+      position: -0.150366798
       gain: 30
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.09819874
+      position: 0.0981987417
       gain: 30
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.4802532
+      position: -0.48025319
       gain: 30
       torque: 100
     - id: L_HIP_PITCH
-      position: -0.4909937
+      position: -0.490993708
       gain: 30
       torque: 100
     - id: R_KNEE
-      position: 0.7854941
+      position: 0.785494089
       gain: 30
       torque: 100
     - id: L_KNEE
-      position: 0.8269216
+      position: 0.826921582
       gain: 30
       torque: 100
     - id: R_ANKLE_PITCH
-      position: -0.5324213
+      position: -0.532421291
       gain: 30
       torque: 100
     - id: L_ANKLE_PITCH
-      position: -0.556971
+      position: -0.556971014
       gain: 30
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.1549699
+      position: 0.154969901
       gain: 30
       torque: 100
     - id: L_ANKLE_ROLL
-      position: -0.09513003
+      position: -0.0951300263
       gain: 30
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.98373
+      position: 1.98372996
       gain: 30
       torque: 100
     - id: R_SHOULDER_ROLL
@@ -549,18 +549,18 @@
       gain: 30
       torque: 100
     - id: R_ELBOW
-      position: -1.574249
+      position: -1.57424903
       gain: 30
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 2.068119
+      position: 2.06811905
       gain: 30
       torque: 100
     - id: L_SHOULDER_ROLL
-      position: 0.1348315
+      position: 0.134831503
       gain: 30
       torque: 100
     - id: L_ELBOW
-      position: -1.565042
+      position: -1.56504202
       gain: 30
       torque: 100


### PR DESCRIPTION
- Changed due to metal legs not quite managing to stand up from it's back. That's another issue that is being sorted.
- This will effect all robots as they will all have metal legs pretty soon.
- Adds RollOverBack.yaml
- Updates behaviour
- Evened out shoulder roll on stand up script
