### PR TITLE
Show error details when NUsight Storybook build fails

### DIFF
--- a/nusight2/conf/storybook/webpack.config.ts
+++ b/nusight2/conf/storybook/webpack.config.ts
@@ -28,5 +28,8 @@ export default ({ config: storybookConfig }: { config: webpack.Configuration }) 
         ...(config.resolve?.extensions || []),
       ],
     },
+    stats: {
+      errorDetails: true,
+    },
   }
 }


### PR DESCRIPTION
Currently a failed webpack build of Storybook (due to a syntax error for example) shows no details about where the error is. This PR makes it show the source of the errors.

<details>
<summary>Before (with a syntax error)</summary>

![screenshot of build failure with no details](https://user-images.githubusercontent.com/5924865/188395449-c3b7a425-3eb5-49f4-a83c-fd527ad1bcaa.png)

</details>

<details>
<summary>After (with a syntax error)</summary>

![screenshot of build failure showing details](https://user-images.githubusercontent.com/5924865/188395763-6dc23be9-bdb3-4b46-a39f-d261986d2edf.png)

</details>