### PR TITLE
Updates default camera settings to compensate for motion blur

### DIFF
--- a/module/input/Camera/data/config/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/Cameras/Left.yaml
@@ -6,8 +6,11 @@ settings:
   Height: 1024
   OffsetX: 0
   OffsetY: 0
-  ExposureAuto: Continuous # Options: Off, Once, Continuous
-  GainAuto: Continuous # Options: Off, Once, Continuous
+  ExposureAuto: Off # Options: Off, Once, Continuous
+  GainAuto: Off # Options: Off, Once, Continuous
   BalanceWhiteAuto: Once # Options: Off, Once, Continuous
   AcquisitionFrameRateEnable: true
-  AcquisitionFrameRate: 20.00 # Adjusting frame rate can help remove flickering from lighting
+  AcquisitionFrameRate: 25.00 # Adjusting frame rate can help remove flickering from lighting
+
+  ExposureTime: 3000
+  Gain: 18

--- a/module/input/Camera/data/config/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/Cameras/Left.yaml
@@ -6,11 +6,12 @@ settings:
   Height: 1024
   OffsetX: 0
   OffsetY: 0
-  ExposureAuto: Off # Options: Off, Once, Continuous
+  ExposureAuto: Continuous # Options: Off, Once, Continuous
+  AutoExposureExposureTimeUpperLimit: 3000 # Lower time reduces motion blur
   GainAuto: Off # Options: Off, Once, Continuous
+  Gain: 18
   BalanceWhiteAuto: Once # Options: Off, Once, Continuous
   AcquisitionFrameRateEnable: true
-  AcquisitionFrameRate: 25.00 # Adjusting frame rate can help remove flickering from lighting
-
-  ExposureTime: 3000
-  Gain: 18
+  AcquisitionFrameRate: 100.00 # Adjusting frame rate can help remove flickering from lighting
+  AutoExposureTargetGreyValueAuto: Off
+  AutoExposureTargetGreyValue: 30

--- a/module/input/Camera/data/config/Cameras/Right.yaml
+++ b/module/input/Camera/data/config/Cameras/Right.yaml
@@ -6,8 +6,11 @@ settings:
   Height: 1024
   OffsetX: 0
   OffsetY: 0
-  ExposureAuto: Continuous # Options: Off, Once, Continuous
-  GainAuto: Continuous # Options: Off, Once, Continuous
+  ExposureAuto: Off # Options: Off, Once, Continuous
+  GainAuto: Off # Options: Off, Once, Continuous
   BalanceWhiteAuto: Once # Options: Off, Once, Continuous
   AcquisitionFrameRateEnable: true
-  AcquisitionFrameRate: 20.00 # Adjusting frame rate can help remove flickering from lighting
+  AcquisitionFrameRate: 25.00 # Adjusting frame rate can help remove flickering from lighting
+
+  ExposureTime: 3000
+  Gain: 18

--- a/module/input/Camera/data/config/Cameras/Right.yaml
+++ b/module/input/Camera/data/config/Cameras/Right.yaml
@@ -6,11 +6,12 @@ settings:
   Height: 1024
   OffsetX: 0
   OffsetY: 0
-  ExposureAuto: Off # Options: Off, Once, Continuous
+  ExposureAuto: Continuous # Options: Off, Once, Continuous
+  AutoExposureExposureTimeUpperLimit: 3000 # Lower time reduces motion blur
   GainAuto: Off # Options: Off, Once, Continuous
+  Gain: 18
   BalanceWhiteAuto: Once # Options: Off, Once, Continuous
   AcquisitionFrameRateEnable: true
-  AcquisitionFrameRate: 25.00 # Adjusting frame rate can help remove flickering from lighting
-
-  ExposureTime: 3000
-  Gain: 18
+  AcquisitionFrameRate: 100.00 # Adjusting frame rate can help remove flickering from lighting
+  AutoExposureTargetGreyValueAuto: Off
+  AutoExposureTargetGreyValue: 30


### PR DESCRIPTION
Change of plan from having a set exposure and trying to compensate for darker images with gain. Now sets an auto exposure upper limit to allow for some auto adjustment, and compensates somewhat by setting the grey value. Seems to work a bit better.
- Turned auto exposure back on and set an upper limit of 3000.
- Sets frame rate to 100.
- Turned off auto exposure grey target value and set to 30. 

