### PR TITLE
Show camera name on images in NUsight

### DIFF
--- a/nusight2/src/client/components/vision/camera/styles.css
+++ b/nusight2/src/client/components/vision/camera/styles.css
@@ -10,3 +10,16 @@
   top: 0;
   right: 0;
 }
+
+.cameraName {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px;
+  border-radius: 4px;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 14px;
+  line-height: 1;
+}

--- a/nusight2/src/client/components/vision/camera/view.tsx
+++ b/nusight2/src/client/components/vision/camera/view.tsx
@@ -27,6 +27,7 @@ export class CameraView extends Component<CameraViewProps> {
         <div className={styles.menu}>
           <SwitchesMenu dropdownMenuPosition="right" options={this.drawOptions} />
         </div>
+        <div className={styles.cameraName}>{this.props.model.name} </div>
       </div>
     )
   }


### PR DESCRIPTION
No more "which one is the left camera?" This PR updates vision to show the camera name on each image.