### PR TITLE
Add a webots global configuration file for the virtual season team ID

### DIFF
--- a/module/support/configuration/GlobalConfig/data/config/webots/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/webots/GlobalConfig.yaml
@@ -1,0 +1,2 @@
+player_id: 1
+team_id: 12


### PR DESCRIPTION
We updated the team ID to 1 for last RoboCup, but there should still be a webots-specific configuration file with the team ID for the virtual games. 