### PR TITLE
Update webots camera FOV and Hpc

### DIFF
--- a/module/platform/Webots/data/config/WebotsCameras/left_camera.yaml
+++ b/module/platform/Webots/data/config/WebotsCameras/left_camera.yaml
@@ -23,9 +23,9 @@ lens:
   fov: 2.0944
   # The homogenous transform from the rigid platform this camera is attached to to its optical location
   Hpc:
-    - [1.0, 0.0, 0.0, 0.069952]
-    - [0.0, 1.0, 0.0, 0.033795]
-    - [0.0, 0.0, 1.0, 0.06488]
+    - [1.0, 0.0, 0.0, 0.0889361]
+    - [0.0, 1.0, 0.0, 0.0352991]
+    - [0.0, 0.0, 1.0, 0.0713675]
     - [0.0, 0.0, 0.0, 1.0]
 
 settings:

--- a/module/platform/Webots/data/config/WebotsCameras/left_camera.yaml
+++ b/module/platform/Webots/data/config/WebotsCameras/left_camera.yaml
@@ -20,12 +20,12 @@ lens:
   # The polynomial distortion coefficients for the lens
   k: [0, 0]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
-  fov: 90 * pi / 180
+  fov: 2.0944
   # The homogenous transform from the rigid platform this camera is attached to to its optical location
   Hpc:
-    - [0.9997403694613228, -0.016551656784825577, -0.01566002262642871, 0.08893612063588988]
-    - [0.01728764296000275, 0.9986932814319833, 0.04809227613146373, 0.03529909622045881]
-    - [0.014843552535558163, -0.04835051478781678, 0.9987201292902445, 0.0713674563254241]
+    - [1.0, 0.0, 0.0, 0.069952]
+    - [0.0, 1.0, 0.0, 0.033795]
+    - [0.0, 0.0, 1.0, 0.06488]
     - [0.0, 0.0, 0.0, 1.0]
 
 settings:


### PR DESCRIPTION
Two problems with the Webots camera config
- FOV was taken from Webots, which is horizontal FOV, but the config is for diagonal FOV, so this has been updated
- Hpc looks like it was copied from a calibrated robot camera, in this PR it has been changed based on the model and given that the cameras in webots are positioned without any extra rotation relative to the last joint, the rotation is identity.

Original is

![image](https://user-images.githubusercontent.com/35280100/215956887-8a7ba82f-5778-4073-9694-04d7adc69d3d.png)

and with this update we have

![image](https://user-images.githubusercontent.com/35280100/215956744-ae429aeb-fb43-4bad-8f42-2ca62eaf177f.png)
