### PR TITLE
Disable CI Build

### DIFF
--- a/.github/workflows/nubots.yaml
+++ b/.github/workflows/nubots.yaml
@@ -142,7 +142,7 @@ jobs:
         run: mkdir -p ../build
 
       - name: Configure the code
-        run: ./b configure -- -DBUILD_TESTS=ON -DCI_BUILD=ON
+        run: ./b configure -- -DBUILD_TESTS=ON # -DCI_BUILD=ON
 
       - name: Build the code
         run: ./b build


### PR DESCRIPTION
We're not actually ready for CI build, it was never on to begin with see #900.