### PR TITLE
Fix bug where Providers that are no longer active try to run subtasks

### DIFF
--- a/module/extension/Director/src/Director.cpp
+++ b/module/extension/Director/src/Director.cpp
@@ -289,15 +289,6 @@ namespace module::extension {
                                        id,
                                        "is a stop provider.");
                 }
-                // Check if this Provider is active and allowed to make subtasks
-                else if (p != p->group.active_provider) {
-                    // Throw an error so the user can see what a fool they are being
-                    log<NUClear::WARN>("The task",
-                                       task->name,
-                                       "cannot be executed as the Provider",
-                                       id,
-                                       "is not active and cannot make subtasks");
-                }
                 // Everything is fine
                 else {
                     pack_builder.emplace(task->requester_task_id, task);

--- a/module/extension/Director/src/director/run_task_pack.cpp
+++ b/module/extension/Director/src/director/run_task_pack.cpp
@@ -171,11 +171,6 @@ namespace module::extension {
                 // This provider is now in the done state
                 provider->group.done = true;
 
-                // Queued up a done but it's not active anymore!
-                if (group.active_task == nullptr) {
-                    return;
-                }
-
                 auto parent_provider = providers.at(group.active_task->requester_id);
                 auto& parent_group   = parent_provider->group;
 

--- a/module/extension/Director/src/director/run_task_pack.cpp
+++ b/module/extension/Director/src/director/run_task_pack.cpp
@@ -146,6 +146,11 @@ namespace module::extension {
         const auto& provider = pack.first;
         auto& group          = provider->group;
 
+        // Check if this Provider is active and allowed to make subtasks
+        if (provider != group.active_provider) {
+            return;
+        }
+
         // See if a Idle command was emitted
         for (const auto& t : pack.second) {
             if (t->type == typeid(::extension::behaviour::Idle)) {
@@ -165,6 +170,11 @@ namespace module::extension {
 
                 // This provider is now in the done state
                 provider->group.done = true;
+
+                // Queued up a done but it's not active anymore!
+                if (group.active_task == nullptr) {
+                    return;
+                }
 
                 auto parent_provider = providers.at(group.active_task->requester_id);
                 auto& parent_group   = parent_provider->group;


### PR DESCRIPTION
By the time a task pack gets run, sometimes the provider is no longer active. Running the task pack breaks the tree. Need to check for this in `run_task_pack`. 