### PR TITLE
Director Servos (Group) Update - ignore missing servos in map

### DIFF
--- a/module/actuation/Servos/src/Servos.hpp
+++ b/module/actuation/Servos/src/Servos.hpp
@@ -71,7 +71,7 @@ namespace module::actuation {
                                     group.servos.at(utility::actuation::ServoMap<Elements>::value)));
                             }
                             else {  // if a servo was not filled in the map for this group, log it
-                                log<NUClear::DEBUG>("Requested a servo group Task but did not provide values for servo",
+                                log<NUClear::TRACE>("Requested a servo group Task but did not provide values for servo",
                                                     utility::actuation::ServoMap<Elements>::value);
                             }
                         }(),

--- a/module/actuation/Servos/src/Servos.hpp
+++ b/module/actuation/Servos/src/Servos.hpp
@@ -71,9 +71,8 @@ namespace module::actuation {
                                     group.servos.at(utility::actuation::ServoMap<Elements>::value)));
                             }
                             else {  // if a servo was not filled in the map for this group, log it
-                                log<NUClear::TRACE>(
-                                    "Requested a Servo Group Task but did not provide values for Servo",
-                                    static_cast<ServoID>(utility::actuation::ServoMap<Elements>::value));
+                                log<NUClear::TRACE>("Requested a Servo Group Task but did not provide values for Servo",
+                                                    ServoID(utility::actuation::ServoMap<Elements>::value));
                             }
                         }(),
                         ...);

--- a/module/actuation/Servos/src/Servos.hpp
+++ b/module/actuation/Servos/src/Servos.hpp
@@ -71,8 +71,9 @@ namespace module::actuation {
                                     group.servos.at(utility::actuation::ServoMap<Elements>::value)));
                             }
                             else {  // if a servo was not filled in the map for this group, log it
-                                log<NUClear::TRACE>("Requested a servo group Task but did not provide values for servo",
-                                                    utility::actuation::ServoMap<Elements>::value);
+                                log<NUClear::TRACE>(
+                                    "Requested a Servo Group Task but did not provide values for Servo",
+                                    static_cast<ServoID>(utility::actuation::ServoMap<Elements>::value));
                             }
                         }(),
                         ...);


### PR DESCRIPTION
Fixes a bug that can occur when a servo group Task is made without all the servos in that group.
Mostly applicable to scripts. Makes it easier when running a sequence of scripts.
Ignores servos that don't exist in the message. 