### PR TITLE
Disable cpu mitigations

### DIFF
--- a/module/tools/SystemConfiguration/data/system/default/etc/default/grub
+++ b/module/tools/SystemConfiguration/data/system/default/etc/default/grub
@@ -3,7 +3,8 @@
 GRUB_DEFAULT=0
 GRUB_TIMEOUT=0
 GRUB_DISTRIBUTOR="Arch"
-GRUB_CMDLINE_LINUX_DEFAULT="loglevel=3 quiet"
+# Only turn mitigations off on the robot! On the robot we're not risking too much, but on anything else this is bad.
+GRUB_CMDLINE_LINUX_DEFAULT="loglevel=3 quiet mitigations=off"
 GRUB_CMDLINE_LINUX=""
 
 # Preload both GPT and MBR modules so that they are not missed


### PR DESCRIPTION
Accidentality broke #904, here it is again.

Looking at a Phoronix [article](https://www.phoronix.com/scan.php?page=article&item=3-years-specmelt&num=1) we can see that there is a [decent amount](https://openbenchmarking.org/result/2101067-HA-MITIGATIO26&imw=1&sgm=1&imw=1) of performance used in mitigating. I think that we should consider these risks and determine if the performance is worth it. I'm planning to update the docker image, but in 5.19 retbleed is fixed with yet another [performance hit](https://www.phoronix.com/scan.php?page=article&item=retbleed-benchmark&num=1).

### Things left to do

- [ ] Test
- [x] Discuss if these risks are worth taking. (I believe that we should be fine)