### PR TITLE
Only include primary source files in Doxygen

### DIFF
--- a/.Doxyfile
+++ b/.Doxyfile
@@ -844,7 +844,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =
+INPUT                  = module shared
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -923,8 +923,7 @@ EXCLUDE_SYMLINKS       = NO
 # name of an input file. Doxygen will then use the output that the filter
 # program writes to standard output. If FILTER_PATTERNS is specified, this tag
 # will be ignored.
-EXCLUDE_PATTERNS       = "*/test/*"
-EXCLUDE_PATTERNS      += "report/*.cpp"
+EXCLUDE_PATTERNS       = "*/test/*" "*/tests/*"
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
We currently include all source files in the codebase for Doxygen. I feel its better if we stick to only the files in `shared` and `module` so as not to include the more obscure types in the documentation.