### PR TITLE
Remove Darwin Global Config and Update Default for 2022

### DIFF
--- a/module/support/configuration/GlobalConfig/data/config/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/GlobalConfig.yaml
@@ -1,2 +1,2 @@
 player_id: 1
-team_id: 12
+team_id: 1

--- a/module/support/configuration/GlobalConfig/data/config/darwin1/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/darwin1/GlobalConfig.yaml
@@ -1,1 +1,0 @@
-player_id: 1

--- a/module/support/configuration/GlobalConfig/data/config/darwin2/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/darwin2/GlobalConfig.yaml
@@ -1,1 +1,0 @@
-player_id: 2

--- a/module/support/configuration/GlobalConfig/data/config/darwin3/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/darwin3/GlobalConfig.yaml
@@ -1,1 +1,0 @@
-player_id: 3

--- a/module/support/configuration/GlobalConfig/data/config/darwin4/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/darwin4/GlobalConfig.yaml
@@ -1,1 +1,0 @@
-player_id: 4

--- a/module/support/configuration/GlobalConfig/data/config/darwin5/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/darwin5/GlobalConfig.yaml
@@ -1,1 +1,0 @@
-player_id: 5

--- a/module/support/configuration/GlobalConfig/data/config/darwin6/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/darwin6/GlobalConfig.yaml
@@ -1,1 +1,0 @@
-player_id: 6


### PR DESCRIPTION
Removes the Darwin config, since it's not really needed.

Updates the default team ID to the team ID for 2022. This will be useful during practice games until next competition.