### PR TITLE
Make webots and nugus specific image compressor config

### DIFF
--- a/module/output/ImageCompressor/data/config/ImageCompressor.yaml
+++ b/module/output/ImageCompressor/data/config/ImageCompressor.yaml
@@ -1,15 +1,2 @@
 # Log level of DEBUG will print out compression rates
 log_level: WARN
-
-# The settings for each compressor
-# These compressors will be tried in order per camera id until a free compressor is found
-compressors:
-  # `vaapi` only works with access to intel GPU
-  # - name: vaapi
-  #   concurrent: 2
-  #   quality: 90
-  #   device: /dev/dri/renderD128
-  #   driver: iHD
-  - name: turbojpeg
-    concurrent: 2
-    quality: 90

--- a/module/output/ImageCompressor/data/config/nugus/ImageCompressor.yaml
+++ b/module/output/ImageCompressor/data/config/nugus/ImageCompressor.yaml
@@ -1,0 +1,9 @@
+# The settings for each compressor
+# These compressors will be tried in order per camera id until a free compressor is found
+compressors:
+  # `vaapi` only works with access to intel GPU
+  - name: vaapi
+    concurrent: 2
+    quality: 90
+    device: /dev/dri/renderD128
+    driver: iHD

--- a/module/output/ImageCompressor/data/config/webots/ImageCompressor.yaml
+++ b/module/output/ImageCompressor/data/config/webots/ImageCompressor.yaml
@@ -1,0 +1,6 @@
+# The settings for each compressor
+# These compressors will be tried in order per camera id until a free compressor is found
+compressors:
+  - name: turbojpeg
+    concurrent: 2
+    quality: 90


### PR DESCRIPTION
Webots uses turbojpeg to compress images, but the robot should use vaapi since it's set up for it and it's quicker. During RoboCup 2021, we changed the default config for ImageCompressor to use turbojpeg because this is what we needed for webots. This PR creates platform specific config for ImageCompressor so that webots will use turbojpeg and the robot will use vaapi.

This was mostly discovered due to a current memory leak in turbojpeg on the real robot, which should be fixed in a follow up PR. See #868.