### PR TITLE
Add extra information so Director Providers can know why they were executed

### DIFF
--- a/module/extension/Director/src/Director.cpp
+++ b/module/extension/Director/src/Director.cpp
@@ -24,6 +24,7 @@
 namespace module::extension {
 
     using ::extension::Configuration;
+    using ::extension::behaviour::RunInfo;
     using ::extension::behaviour::commands::BehaviourTask;
     using ::extension::behaviour::commands::CausingExpression;
     using ::extension::behaviour::commands::NeedsExpression;
@@ -33,6 +34,9 @@ namespace module::extension {
     using provider::Provider;
     using provider::ProviderGroup;
     using Unbind = NUClear::dsl::operation::Unbind<ProvideReaction>;
+
+
+    thread_local RunInfo::RunReason Director::current_run_reason = RunInfo::RunReason::OTHER_TRIGGER;
 
     /**
      * This message gets emitted when a state we are monitoring is updated.

--- a/module/extension/Director/src/Director.hpp
+++ b/module/extension/Director/src/Director.hpp
@@ -391,7 +391,7 @@ namespace module::extension {
          *
          * @param reason the reason to hold until the lock is destroyed
          *
-         * @return a lock object that will reset the current run reason when it is destroyed
+         * @return a lock object that will reset `current_run_reason` to its default when destroyed
          */
         RunReasonLock hold_run_reason(const ::extension::behaviour::RunInfo::RunReason& reason);
 

--- a/module/extension/Director/src/Director.hpp
+++ b/module/extension/Director/src/Director.hpp
@@ -321,11 +321,13 @@ namespace module::extension {
         /**
          * Runs the passed task on the passed provider.
          *
-         * @param task      the task we are running
-         * @param provider  the provider that we are running the task on
+         * @param task          the task we are running
+         * @param provider      the provider that we are running the task on
+         * @param run_reason    the reason that we are running this task
          */
         void run_task_on_provider(const std::shared_ptr<BehaviourTask>& task,
-                                  const std::shared_ptr<provider::Provider>& provider);
+                                  const std::shared_ptr<provider::Provider>& provider,
+                                  const ::extension::behaviour::RunInfo::RunReason& run_reason);
 
         /**
          * The level of solution that we can run at
@@ -370,19 +372,48 @@ namespace module::extension {
          */
         void run_task_pack(const TaskPack& pack);
 
+        /**
+         * A RunReasonLock instance will reset the current_run_reason back to OTHER_TRIGGER when it is destroyed.
+         *
+         * This is used so that the run reason can temporarily be set to something else, and then reset back to the
+         * default if there is an exception or other error.
+         */
+        using RunReasonLock = std::unique_ptr<void, std::function<void(void*)>>;
+
+        /**
+         * Holds a run reason as the current run reason for the current thread.
+         *
+         * It returns a lock object that acts as an RAII object that will reset the current run reason when it is
+         * destroyed.
+         *
+         * @param reason the reason to hold until the lock is destroyed
+         *
+         * @return a lock object that will reset the current run reason when it is destroyed
+         */
+        RunReasonLock hold_run_reason(const ::extension::behaviour::RunInfo::RunReason& reason);
+
     public:
         /// Called by the powerplant to build and setup the Director reactor.
         explicit Director(std::unique_ptr<NUClear::Environment> environment);
         virtual ~Director();
 
         /**
-         * @brief Provides the task data via the InformationSource interface so it can be accessed
+         * Provides the task data via the InformationSource interface so it can be accessed
          *
          * @param reaction_id the provider reaction that is requesting its information.
          *
          * @return the data that is stored in this reaction, or nullptr if it shouldn't be executing
          */
         std::shared_ptr<void> _get_task_data(const uint64_t& reaction_id) override;
+
+        /**
+         * Provides the RunInfo data via the InformationSource interface so it can be accessed
+         *
+         * @param reaction_id the provider reaction that is requesting its information.
+         *
+         * @return the information about why this task has been executed
+         */
+        ::extension::behaviour::RunInfo _get_run_info(const uint64_t& reaction_id) override;
 
     private:
         /// A list of Provider groups
@@ -392,6 +423,10 @@ namespace module::extension {
 
         /// A source for unique reaction ids when making root task providers. Starts at 0 and wraps around to maxvalue.
         uint64_t unique_id_source = 0;
+
+        /// The current run reason this thread is executing for. Defaults to OTHER_TRIGGER as that will be what it
+        /// is if a non Director execution occurs
+        thread_local static ::extension::behaviour::RunInfo::RunReason current_run_reason;
 
         /// A list of reaction_task_ids to director_task objects, once the Provider has finished running it will emit
         /// all these as a pack so that the director can work out when Providers change which subtasks they emit

--- a/module/extension/Director/src/director/hold_run_reason.cpp
+++ b/module/extension/Director/src/director/hold_run_reason.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2022 NUbots <nubots@nubots.net>
+ */
+
+#include <memory>
+
+#include "Director.hpp"
+
+#include "extension/Behaviour.hpp"
+
+namespace module::extension {
+
+    using ::extension::behaviour::RunInfo;
+
+    Director::RunReasonLock Director::hold_run_reason(const RunInfo::RunReason& reason) {
+        current_run_reason = reason;
+        // We just set this on this unique pointer so that it's not null
+        // If it's null the unique pointer not run the deleter
+        // We don't actually use the pointer for anything so the value is irrelevant
+        return RunReasonLock(this, [this](void*) { current_run_reason = RunInfo::RunReason::OTHER_TRIGGER; });
+    }
+
+}  // namespace module::extension

--- a/module/extension/Director/src/director/remove_task.cpp
+++ b/module/extension/Director/src/director/remove_task.cpp
@@ -22,6 +22,7 @@
 
 namespace module::extension {
 
+    using ::extension::behaviour::RunInfo;
     using ::extension::behaviour::commands::BehaviourTask;
     using provider::Provider;
 
@@ -53,6 +54,7 @@ namespace module::extension {
                 for (auto& provider : group.providers) {
                     if (provider->classification == Provider::Classification::STOP) {
                         group.active_provider = provider;
+                        auto lock             = hold_run_reason(RunInfo::RunReason::STOPPED);
                         auto task             = provider->reaction->get_task();
                         if (task) {
                             task->run(std::move(task));

--- a/module/extension/Director/src/director/run_task_on_provider.cpp
+++ b/module/extension/Director/src/director/run_task_on_provider.cpp
@@ -38,7 +38,7 @@ namespace module::extension {
         if (run_start_providers) {
             for (auto& provider : group.providers) {
                 if (provider->classification == Provider::Classification::START) {
-                    // We have to swap to this as the active provdider so it can actually run
+                    // We have to swap to this as the active provider so it can actually run
                     group.active_provider = provider;
 
                     auto lock = hold_run_reason(RunInfo::RunReason::STARTED);

--- a/module/extension/Director/src/director/run_task_pack.cpp
+++ b/module/extension/Director/src/director/run_task_pack.cpp
@@ -21,6 +21,7 @@
 
 namespace module::extension {
 
+    using ::extension::behaviour::RunInfo;
     using provider::Provider;
     using provider::ProviderGroup;
 
@@ -84,8 +85,7 @@ namespace module::extension {
                         if (current_task != nullptr
                             && providers.at(current_task->requester_id)->type
                                    == providers.at(new_task->requester_id)->type) {
-
-                            run_task_on_provider(new_task, main_provider);
+                            run_task_on_provider(new_task, main_provider, RunInfo::RunReason::NEW_TASK);
                         }
                         else {
                             if (current_task != nullptr) {
@@ -113,7 +113,7 @@ namespace module::extension {
                             }
 
                             // Run this specific task using this specific provider
-                            run_task_on_provider(new_task, main_provider);
+                            run_task_on_provider(new_task, main_provider, RunInfo::RunReason::NEW_TASK);
                         }
                     }
                 }
@@ -174,7 +174,10 @@ namespace module::extension {
                     remove_task(task);
                 }
                 else {
-                    run_task_on_provider(parent_group.active_task, parent_group.active_provider);
+                    // TODO check somehow if this provider is equipped to handle done
+                    run_task_on_provider(parent_group.active_task,
+                                         parent_group.active_provider,
+                                         RunInfo::RunReason::SUBTASK_DONE);
                 }
 
                 if (pack.second.size() > 1) {

--- a/module/extension/Director/src/director/run_task_pack.cpp
+++ b/module/extension/Director/src/director/run_task_pack.cpp
@@ -174,7 +174,7 @@ namespace module::extension {
                     remove_task(task);
                 }
                 else {
-                    // TODO check somehow if this provider is equipped to handle done
+                    // TODO(thouliston) check somehow if this provider is equipped to handle done
                     run_task_on_provider(parent_group.active_task,
                                          parent_group.active_provider,
                                          RunInfo::RunReason::SUBTASK_DONE);

--- a/module/extension/Director/src/information/get_run_info.cpp
+++ b/module/extension/Director/src/information/get_run_info.cpp
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2022 NUbots <nubots@nubots.net>
+ */
+
+#include "Director.hpp"
+
+namespace module::extension {
+
+    using ::extension::behaviour::RunInfo;
+
+    RunInfo Director::_get_run_info(const uint64_t& /*reaction_id*/) {
+
+        return RunInfo{current_run_reason};
+    }
+
+}  // namespace module::extension

--- a/module/extension/Director/tests/run_reason.cpp
+++ b/module/extension/Director/tests/run_reason.cpp
@@ -1,0 +1,148 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2022 NUbots <nubots@nubots.net>
+ */
+
+#include <catch.hpp>
+#include <nuclear>
+
+#include "Director.hpp"
+#include "TestBase.hpp"
+#include "util/diff_string.hpp"
+
+// Anonymous namespace to avoid name collisions
+namespace {
+
+    struct SimpleTask {};
+    struct Subtask {};
+    struct TriggerTest {};
+
+    std::vector<std::string> events;
+
+    class TestReactor : public TestBase<TestReactor> {
+    public:
+        std::string decode_reason(const RunInfo::RunReason& reason) {
+            switch (reason) {
+                case RunInfo::RunReason::OTHER_TRIGGER: return "OTHER_TRIGGER"; break;
+                case RunInfo::RunReason::NEW_TASK: return "NEW_TASK"; break;
+                case RunInfo::RunReason::STARTED: return "STARTED"; break;
+                case RunInfo::RunReason::STOPPED: return "STOPPED"; break;
+                case RunInfo::RunReason::SUBTASK_DONE: return "SUBTASK_DONE"; break;
+                case RunInfo::RunReason::PUSHED: return "PUSHED"; break;
+                default: return "ERROR"; break;
+            };
+        }
+
+        explicit TestReactor(std::unique_ptr<NUClear::Environment> environment)
+            : TestBase<TestReactor>(std::move(environment)) {
+
+            on<Provide<SimpleTask>, Trigger<TriggerTest>>().then([this](const RunInfo& info) {
+                events.push_back("simple task ran because: " + decode_reason(info.run_reason));
+
+                // If we get a new task then emit a subtask
+                // When we re-run because of SUBTASK_DONE we won't re-emit this subtask making it stop
+                if (info.run_reason == RunInfo::RunReason::NEW_TASK) {
+                    events.push_back("emitting subtask");
+                    emit<Task>(std::make_unique<Subtask>());
+                }
+
+                if (info.run_reason == RunInfo::RunReason::OTHER_TRIGGER) {
+                    events.push_back("emitting simple task done");
+                    emit<Task>(std::make_unique<Done>());
+                }
+            });
+
+            on<Start<SimpleTask>>().then([this](const RunInfo& info) {  //
+                events.push_back("simple task started because: " + decode_reason(info.run_reason));
+            });
+            on<Stop<SimpleTask>>().then([this](const RunInfo& info) {  //
+                events.push_back("simple task stopped because: " + decode_reason(info.run_reason));
+            });
+
+            // This subtask will immediately return done
+            on<Provide<Subtask>, Trigger<TriggerTest>>().then([this](const RunInfo& info) {
+                events.push_back("subtask ran because: " + decode_reason(info.run_reason));
+                events.push_back("emitting subtask done");
+                emit<Task>(std::make_unique<Done>());
+            });
+
+            on<Start<Subtask>>().then([this](const RunInfo& info) {  //
+                events.push_back("subtask started because: " + decode_reason(info.run_reason));
+            });
+            on<Stop<Subtask>>().then([this](const RunInfo& info) {  //
+                events.push_back("subtask stopped because: " + decode_reason(info.run_reason));
+            });
+
+            /**************
+             * TEST STEPS *
+             **************/
+            on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+                // Emit initial trigger test so we can run the task
+                emit(std::make_unique<TriggerTest>());
+                // Checks STARTED, NEW_TASK, SUBTASK_DONE and STOPPED for subtask
+                events.push_back("emitting simple task");
+                emit<Task>(std::make_unique<SimpleTask>());
+            });
+            on<Trigger<Step<2>>, Priority::LOW>().then([this] {
+                // Checks OTHER_TRIGGER and STOPPED for simple task
+                events.push_back("emitting trigger test");
+                emit(std::make_unique<TriggerTest>());
+            });
+
+            on<Startup>().then([this] {
+                emit(std::make_unique<Step<1>>());
+                emit(std::make_unique<Step<2>>());
+                emit(std::make_unique<Step<3>>());
+            });
+        }
+    };
+
+}  // namespace
+
+TEST_CASE("Tests that the reason for a provider being executed can be provided in its RunInfo",
+          "[director][triggered][runinfo][runreason]") {
+
+    // Run the module
+    NUClear::PowerPlant::Configuration config;
+    config.thread_count = 1;
+    NUClear::PowerPlant powerplant(config);
+    powerplant.install<module::extension::Director>();
+    powerplant.install<TestReactor>();
+    powerplant.start();
+
+    std::vector<std::string> expected = {
+        "emitting simple task",
+        "simple task started because: STARTED",
+        "simple task ran because: NEW_TASK",
+        "emitting subtask",
+        "subtask started because: STARTED",
+        "subtask ran because: NEW_TASK",
+        "emitting subtask done",
+        "simple task ran because: SUBTASK_DONE",
+        "subtask stopped because: STOPPED",
+        "emitting trigger test",
+        "simple task ran because: OTHER_TRIGGER",
+        "emitting simple task done",
+        "simple task stopped because: STOPPED",
+    };
+
+    // Make an info print the diff in an easy to read way if we fail
+    INFO(util::diff_string(expected, events));
+
+    // Check the events fired in order and only those events
+    REQUIRE(events == expected);
+}

--- a/shared/extension/Behaviour.hpp
+++ b/shared/extension/Behaviour.hpp
@@ -69,8 +69,12 @@ namespace extension::behaviour {
          * @return the information needed by the on statement
          */
         template <typename DSL>
-        static inline std::shared_ptr<T> get(NUClear::threading::Reaction& r) {
-            return std::static_pointer_cast<T>(information::InformationSource::get_task_data(r.id));
+        static inline std::tuple<std::shared_ptr<const T>, std::shared_ptr<const RunInfo>> get(
+            NUClear::threading::Reaction& r) {
+
+            auto run_info = std::make_shared<RunInfo>(information::InformationSource::get_run_info(r.id));
+            auto run_data = std::static_pointer_cast<T>(information::InformationSource::get_task_data(r.id));
+            return std::make_tuple(run_data, run_info);
         }
 
         /**
@@ -350,9 +354,10 @@ namespace extension::behaviour {
         template <typename T>
         using Uses = ::extension::behaviour::Uses<T>;
         template <typename T>
-        using Task = ::extension::behaviour::Task<T>;
-        using Done = ::extension::behaviour::Done;
-        using Idle = ::extension::behaviour::Idle;
+        using Task    = ::extension::behaviour::Task<T>;
+        using RunInfo = ::extension::behaviour::RunInfo;
+        using Done    = ::extension::behaviour::Done;
+        using Idle    = ::extension::behaviour::Idle;
     };
 
 }  // namespace extension::behaviour


### PR DESCRIPTION
Adds an optional RunInfo object that can be given alongside a provider that can give additional information about why it was run.
Currently only provides an enum that describes the reason the provider was executed.