### PR TITLE
Refactor the Director Look planner into a planner and strategy

### DIFF
--- a/module/planning/PlanLook/README.md
+++ b/module/planning/PlanLook/README.md
@@ -2,23 +2,14 @@
 
 ## Description
 
-Plans how to look for features.
-
-LookAtBall looks for the ball and fixates on it if it has been seen.
-LookAtGoals looks for goals and fixates on them if they have been seen.
-LookAround performs a search pattern to look around the environment.
+Plans how to look around. Follows a search pattern to find objects.
 
 ## Usage
 
-Add this module to your role to make the robot look for requested features.
+Add this module to your role to make the robot look around when requested.
 
 ## Consumes
 
-- `message::planning::LookAtBall` a Task requesting to look at the ball and search if it can't see it
-- `message::planning::LookAtGoals` a Task requesting to look at the goals and search if it can't see any
-- `message::localisation::FilteredBall` with the position of the ball for fixation and knowing if we've seen the ball
-- `message::vision::Goals` with the position of the goals for fixation and knowing if we've seen goals
-- `message::input::Sensors` for the world matrix to convert the goals measurement into the right space
 - `message::planning::LookAround` a Task requesting to run the search pattern to look around
 
 ## Emits
@@ -27,5 +18,3 @@ Add this module to your role to make the robot look for requested features.
 - `message::planning::LookAround` a Task requesting to run the search pattern to look around the environment
 
 ## Dependencies
-
-- The coordinates utility

--- a/module/planning/PlanLook/data/config/PlanLook.yaml
+++ b/module/planning/PlanLook/data/config/PlanLook.yaml
@@ -1,13 +1,6 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-# How long to wait until looking for the ball again (seconds)
-ball_search_timeout: 2
-# How long to wait until looking for the goals again (seconds)
-goal_search_timeout: 3
-# How long to wait until looking over the field again (seconds)
-field_search_timeout: 5
-
 # Time lingering at each position in search (seconds)
 search_fixation_time: 2
 

--- a/module/planning/PlanLook/src/PlanLook.cpp
+++ b/module/planning/PlanLook/src/PlanLook.cpp
@@ -3,38 +3,23 @@
 #include "extension/Behaviour.hpp"
 #include "extension/Configuration.hpp"
 
-#include "message/input/Sensors.hpp"
-#include "message/localisation/FilteredBall.hpp"
-#include "message/planning/LookAtFeature.hpp"
+#include "message/planning/LookAround.hpp"
 #include "message/skill/Look.hpp"
-#include "message/vision/Goal.hpp"
 
