### PR TITLE
Updates the Look skill to use torso space and vector for smoothing

### DIFF
--- a/module/skill/Look/data/config/Look.yaml
+++ b/module/skill/Look/data/config/Look.yaml
@@ -6,4 +6,4 @@ head_gain: 10.0
 head_torque: 100.0
 
 # Smoothing factor for goal angle to reduce look judder and oscillation, https://en.wikipedia.org/wiki/Exponential_smoothing
-smoothing_factor: 0.1
+smoothing_factor: 0.01

--- a/module/skill/Look/src/Look.cpp
+++ b/module/skill/Look/src/Look.cpp
@@ -29,10 +29,9 @@ namespace module::skill {
     using utility::math::coordinates::screen_angular_from_object_direction;
     using utility::math::coordinates::sphericalToCartesian;
     using utility::nusight::graph;
-    using LookTask = message::skill::Look
+    using LookTask = message::skill::Look;
 
-        Look::Look(std::unique_ptr<NUClear::Environment> environment)
-        : BehaviourReactor(std::move(environment)) {
+    Look::Look(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
 
         on<Configuration>("Look.yaml").then([this](const Configuration& config) {
             // Use configuration here from file Look.yaml

--- a/module/skill/Look/src/Look.hpp
+++ b/module/skill/Look/src/Look.hpp
@@ -1,6 +1,7 @@
 #ifndef MODULE_SKILL_LOOK_HPP
 #define MODULE_SKILL_LOOK_HPP
 
+#include <Eigen/Core>
 #include <nuclear>
 
 #include "extension/Behaviour.hpp"
@@ -19,6 +20,9 @@ namespace module::skill {
         /// @brief Store whether we are smoothing the head movements from the previous run, to help with transitioning
         /// between smoothing and not smoothing. Smoothing is given by the message.
         bool smooth = false;
+
+        /// @brief Last goal vector, used for smoothing
+        Eigen::Vector3d uPCt = Eigen::Vector3d::Zero();
 
     public:
         /// @brief Called by the powerplant to build and setup the Look reactor.

--- a/roles/webots/directormotion.role
+++ b/roles/webots/directormotion.role
@@ -25,7 +25,6 @@ nuclear_role(
   skill::GetUp
   skill::Look
   # Planners
-  planning::PlanLook
   planning::GetUpPlanner
   planning::FallingRelaxPlanner
   # Strategies

--- a/roles/webots/directormotion.role
+++ b/roles/webots/directormotion.role
@@ -3,6 +3,18 @@ nuclear_role(
   extension::FileWatcher
   support::SignalCatcher
   support::logging::ConsoleLogHandler
+  # Config
+  support::configuration::SoccerConfig
+  actuation::KinematicsConfiguration
+  # Sensors
+  input::SensorFilter
+  platform::Webots
+  # Vision
+  vision::VisualMesh
+  vision::GreenHorizonDetector
+  vision::BallDetector
+  # Localisation
+  localisation::BallFilter
   # Director
   extension::Director
   # Servos
@@ -11,7 +23,9 @@ nuclear_role(
   # Skills
   skill::ScriptKick
   skill::GetUp
+  skill::Look
   # Planners
+  planning::PlanLook
   planning::GetUpPlanner
   planning::FallingRelaxPlanner
   # Strategies

--- a/shared/message/skill/Look.proto
+++ b/shared/message/skill/Look.proto
@@ -23,7 +23,7 @@ import "Vector.proto";
 
 /// A message telling the robot to look in the given direction
 message Look {
-    /// Vector from the torso to the point to look at, in torso space
+    /// Vector from the camera to the point to look at, in torso space
     vec3 rPCt = 1;
     /// If true, smooth the goal angle using exponential smoothing
     bool smooth = 2;

--- a/shared/message/skill/Look.proto
+++ b/shared/message/skill/Look.proto
@@ -23,8 +23,8 @@ import "Vector.proto";
 
 /// A message telling the robot to look in the given direction
 message Look {
-    /// Vector from the camera to the point to look at, in camera space
-    vec3 rPCc = 1;
+    /// Vector from the torso to the point to look at, in torso space
+    vec3 rPCt = 1;
     /// If true, smooth the goal angle using exponential smoothing
     bool smooth = 2;
 }


### PR DESCRIPTION
The PR makes the Look skill somewhat more accurate.

- Uses rPCt instead of rPCc
- Smooths the vector, not the angle (no conversion to angles in the Look skill)

The changes result in

- The head looks directly at the ball, rather than before where it was not quite accurately looking at the ball particularly on the bounds of the head angles
- There is an oscillation issue around IK problems but the smoothing stops most of the movement