### PR TITLE
Quickens the look search fixation time from 2 seconds to half a second

### DIFF
--- a/module/planning/PlanLook/data/config/PlanLook.yaml
+++ b/module/planning/PlanLook/data/config/PlanLook.yaml
@@ -2,7 +2,7 @@
 log_level: INFO
 
 # Time lingering at each position in search (seconds)
-search_fixation_time: 2
+search_fixation_time: 0.5
 
 # List of positions for search
 min_yaw: &min_yaw -0.7


### PR DESCRIPTION
The look search was a bit slow. This quickens it up so it's more likely to see the ball near its feet when it's lost it.