### PR TITLE
Add an information source so the Director can communicate to the Behaviour DSL

### DIFF
--- a/module/extension/Director/src/Director.cpp
+++ b/module/extension/Director/src/Director.cpp
@@ -179,6 +179,10 @@ namespace module::extension {
     }
 
     Director::Director(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
+        if (source != nullptr) {
+            throw std::runtime_error("Multiple behaviour directors are not allowed.");
+        }
+        source = this;
 
         on<Configuration>("Director.yaml").then("Configure", [this](const Configuration& config) {
             log_level = config["log_level"].as<NUClear::LogLevel>();
@@ -267,6 +271,11 @@ namespace module::extension {
         on<Trigger<TaskPack>, Sync<Director>>().then("Run Task Pack", [this](const TaskPack& pack) {  //
             run_task_pack(pack);
         });
+    }
+
+    Director::~Director() {
+        // Remove this director as the information source
+        source = nullptr;
     }
 
 }  // namespace module::extension

--- a/module/extension/Director/src/Director.hpp
+++ b/module/extension/Director/src/Director.hpp
@@ -254,7 +254,7 @@ namespace module::extension {
 
         /// A list of reaction_task_ids to director_task objects, once the Provider has finished running it will emit
         /// all these as a pack so that the director can work out when Providers change which subtasks they emit
-        std::multimap<uint64_t, std::shared_ptr<const BehaviourTask>> pack_builder;
+        std::multimap<uint64_t, std::shared_ptr<const ::extension::behaviour::commands::BehaviourTask>> pack_builder;
 
     public:
         friend class InformationSource;

--- a/module/extension/Director/src/Director.hpp
+++ b/module/extension/Director/src/Director.hpp
@@ -30,7 +30,9 @@
 
 namespace module::extension {
 
-    class Director : public NUClear::Reactor {
+    class Director
+        : public NUClear::Reactor
+        , ::extension::behaviour::information::InformationSource {
     public:
         /// A task queue holds tasks in a provider that are waiting to be executed by that group
         using TaskQueue = std::vector<std::shared_ptr<const ::extension::behaviour::commands::BehaviourTask>>;
@@ -233,6 +235,16 @@ namespace module::extension {
     public:
         /// Called by the powerplant to build and setup the Director reactor.
         explicit Director(std::unique_ptr<NUClear::Environment> environment);
+        virtual ~Director();
+
+        /**
+         * @brief Provides the task data via the InformationSource interface so it can be accessed
+         *
+         * @param reaction_id the provider reaction that is requesting its information.
+         *
+         * @return the data that is stored in this reaction, or nullptr if it shouldn't be executing
+         */
+        std::shared_ptr<void> _get_task_data(const uint64_t& reaction_id) override;
 
     private:
         /// A list of Provider groups
@@ -242,7 +254,10 @@ namespace module::extension {
 
         /// A list of reaction_task_ids to director_task objects, once the Provider has finished running it will emit
         /// all these as a pack so that the director can work out when Providers change which subtasks they emit
-        std::multimap<uint64_t, std::shared_ptr<const ::extension::behaviour::commands::BehaviourTask>> pack_builder;
+        std::multimap<uint64_t, std::shared_ptr<const BehaviourTask>> pack_builder;
+
+    public:
+        friend class InformationSource;
     };
 
 }  // namespace module::extension

--- a/module/extension/Director/src/information/get_task_data.cpp
+++ b/module/extension/Director/src/information/get_task_data.cpp
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright 2021 NUbots <nubots@nubots.net>
+ * Copyright 2022 NUbots <nubots@nubots.net>
  */
 
 #include "Director.hpp"

--- a/module/extension/Director/src/information/get_task_data.cpp
+++ b/module/extension/Director/src/information/get_task_data.cpp
@@ -29,10 +29,10 @@ namespace module::extension {
 
         // Get the provider and group for the reaction
         auto provider = providers.at(reaction_id);
-        auto group    = provider->group;
+        auto group    = groups[provider->type];
 
         // Only the active provider is allowed to have data
-        if (group.active_provider != provider) {
+        if (provider->active) {
             return nullptr;
         }
 

--- a/module/extension/Director/src/information/get_task_data.cpp
+++ b/module/extension/Director/src/information/get_task_data.cpp
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2021 NUbots <nubots@nubots.net>
+ */
+
+#include "Director.hpp"
+
+namespace module::extension {
+
+    std::shared_ptr<void> Director::_get_task_data(const uint64_t& reaction_id) {
+        // How did we get here?
+        if (providers.count(reaction_id) == 0) {
+            return nullptr;
+        }
+
+        // Get the provider and group for the reaction
+        auto provider = providers.at(reaction_id);
+        auto group    = provider->group;
+
+        // Only the active provider is allowed to have data
+        if (group.active_provider != provider) {
+            return nullptr;
+        }
+
+        // If the task is of the wrong type we can't return it
+        if (group.active_task->type != provider->type) {
+            return nullptr;
+        }
+
+        // Return the data
+        return group.active_task->data;
+    }
+
+}  // namespace module::extension

--- a/shared/extension/behaviour/InformationSource.cpp
+++ b/shared/extension/behaviour/InformationSource.cpp
@@ -1,0 +1,5 @@
+#include "InformationSource.hpp"
+
+namespace extension::behaviour::information {
+    InformationSource* InformationSource::source = nullptr;
+}

--- a/shared/extension/behaviour/InformationSource.hpp
+++ b/shared/extension/behaviour/InformationSource.hpp
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2021 NUbots <nubots@nubots.net>
+ */
+#ifndef EXTENSION_BEHAVIOUR_INFORMATIONSOURCE_HPP
+#define EXTENSION_BEHAVIOUR_INFORMATIONSOURCE_HPP
+
+#include <memory>
+#include <typeindex>
+
+namespace extension::behaviour::information {
+
+    /**
+     * @brief This class is an abstract class that allows the static Behaviour DSL to access the relevant state from the
+     * algorithm that is backing it.
+     *
+     * Extend this class to provide whatever information is needed for outputs in the DSL.
+     */
+    class InformationSource {
+    protected:
+        /// This static variable gets set by whatever class is acting as the information source
+        static InformationSource* source;
+
+        /**
+         * @brief Internal get task data function. Is overridden by the class that is acting as the information source.
+         *
+         * @param reaction_id the reaction id of the reaction that is asking for data
+         *
+         * @return a void shared pointer to the data for this reaction
+         */
+        virtual std::shared_ptr<void> _get_task_data(const uint64_t& reaction_id) = 0;
+
+    public:
+        virtual ~InformationSource() = default;
+
+        /**
+         * @brief Static method that redirects to the singleton instance providing the InformationSource
+         *
+         * @param reaction_id the reaction id of the reaction that is asking for data
+         *
+         * @return a void shared pointer to the data for this reaction
+         */
+        static std::shared_ptr<void> get_task_data(const uint64_t& reaction_id) {
+            return source->_get_task_data(reaction_id);
+        }
+    };
+
+}  // namespace extension::behaviour::information
+
+#endif  // EXTENSION_BEHAVIOUR_INFORMATIONSOURCE_HPP


### PR DESCRIPTION
This adds an InformationSource class interface that lets the Behaviour DSL communicate with the Director so they can provide information about the task that is running