### PR TITLE
Add VS Code debugging launchers for roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ tags
 *.sublime-workspace
 \.vscode/ipch
 .ccls-cache
+.vscode/launch.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,3 +125,18 @@ endif()
 if(BUILD_TESTS)
   add_subdirectory(${NUCLEAR_SHARED_DIR}/tests)
 endif()
+
+# Generate VSCode launch configurations
+find_package(PythonInterp 3 REQUIRED)
+list(JOIN NUCLEAR_ROLES " " launch_roles)
+add_custom_command(
+  OUTPUT "${PROJECT_SOURCE_DIR}/.vscode/launch.json"
+  COMMAND
+    ${PYTHON_EXECUTABLE} ARGS "${PROJECT_SOURCE_DIR}/cmake/scripts/generate_launch_configurations.py" "-s"
+    "${PROJECT_SOURCE_DIR}" "-b" "${PROJECT_BINARY_DIR}" "-l" "${PROJECT_SOURCE_DIR}/.vscode/launch.json" "-a"
+    "${USE_ASAN}" "${launch_roles}"
+  DEPENDS "${PROJECT_SOURCE_DIR}/cmake/scripts/generate_launch_configurations.py"
+  USES_TERMINAL
+  COMMENT "Generating VSCode launch configurations"
+)
+add_custom_target(generate_launch_configurations ALL DEPENDS "${PROJECT_SOURCE_DIR}/.vscode/launch.json")

--- a/cmake/scripts/generate_launch_configurations.py
+++ b/cmake/scripts/generate_launch_configurations.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+
+
+def generate(project_source_dir, project_binary_dir, use_asan, roles):
+    configurations = []
+    for role in roles:
+        if "-" in role:
+            role_path = role.split("-")
+            role_name = " ".join([r.title() for r in role_path[-1].split("_")]) + ": " + os.path.join(*role_path[:-1])
+            role_binary = os.path.join(project_binary_dir, "bin", *role_path)
+        else:
+            role_name = " ".join([r.title() for r in role.split("_")])
+            role_binary = os.path.join(project_binary_dir, "bin", role)
+        configurations.append(
+            {
+                "name": role_name,
+                "type": "cppdbg",
+                "request": "launch",
+                "program": role_binary,
+                "args": [],
+                "additionalSOLibSearchPath": f"{project_binary_dir}/bin/lib;{project_binary_dir}/bin",
+                "stopAtEntry": True,
+                "cwd": project_binary_dir,
+                "environment": [{"name": "GUILE_AUTO_COMPILE", "value": "0"}],
+                "externalConsole": False,
+                "MIMode": "gdb",
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": True,
+                    },
+                    {
+                        "description": "Set Disassembly Flavor to Intel",
+                        "text": "-gdb-set disassembly-flavor intel",
+                        "ignoreFailures": True,
+                    },
+                    {
+                        "description": "Turn on pending breakpoints",
+                        "text": "-ex set breakpoint pending on",
+                        "ignoreFailures": True,
+                    },
+                    {
+                        "description": "Set breakpoint to catch ASan error reporting",
+                        "text": "-ex br __asan::ReportGenericError",
+                        "ignoreFailures": True,
+                    },
+                    {
+                        "description": "Disable debuginfod",
+                        "text": "-ex set debuginfod enabled off",
+                        "ignoreFailures": True,
+                    },
+                ],
+            }
+        )
+
+        if use_asan:
+            configurations[-1]["environment"].append(
+                {"name": "ASAN_OPTIONS", "value": f"log_path={project_source_dir}/log"}
+            )
+
+    return {"versions": "0.2.0", "configurations": configurations}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate launch configurations for debugging roles")
+    parser.add_argument(
+        "--source-directory", "-s", default=os.path.join("", "home", "fourtel", "Horus"), help="Location of source code"
+    )
+    parser.add_argument(
+        "--binary-directory",
+        "-b",
+        default=os.path.join("", "home", "fourtel", "build"),
+        help="Location of build directory",
+    )
+    parser.add_argument(
+        "--launch-file",
+        "-l",
+        default=os.path.join("", "home", "fourtel", "Horus", ".vscode", "launch.json"),
+        help="Location of build directory",
+    )
+    parser.add_argument(
+        "--use-asan",
+        "-a",
+        help="Include ASAN_OPTIONS environment variable in launch configurations",
+    )
+    parser.add_argument("roles", nargs="*", help="Roles to generate launch configurations for")
+    args = parser.parse_args()
+
+    roles = []
+    for role in args.roles:
+        roles.extend(role.split(" "))
+
+    with open(args.launch_file, "w") as f:
+        json.dump(
+            generate(
+                project_source_dir=args.source_directory,
+                project_binary_dir=args.binary_directory,
+                use_asan=args.use_asan.upper() == "ON",
+                roles=roles,
+            ),
+            f,
+            ensure_ascii=True,
+            indent=2,
+        )


### PR DESCRIPTION
This PR will generate a `.vscode/launch.json` file containing a launch configuration for each role that is currently being built that will allow those roles to be actively debugged inside of VS Code.

There are a couple of limitations to this

1. This will only work inside the devcontainer
2. Since the devcontainer currently does not expose any GPUs, no roles/modules that use a GPU can be debugged in this manner, you will have to fallback to the ./b run --gpus all --gdb role/to/debug method

### Pre-PR Checklist:

Have you

- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [X] Added a descriptive title and relevant labels to the PR

### Reviewers, Note

Pull this branch and run `./b configure` followed by `./b build`. One of the build targets will generate `.vscode/launch.json` which will contain a launch configuration for all of the currently built roles.

Now switch to the `Run and Debug` tab in VS Code (or `Ctrl+Shift+D`) and you will be able to select a role to debug. You should also be able to add breakpoints in the editor (click just to the left of the line numbers and a red dot will appear).