### PR TITLE
Remove wants to kick from walk path planner

### DIFF
--- a/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
+++ b/module/behaviour/planning/SimpleWalkPathPlanner/src/SimpleWalkPathPlanner.cpp
@@ -123,37 +123,29 @@ namespace module::behaviour::planning {
         // Freq should be equal to the main loop in soccer strategy. TODO (Bryce Tuppurainen): Potentially
         // change this value to a define in an included header if this will be used again for added design cohesion if
         // this will be something we change in future
-        on<Every<30, Per<std::chrono::seconds>>, With<WantsToKick>, Sync<SimpleWalkPathPlanner>>().then(
-            [this](const WantsToKick& wants_to) {
-                //  Stop the walk engine and path planner if the KickPlanner module emits a WantsToKick message saying
-                //  it is executing a kick
-                if (wants_to.kick) {
+        on<Every<30, Per<std::chrono::seconds>>, Sync<SimpleWalkPathPlanner>>().then([this]() {
+            switch (static_cast<int>(latest_command.type.value)) {
+                case message::behaviour::MotionCommand::Type::STAND_STILL:
                     emit(std::make_unique<StopCommand>(subsumption_id));
                     return;
-                }
 
-                switch (static_cast<int>(latest_command.type.value)) {
-                    case message::behaviour::MotionCommand::Type::STAND_STILL:
-                        emit(std::make_unique<StopCommand>(subsumption_id));
-                        return;
+                case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walk_directly(); return;
 
-                    case message::behaviour::MotionCommand::Type::DIRECT_COMMAND: walk_directly(); return;
+                case message::behaviour::MotionCommand::Type::BALL_APPROACH: vision_walk_path(); return;
 
-                    case message::behaviour::MotionCommand::Type::BALL_APPROACH: vision_walk_path(); return;
+                // TODO(MotionTeam): Walk to a given position and heading on the field, avoiding obstacles
+                case message::behaviour::MotionCommand::Type::WALK_TO_STATE: return;
 
-                    // TODO(MotionTeam): Walk to a given position and heading on the field, avoiding obstacles
-                    case message::behaviour::MotionCommand::Type::WALK_TO_STATE: return;
+                case message::behaviour::MotionCommand::Type::ROTATE_ON_SPOT: rotate_on_spot(); return;
 
-                    case message::behaviour::MotionCommand::Type::ROTATE_ON_SPOT: rotate_on_spot(); return;
-
-                    case message::behaviour::MotionCommand::Type::WALK_TO_READY: walk_to_ready(); return;
-                    default:  // This line should be UNREACHABLE
-                        log<NUClear::ERROR>(
-                            fmt::format("Invalid walk path planning command {}.", latest_command.type.value));
-                        emit(std::make_unique<StopCommand>(subsumption_id));
-                        return;
-                }
-            });
+                case message::behaviour::MotionCommand::Type::WALK_TO_READY: walk_to_ready(); return;
+                default:  // This line should be UNREACHABLE
+                    log<NUClear::ERROR>(
+                        fmt::format("Invalid walk path planning command {}.", latest_command.type.value));
+                    emit(std::make_unique<StopCommand>(subsumption_id));
+                    return;
+            }
+        });
 
         // Save the plan cmd into latest_command
         on<Trigger<MotionCommand>, Sync<SimpleWalkPathPlanner>>().then(


### PR DESCRIPTION
`robocup` on `main` is broken, the robot won't walk because SimpleWalkPathPlanner expects a `WantsToKick` message and it never gets one. It came from KickPlanner, but we don't use it anymore and it was removed from the role at some point.