### PR TITLE
Bring the Visual Mesh more up to date with the Fastcode repo and fix the holes in the mesh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -273,7 +273,7 @@ RUN mkdir -p /usr/local/include/zstr \
     && wget https://raw.githubusercontent.com/mateidavid/zstr/946ab409380e90e4a46c88c2da4f645a7ffaa51d/src/zstr_make_unique_polyfill.h -O /usr/local/include/zstr_make_unique_polyfill.h
 
 # Visual Mesh
-RUN install-from-source https://github.com/ysims/VisualMesh/archive/4a4da25de2519546eb2cce6d8c5fd9d8f8cf0f4f.tar.gz \
+RUN install-from-source https://github.com/NUbots/VisualMesh/archive/64c49fce3a17bbee73339eaee556f47a80b93c40.tar.gz \
     -DBUILD_TENSORFLOW_OP=OFF \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_OPENCL_ENGINE=ON

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -273,7 +273,7 @@ RUN mkdir -p /usr/local/include/zstr \
     && wget https://raw.githubusercontent.com/mateidavid/zstr/946ab409380e90e4a46c88c2da4f645a7ffaa51d/src/zstr_make_unique_polyfill.h -O /usr/local/include/zstr_make_unique_polyfill.h
 
 # Visual Mesh
-RUN install-from-source https://github.com/ysims/VisualMesh/archive/1c8d08b8d93a438acce2dce0bcfe7e1f58509e1a.tar.gz \
+RUN install-from-source https://github.com/ysims/VisualMesh/archive/4a4da25de2519546eb2cce6d8c5fd9d8f8cf0f4f.tar.gz \
     -DBUILD_TENSORFLOW_OP=OFF \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_OPENCL_ENGINE=ON


### PR DESCRIPTION
Currently the Visual Mesh library we grab in the Dockerfile is from a commit on my personal fork. It's a pretty old version of the public Fastcode/VisualMesh repo but applies last year's OpenCL caching so we're not waiting forever for the engines to load.

This PR uses a commit (currently the latest) from the new NUbots fork of Fastcode/VisualMesh. The commit contains everything on the current Fastcode/VisualMesh repo but it applies two fixes
- Reverts a change in the CPU engine that breaks it (thus breaking Webots vision)
- Applies a fix for the holes that were appearing in the mesh, credit to @Bidski 

Overall the benefits of this PR are
- Using a NUbots fork instead of my personal one
- Adding a lot (like 10+) of recent(-ish) commits from Fastcode that hopefully have some benefits 
- No holes anymore in the mesh!

This has all been tested but I'm a little skeptical of why it works so feel free to be skeptical as well.