### PR TITLE
Allow empty platforms in Configuration extension

### DIFF
--- a/shared/extension/Configuration.hpp
+++ b/shared/extension/Configuration.hpp
@@ -82,7 +82,7 @@ namespace extension {
             }
 
             // If the same file exists in this platform's per-platform config directory then load and merge
-            if (fs::exists(fs::path("config") / platform / fileName)) {
+            if (fs::exists(fs::path("config") / platform / fileName) && !platform.empty()) {
                 if (loaded) {
                     config = merge_yaml_nodes(config, YAML::LoadFile(fs::path("config") / platform / fileName));
                 }
@@ -387,7 +387,6 @@ namespace NUClear::dsl {
 
                 // If it's the installation phase, and the path contains anything indicating it is not default config,
                 // then don't let the reaction run
-
                 if (watch.events == ::extension::FileWatch::Event::NO_OP
                     && (str_exists(hostname) || str_exists(platform) || str_exists(binaryName))) {
                     return false;


### PR DESCRIPTION
https://github.com/NUbots/NUbots/actions/runs/3216813323/jobs/5259088665#step:7:110
This failed because no platform, I guess a GitHub actions thing? Anyway this allows for no platforms by returning an empty string and checking for empty around the place. Tested on https://github.com/NUbots/NUbots/pull/963 and it seems to work :shrug: 