### PR TITLE
Use a recursive mutex in Director instead of Sync

### DIFF
--- a/module/extension/Director/src/Director.cpp
+++ b/module/extension/Director/src/Director.cpp
@@ -204,33 +204,39 @@ namespace module::extension {
         });
 
         // Removes all the Providers for a reaction when it is unbound
-        on<Trigger<Unbind>, Sync<Director>>().then("Remove Provider", [this](const Unbind& unbind) {  //
+        on<Trigger<Unbind>>().then("Remove Provider", [this](const Unbind& unbind) {  //
+            std::lock_guard<std::recursive_mutex> lock(director_mutex);
             remove_provider(unbind.id);
         });
 
         // Add a Provider
-        on<Trigger<ProvideReaction>, Sync<Director>>().then("Add Provider", [this](const ProvideReaction& provide) {
+        on<Trigger<ProvideReaction>>().then("Add Provider", [this](const ProvideReaction& provide) {
+            std::lock_guard<std::recursive_mutex> lock(director_mutex);
             add_provider(provide);
         });
 
         // Add a when expression to this Provider
-        on<Trigger<WhenExpression>, Sync<Director>>().then("Add When", [this](const WhenExpression& when) {  //
+        on<Trigger<WhenExpression>>().then("Add When", [this](const WhenExpression& when) {  //
+            std::lock_guard<std::recursive_mutex> lock(director_mutex);
             add_when(when);
         });
 
         // Add a causing condition to this Provider
-        on<Trigger<CausingExpression>, Sync<Director>>().then("Add Causing", [this](const CausingExpression& causing) {
+        on<Trigger<CausingExpression>>().then("Add Causing", [this](const CausingExpression& causing) {
+            std::lock_guard<std::recursive_mutex> lock(director_mutex);
             add_causing(causing);
         });
 
         // Add a needs relationship to this Provider
-        on<Trigger<NeedsExpression>, Sync<Director>>().then("Add Needs", [this](const NeedsExpression& needs) {  //
+        on<Trigger<NeedsExpression>>().then("Add Needs", [this](const NeedsExpression& needs) {  //
+            std::lock_guard<std::recursive_mutex> lock(director_mutex);
             add_needs(needs);
         });
 
         // A task has arrived, either it's a root task so we send it off immediately, or we build up our pack for when
         // the Provider has finished executing
-        on<Trigger<BehaviourTask>, Sync<Director>>().then("Director Task", [this](const BehaviourTask& t) {
+        on<Trigger<BehaviourTask>>().then("Director Task", [this](const BehaviourTask& t) {
+            std::lock_guard<std::recursive_mutex> lock(director_mutex);
             // Make our own mutable copy of the task
             auto task = std::make_shared<BehaviourTask>(t);
 
@@ -296,7 +302,8 @@ namespace module::extension {
         });
 
         // This reaction runs when a Provider finishes to send off the task pack to the main director
-        on<Trigger<ProviderDone>, Sync<Director>>().then("Package Tasks", [this](const ProviderDone& done) {
+        on<Trigger<ProviderDone>>().then("Package Tasks", [this](const ProviderDone& done) {
+            std::lock_guard<std::recursive_mutex> lock(director_mutex);
             // Get all the tasks that were emitted by this provider and send it as a task pack
             auto range  = pack_builder.equal_range(done.requester_task_id);
             auto pack   = std::make_unique<TaskPack>();
@@ -319,7 +326,8 @@ namespace module::extension {
         });
 
         // A state that we were monitoring is updated, we might be able to run the task now
-        on<Trigger<StateUpdate>, Sync<Director>>().then("State Updated", [this](const StateUpdate& update) {
+        on<Trigger<StateUpdate>>().then("State Updated", [this](const StateUpdate& update) {
+            std::lock_guard<std::recursive_mutex> lock(director_mutex);
             // Get the group that had a state update
             auto p  = providers.at(update.provider_id);
             auto& g = p->group;
@@ -329,7 +337,8 @@ namespace module::extension {
         });
 
         // We have a new task pack to run
-        on<Trigger<TaskPack>, Sync<Director>>().then("Run Task Pack", [this](const TaskPack& pack) {  //
+        on<Trigger<TaskPack>>().then("Run Task Pack", [this](const TaskPack& pack) {  //
+            std::lock_guard<std::recursive_mutex> lock(director_mutex);
             run_task_pack(pack);
         });
     }

--- a/module/extension/Director/src/Director.hpp
+++ b/module/extension/Director/src/Director.hpp
@@ -21,6 +21,7 @@
 #define MODULE_EXTENSION_DIRECTOR_HPP
 
 #include <memory>
+#include <mutex>
 #include <nuclear>
 #include <typeindex>
 #include <vector>
@@ -43,6 +44,8 @@ namespace module::extension {
         using TaskPack = std::pair<std::shared_ptr<provider::Provider>, TaskList>;
 
     private:
+        std::recursive_mutex director_mutex{};
+
         /**
          * Adds a Provider for a type
          *

--- a/module/extension/Director/src/information/get_task_data.cpp
+++ b/module/extension/Director/src/information/get_task_data.cpp
@@ -22,6 +22,7 @@
 namespace module::extension {
 
     std::shared_ptr<void> Director::_get_task_data(const uint64_t& reaction_id) {
+        std::lock_guard<std::recursive_mutex> lock(director_mutex);
 
         // How did we get here?
         if (!providers.contains(reaction_id)) {


### PR DESCRIPTION
Sync isn't working to prevent multithreading issues, use a mutex. Use a recursive mutex because of `_get_task_data`, which also needs a mutex but can be called indirectly within Director reactions. 