-#include "utility/math/coordinates.hpp"
 #include "utility/support/yaml_expression.hpp"
 
 namespace module::planning {
 
     using extension::Configuration;
-    using message::input::Sensors;
-    using message::localisation::FilteredBall;
     using message::planning::LookAround;
-    using message::planning::LookAtBall;
-    using message::planning::LookAtGoals;
     using message::skill::Look;
-    using message::vision::Goals;
-    using utility::math::coordinates::sphericalToCartesian;
     using utility::support::Expression;
 
     PlanLook::PlanLook(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
 
         on<Configuration>("PlanLook.yaml").then([this](const Configuration& config) {
             // Use configuration here from file PlanLook.yaml
-            this->log_level = config["log_level"].as<NUClear::LogLevel>();
-
-            cfg.ball_search_timeout = duration_cast<NUClear::clock::duration>(
-                std::chrono::duration<double>(config["ball_search_timeout"].as<double>()));
-            cfg.goal_search_timeout = duration_cast<NUClear::clock::duration>(
-                std::chrono::duration<double>(config["goal_search_timeout"].as<double>()));
+            this->log_level          = config["log_level"].as<NUClear::LogLevel>();
             cfg.search_fixation_time = config["search_fixation_time"].as<float>();
 
             // Create vector of search positions
@@ -42,36 +27,6 @@ namespace module::planning {
                 cfg.search_positions.push_back(search_position.as<Expression>());
             }
         });
-
-        on<Provide<LookAtBall>, Optional<With<FilteredBall>>, Every<30, Per<std::chrono::seconds>>>().then(
-            [this](const std::shared_ptr<const FilteredBall>& ball) {
-                // If we have a ball and it is recent, look at it
-                if (ball && (NUClear::clock::now() - ball->time_of_measurement < cfg.ball_search_timeout)) {
-                    emit<Task>(std::make_unique<Look>(ball->rBCt.cast<double>(), true));
-                }
-                // Otherwise, look around for the ball
-                else {
-                    emit<Task>(std::make_unique<LookAround>());
-                }
-            });
-
-        on<Provide<LookAtGoals>, Optional<With<Goals>>, With<Sensors>>().then(
-            [this](const std::shared_ptr<const Goals>& goals, const Sensors& sensors) {
-                // If we have goals, with at least one measurement and the goals are recent, look at the goals
-                if (goals && !goals->goals.empty()
-                    && (NUClear::clock::now() - goals->timestamp < cfg.goal_search_timeout)) {
-                    // Convert goal measurement to cartesian coordinates
-                    Eigen::Vector3d rGCc = sphericalToCartesian(goals->goals[0].measurements[0].srGCc.cast<double>());
-                    // Convert to torso space
-                    Eigen::Vector3d rGCt = Eigen::Isometry3d(sensors.Htw * goals->Hcw.inverse()).rotation() * rGCc;
-                    // Look at the goal
-                    emit<Task>(std::make_unique<Look>(rGCt, true));
-                }
-                // Otherwise, look around for the goals
-                else {
-                    emit<Task>(std::make_unique<LookAround>());
-                }
-            });
 
         on<Provide<LookAround>, Every<30, Per<std::chrono::seconds>>>().then([this] {
             // How long the look has lingered - will move to the next position if long enough

--- a/module/planning/PlanLook/src/PlanLook.hpp
+++ b/module/planning/PlanLook/src/PlanLook.hpp
@@ -12,9 +12,9 @@ namespace module::planning {
     private:
         /// @brief Stores configuration values
         struct Config {
-            NUClear::clock::duration ball_search_timeout{};
-            NUClear::clock::duration goal_search_timeout{};
+            /// @brief How long to look at each search position
             float search_fixation_time = 0.0f;
+            /// @brief List of search positions for the search pattern
             std::vector<Eigen::Vector2d> search_positions{};
         } cfg;
 

--- a/module/strategy/StrategiseLook/CMakeLists.txt
+++ b/module/strategy/StrategiseLook/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Build our NUClear module
+nuclear_module()

--- a/module/strategy/StrategiseLook/README.md
+++ b/module/strategy/StrategiseLook/README.md
@@ -1,0 +1,26 @@
+# StrategiseLook
+
+## Description
+
+LookAtBall fixates on a ball if a recent one exists.
+LookAtGoals fixates on a goal if a recent goal exists.
+
+## Usage
+
+Add this module to your role to make the robot look at balls or goals when requested.
+
+## Consumes
+
+- `message::planning::LookAtBall` a Task requesting to look at the ball if there is a recent ball
+- `message::planning::LookAtGoals` a Task requesting to look at a goal if there is a recent goal
+- `message::localisation::FilteredBall` with the position of the ball for fixation
+- `message::vision::Goals` with the position of the goals for fixation
+- `message::input::Sensors` for the world matrix to convert the goals measurement into the correct space
+
+## Emits
+
+- `message::skill::Look` a Task requesting to look in a direction (to the balls or goals)
+
+## Dependencies
+
+- The coordinates utility

--- a/module/strategy/StrategiseLook/data/config/StrategiseLook.yaml
+++ b/module/strategy/StrategiseLook/data/config/StrategiseLook.yaml
@@ -1,0 +1,2 @@
+# Controls the minimum log level that NUClear log will display
+log_level: INFO

--- a/module/strategy/StrategiseLook/data/config/StrategiseLook.yaml
+++ b/module/strategy/StrategiseLook/data/config/StrategiseLook.yaml
@@ -1,2 +1,7 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
+
+# How long to wait until looking for the ball again (seconds)
+ball_search_timeout: 2
+# How long to wait until looking for the goals again (seconds)
+goal_search_timeout: 3

--- a/module/strategy/StrategiseLook/src/StrategiseLook.cpp
+++ b/module/strategy/StrategiseLook/src/StrategiseLook.cpp
@@ -1,0 +1,60 @@
+#include "StrategiseLook.hpp"
+
+#include "extension/Behaviour.hpp"
+#include "extension/Configuration.hpp"
+
+#include "message/input/Sensors.hpp"
+#include "message/localisation/FilteredBall.hpp"
+#include "message/skill/Look.hpp"
+#include "message/vision/Goals.hpp"
+
+#include "utility/math/coordinates.hpp"
+
+namespace module::strategy {
+
+    using extension::Configuration;
+    using message::input::Sensors;
+    using message::localisation::FilteredBall;
+    using message::skill::Look;
+    using message::vision::Goals;
+    using utility::math::coordinates::sphericalToCartesian;
+
+    StrategiseLook::StrategiseLook(std::unique_ptr<NUClear::Environment> environment)
+        : BehaviourReactor(std::move(environment)) {
+
+        on<Configuration>("StrategiseLook.yaml").then([this](const Configuration& config) {
+            // Use configuration here from file StrategiseLook.yaml
+            this->log_level         = config["log_level"].as<NUClear::LogLevel>();
+            cfg.ball_search_timeout = duration_cast<NUClear::clock::duration>(
+                std::chrono::duration<double>(config["ball_search_timeout"].as<double>()));
+            cfg.goal_search_timeout = duration_cast<NUClear::clock::duration>(
+                std::chrono::duration<double>(config["goal_search_timeout"].as<double>()));
+        });
+
+        // Trigger on FilteredBall to update readings
+        // Uses Every to update time difference so if the ball is not recent, the Look Task will not be emitted
+        on<Provide<LookAtBall>, Trigger<FilteredBall>, Every<Per<30, std::chrono::seconds>>>().then(
+            [this](const FilteredBall& ball) {
+                // If we have a ball and it is recent, look at it
+                if (NUClear::clock::now() - ball->time_of_measurement < cfg.ball_search_timeout) {
+                    emit<Task>(std::make_unique<Look>(ball->rBCt.cast<double>(), true));
+                }
+            });
+
+        // Trigger on Goals to update readings
+        // Uses Every to update time difference so if the goals are not recent, the Look Task will not be emitted
+        on<Provide<LookAtGoals>, Trigger<Goals>, With<Sensors>, Every<Per<30, std::chrono::seconds>>>().then(
+            [this](const Goals& goals, const Sensors& sensors) {
+                // If we have goals, with at least one measurement and the goals are recent, look at the goals
+                if (!goals->goals.empty() && (NUClear::clock::now() - goals->timestamp < cfg.goal_search_timeout)) {
+                    // Convert goal measurement to cartesian coordinates
+                    Eigen::Vector3d rGCc = sphericalToCartesian(goals->goals[0].measurements[0].srGCc.cast<double>());
+                    // Convert to torso space
+                    Eigen::Vector3d rGCt = Eigen::Isometry3d(sensors.Htw * goals->Hcw.inverse()).rotation() * rGCc;
+                    // Look at the goal
+                    emit<Task>(std::make_unique<Look>(rGCt, true));
+                }
+            });
+    }
+
+}  // namespace module::strategy

--- a/module/strategy/StrategiseLook/src/StrategiseLook.hpp
+++ b/module/strategy/StrategiseLook/src/StrategiseLook.hpp
@@ -1,0 +1,27 @@
+#ifndef MODULE_STRATEGY_STRATEGISELOOK_HPP
+#define MODULE_STRATEGY_STRATEGISELOOK_HPP
+
+#include <nuclear>
+
+#include "extension/Behaviour.hpp"
+
+namespace module::strategy {
+
+    class StrategiseLook : public ::extension::behaviour::BehaviourReactor {
+    private:
+        /// @brief Stores configuration values
+        struct Config {
+            /// @brief How long before the ball measurement is too old and we have nothing to look at
+            NUClear::clock::duration ball_search_timeout{};
+            /// @brief How long before the goal measurement is too old and we have nothing to look at
+            NUClear::clock::duration goal_search_timeout{};
+        } cfg;
+
+    public:
+        /// @brief Called by the powerplant to build and setup the StrategiseLook reactor.
+        explicit StrategiseLook(std::unique_ptr<NUClear::Environment> environment);
+    };
+
+}  // namespace module::strategy
+
+#endif  // MODULE_STRATEGY_STRATEGISELOOK_HPP

--- a/module/strategy/StrategiseLook/tests/StrategiseLook.cpp
+++ b/module/strategy/StrategiseLook/tests/StrategiseLook.cpp
@@ -1,0 +1,8 @@
+// Uncomment this line when other test files are added
+//#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+//#include <catch.hpp>
+
+// Remove this line when test files are added
+int main() {
+    return 0;
+}

--- a/roles/webots/directormotion.role
+++ b/roles/webots/directormotion.role
@@ -33,4 +33,5 @@ nuclear_role(
   planning::FallingRelaxPlanner
   # Strategies
   strategy::FallRecovery
+  strategy::StrategiseLook
 )

--- a/shared/message/planning/LookAround.proto
+++ b/shared/message/planning/LookAround.proto
@@ -14,17 +14,11 @@
  * You should have received a copy of the GNU General Public License
  * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright 2022 NUbots <nubots@nubots.net>
+ * Copyright 2023 NUbots <nubots@nubots.net>
  */
-syntax = "proto3";
+ syntax = "proto3";
 
-package message.planning;
-
-/// Task requesting to look at the ball
-message LookAtBall {}
-
-/// Task requesting to look at the goal
-message LookAtGoals {}
+ package message.planning;
 
 /// Task requesting to look around the environment
 message LookAround {}

--- a/shared/message/planning/LookAround.proto
+++ b/shared/message/planning/LookAround.proto
@@ -16,9 +16,9 @@
  *
  * Copyright 2023 NUbots <nubots@nubots.net>
  */
- syntax = "proto3";
+syntax = "proto3";
 
- package message.planning;
+package message.planning;
 
 /// Task requesting to look around the environment
 message LookAround {}

--- a/shared/message/strategy/LookAtFeature.proto
+++ b/shared/message/strategy/LookAtFeature.proto
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2023 NUbots <nubots@nubots.net>
+ */
+syntax = "proto3";
+
+package message.strategy;
+
+/// Task requesting to look at the ball
+message LookAtBall {}
+
+/// Task requesting to look at the goal
+message LookAtGoals {}


### PR DESCRIPTION
The planner includes only the LookAround (search).
The strategy includes the LookAtBall and LookAtGoals

This is to match better with the rest of the system, where WalkToBall is a strategy and TurnOnSpot is a planner.

The strategies only fixate on the ball/goals if they exist.

Future strategies will involve a FindBall which uses the LookAround and TurnOnSpot to find the ball.
A WalkToBall will only walk to the ball if the ball is found.
Then in the purpose level, if the WalkToBall and LookAtBall cannot run, the lower priority FindBall will take over and find the ball.