### PR TITLE
Fix challenge priority function in Director and adds a test that targets the error

### DIFF
--- a/module/extension/Director/src/director/challenge_priority.cpp
+++ b/module/extension/Director/src/director/challenge_priority.cpp
@@ -53,8 +53,8 @@ namespace module::extension {
             return false;
         }
 
-        // A provider can always replace its own task with a new challenger
-        if (incumbent->requester_id == challenger->requester_id) {
+        // A provider of the same group can always replace its own task with a new challenger
+        if (providers.at(incumbent->requester_id)->type == providers.at(challenger->requester_id)->type) {
             return true;
         }
 
@@ -66,21 +66,20 @@ namespace module::extension {
             std::vector<TaskPriority> ancestors;
 
             // Loop up through the providers until we reach a point where a task was emitted by a root provider
-            for (auto t = task; providers.at(t->requester_id)->classification != Provider::Classification::ROOT;) {
+            // We recognise that we have passed a root provider when the active task is nullptr
+            auto t = task;
+            do {
+                ancestors.emplace_back(t->type, t->priority, t->optional);
+                auto p              = providers.at(t->requester_id);
+                auto classification = p->classification;
+                t                   = p->group.active_task;
 
-                // Get the provider that emitted this task, and from that the provider group
-                auto provider = providers.at(t->requester_id);
-                auto& group   = provider->group;
-
-                // If there is no active task something has gone wrong with the algorithm
-                if (group.active_task == nullptr) {
+                // Check if we reached a nullptr task but we are not a root provider
+                if (t == nullptr && classification != Provider::Classification::ROOT) {
                     throw std::runtime_error("Task has broken parentage");
                 }
+            } while (t != nullptr);
 
-                // Add this new parent we found and set t so we can loop up further
-                t = group.active_task;
-                ancestors.emplace_back(provider->type, t->priority, t->optional);
-            }
             return ancestors;
         };
 
@@ -91,9 +90,7 @@ namespace module::extension {
         // Remove all of the common ancestors
         // If one of the lists ends up empty that means that it is a direct ancestor of the other
         // If either ends up as nullptr_t that means that it is a root task and we don't remove it
-        while ((!i_p.empty() && !c_p.empty())
-               && (i_p.back().requester != typeid(nullptr_t) && c_p.back().requester != typeid(nullptr_t))
-               && (i_p.back().requester == c_p.back().requester)) {
+        while ((!i_p.empty() && !c_p.empty()) && (i_p.back().requester == c_p.back().requester)) {
             i_p.pop_back();
             c_p.pop_back();
         }

--- a/module/extension/Director/src/director/challenge_priority.cpp
+++ b/module/extension/Director/src/director/challenge_priority.cpp
@@ -60,9 +60,6 @@ namespace module::extension {
 
         // Function to get the priorities of the ancestors of this task
         auto get_ancestor_priorities = [this](const std::shared_ptr<BehaviourTask>& task) {
-            // We are our first ancestor.
-            // However, the task might be a root task, in which case we won't have any provider
-            // In that case we set the type to nullptr_t to indicate that we are a root task
             std::vector<TaskPriority> ancestors;
 
             // Loop up through the providers until we reach a point where a task was emitted by a root provider

--- a/module/extension/Director/src/director/challenge_priority.cpp
+++ b/module/extension/Director/src/director/challenge_priority.cpp
@@ -64,10 +64,6 @@ namespace module::extension {
             // However, the task might be a root task, in which case we won't have any provider
             // In that case we set the type to nullptr_t to indicate that we are a root task
             std::vector<TaskPriority> ancestors;
-            ancestors.emplace_back(
-                providers.contains(task->requester_id) ? providers.at(task->requester_id)->type : typeid(nullptr_t),
-                task->priority,
-                task->optional);
 
             // Loop up through the providers until we reach a point where a task was emitted by a root provider
             for (auto t = task; providers.at(t->requester_id)->classification != Provider::Classification::ROOT;) {

--- a/module/extension/Director/tests/challenge_child.cpp
+++ b/module/extension/Director/tests/challenge_child.cpp
@@ -1,0 +1,87 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2022 NUbots <nubots@nubots.net>
+ */
+
+#include <catch.hpp>
+#include <nuclear>
+
+#include "Director.hpp"
+#include "TestBase.hpp"
+#include "util/diff_string.hpp"
+
+// Anonymous namespace to avoid name collisions
+namespace {
+
+    struct SimpleTask {};
+
+    struct SubTask {};
+
+    std::vector<std::string> events;
+
+    class TestReactor : public TestBase<TestReactor> {
+    public:
+        explicit TestReactor(std::unique_ptr<NUClear::Environment> environment)
+            : TestBase<TestReactor>(std::move(environment)) {
+
+            on<Provide<SimpleTask>, Needs<SubTask>>().then([this] {
+                // Task has been executed!
+                events.push_back("simple task executed");
+                emit<Task>(std::make_unique<SubTask>());
+            });
+
+            on<Provide<SubTask>>().then([this] { events.push_back("subtask executed"); });
+
+            /**************
+             * TEST STEPS *
+             **************/
+            on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+                events.push_back("emitting task");
+                emit<Task>(std::make_unique<SimpleTask>());
+            });
+            on<Startup>().then([this] {  //
+                emit(std::make_unique<Step<1>>());
+                emit(std::make_unique<Step<1>>());
+            });
+        }
+    };
+}  // namespace
+
+TEST_CASE("Tests that director works when a parent is challenging its needs child", "[director][needs][challenge]") {
+
+    NUClear::PowerPlant::Configuration config;
+    config.thread_count = 1;
+    NUClear::PowerPlant powerplant(config);
+    powerplant.install<module::extension::Director>();
+    powerplant.install<TestReactor>();
+    powerplant.start();
+
+    std::vector<std::string> expected = {
+        "emitting task",
+        "simple task executed",
+        "subtask executed",
+        "emitting task",
+        "simple task executed",
+        "subtask executed",
+    };
+
+    // Make an info print the diff in an easy to read way if we fail
+    INFO(util::diff_string(expected, events));
+
+    // Check the events fired in order and only those events
+    REQUIRE(events == expected);
+}

--- a/module/extension/Director/tests/challenge_child.cpp
+++ b/module/extension/Director/tests/challenge_child.cpp
@@ -61,7 +61,7 @@ namespace {
     };
 }  // namespace
 
-TEST_CASE("Tests that director works when a parent is challenging its needs child", "[director][needs][challenge]") {
+TEST_CASE("Test that a parent task wins when challenging its child task", "[director][needs][challenge]") {
 
     NUClear::PowerPlant::Configuration config;
     config.thread_count = 1;


### PR DESCRIPTION
`challenge_priority` function was broken, the ancestors were not right. This prevented a parent task from beating its child in the `challenge_priority` function. This PR adds a test for that case and fixes the function. 