### PR TITLE
Separate get up scripts into webots and real robot

### DIFF
--- a/module/behaviour/skills/Getup/data/config/webots/Getup.yaml
+++ b/module/behaviour/skills/Getup/data/config/webots/Getup.yaml
@@ -9,6 +9,5 @@ getup_front:
   - "StandUpFront.yaml"
   - "Stand.yaml"
 getup_back:
-  - "RollOverBack.yaml"
-  - "StandUpFront.yaml"
+  - "StandUpBack.yaml"
   - "Stand.yaml"

--- a/module/behaviour/skills/Getup/src/Getup.cpp
+++ b/module/behaviour/skills/Getup/src/Getup.cpp
@@ -54,6 +54,9 @@ namespace module::behaviour::skills {
             log_level          = config["log_level"].as<NUClear::LogLevel>();
             cfg.fallen_angle   = config["fallen_angle"].as<float>();
             cfg.getup_priority = config["getup_priority"].as<float>();
+
+            cfg.getup_front = config["getup_front"].as<std::vector<std::string>>();
+            cfg.getup_back  = config["getup_back"].as<std::vector<std::string>>();
         });
 
         emit<Scope::INITIALIZE>(std::make_unique<RegisterAction>(RegisterAction{
@@ -88,14 +91,10 @@ namespace module::behaviour::skills {
 
             // Check with side we're getting up from
             if (is_front) {
-                emit(std::make_unique<ExecuteScriptByName>(
-                    subsumption_id,
-                    std::vector<std::string>({"StandUpFront.yaml", "Stand.yaml"})));
+                emit(std::make_unique<ExecuteScriptByName>(subsumption_id, std::vector<std::string>(cfg.getup_front)));
             }
             else {
-                emit(std::make_unique<ExecuteScriptByName>(
-                    subsumption_id,
-                    std::vector<std::string>({"RollOverBack.yaml", "StandUpFront.yaml", "Stand.yaml"})));
+                emit(std::make_unique<ExecuteScriptByName>(subsumption_id, std::vector<std::string>(cfg.getup_back)));
             }
         });
 

--- a/module/behaviour/skills/Getup/src/Getup.hpp
+++ b/module/behaviour/skills/Getup/src/Getup.hpp
@@ -42,6 +42,10 @@ namespace module::behaviour::skills {
             float getup_priority = 0.0f;
             /// @brief Threshold angle for executing getup, between torso z axis and world z axis
             float fallen_angle = 0.0f;
+            /// @brief Script sequence to run when getting from lying on the front to standing
+            std::vector<std::string> getup_front;
+            /// @brief Script sequence to run when getting from lying on the back to standing
+            std::vector<std::string> getup_back;
         } cfg;
 
         /// @brief Bool to indicate if the robot has fallen on its front or back


### PR DESCRIPTION
There's no roll over script for webots so we get a runtime error with the current stuff. This fixes that by specifying separate scripts for webots and real.