### PR TITLE
Fix the role search in the Webots build command for the virtual competitions

### DIFF
--- a/tools/webots.py
+++ b/tools/webots.py
@@ -22,7 +22,7 @@ random.seed(datetime.now())
 
 # The docker image details for Robocup
 ROBOCUP_IMAGE_NAME = "robocup-vhsc-nubots"  # Provided by the TC and shouldn't be changed
-ROBOCUP_IMAGE_TAG = "robocup2021"  # Submitted in our team_config.json, shouldn't be changed here unless changed there
+ROBOCUP_IMAGE_TAG = "robocup"  # Submitted in our team_config.json, shouldn't be changed here unless changed there
 ROBOCUP_IMAGE_REGISTRY = "047817357099.dkr.ecr.us-east-2.amazonaws.com/hl-vs-nubots"  # Provided by the TC
 
 # NUbots RoboCup team ID
@@ -100,6 +100,8 @@ def get_cmake_flags(roles_to_build):
 
     # Find all available roles
     available_roles = glob(os.path.join(b.project_dir, "roles", "**", "*.role"), recursive=True)
+    available_roles = [role.split(os.path.join(b.project_dir, "roles/"))[1] for role in available_roles]
+    available_roles = [role.split(".")[0] for role in available_roles]
 
     # Ensure that all the roles requested are available
     for role in roles_to_build:


### PR DESCRIPTION
The script accepts a role name as command line input. It searches all the role files and checks if the requested role exists.

The old role search found the full path of the roles. This means the script fails to find the role in the available list. If you input the full path, then the part where the script turns the role on and builds it fails because it expects the role path and name relative to the role folder. 

This PR fixes it so the role search stores the role names relative to the folder and without the `.role` suffix. 

Also changed the image tag from robocup2021 to robocup.