### PR TITLE
Lock pacman date

### DIFF
--- a/doc/ArchInstall/arch-chroot_install.sh
+++ b/doc/ArchInstall/arch-chroot_install.sh
@@ -31,6 +31,12 @@ cat << EOF > /etc/hosts
 127.0.1.1       ${HOSTNAME}
 EOF
 
+# Lock the pacman date
+# ↓↓↓ UPDATE MIRRORS HERE ↓↓↓
+cat > /etc/pacman.d/mirrorlist << EOF
+Server=https://archive.archlinux.org/repos/2021/08/29/\$repo/os/\$arch
+EOF
+
 #########
 # USERS #
 #########


### PR DESCRIPTION
Currently we lock the date in the dockerfile, but we don't when we install on the robot. This leads to the us building with `libasan.so.6` but the robot has `libasan.so.8`.

https://wiki.archlinux.org/title/Arch_Linux_Archive#How_to_restore_all_packages_to_a_specific_date