### PR TITLE
Uses old visual mesh commit with opencl cashing on top

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -274,7 +274,7 @@ RUN mkdir -p /usr/local/include/zstr \
     && wget https://raw.githubusercontent.com/mateidavid/zstr/946ab409380e90e4a46c88c2da4f645a7ffaa51d/src/zstr_make_unique_polyfill.h -O /usr/local/include/zstr_make_unique_polyfill.h
 
 # Visual Mesh
-RUN install-from-source https://github.com/ysims/VisualMesh/1c8d08b8d93a438acce2dce0bcfe7e1f58509e1a.tar.gz \
+RUN install-from-source https://github.com/ysims/VisualMesh/archive/1c8d08b8d93a438acce2dce0bcfe7e1f58509e1a.tar.gz \
     -DBUILD_TENSORFLOW_OP=OFF \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_OPENCL_ENGINE=ON

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -274,7 +274,7 @@ RUN mkdir -p /usr/local/include/zstr \
     && wget https://raw.githubusercontent.com/mateidavid/zstr/946ab409380e90e4a46c88c2da4f645a7ffaa51d/src/zstr_make_unique_polyfill.h -O /usr/local/include/zstr_make_unique_polyfill.h
 
 # Visual Mesh
-RUN install-from-source https://github.com/Fastcode/VisualMesh/archive/refs/tags/v2.1.1.tar.gz \
+RUN install-from-source https://github.com/ysims/VisualMesh/1c8d08b8d93a438acce2dce0bcfe7e1f58509e1a.tar.gz \
     -DBUILD_TENSORFLOW_OP=OFF \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_OPENCL_ENGINE=ON


### PR DESCRIPTION
OpenCL caching on the old commit.
Webots breaks with latest visual mesh code.