### PR TITLE
Fix for Dockerfile smell DL3003

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,8 @@ COPY etc/ld.so.conf.d/usrlocal.conf /etc/ld.so.conf.d/usrlocal.conf
 RUN ldconfig
 
 # Make a symlink from /usr/local/lib to /usr/local/lib64 so library install location is irrelevant
-RUN cd /usr/local && ln -sf lib lib64
+WORKDIR /usr/local 
+RUN  ln -sf lib lib64
 
 # Generate toolchain files for the generic platform
 COPY usr/local/toolchain/generate_toolchains.py /usr/local/generate_toolchains.py


### PR DESCRIPTION
Hi!
The Dockerfile placed at "docker/Dockerfile" contains the best practice violation [DL3003](https://github.com/hadolint/hadolint/wiki/DL3003) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3003 occurs if the pattern `RUN cd ...` is used to change directories instead of the dedicated WORKDIR instruction.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the pattern `RUN cd ...` is replaced with the equivalent WORKDIR instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance

### Pre-PR Checklist:

Have you

- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [ ] Added a descriptive title and relevant labels to the PR

### Reviewers, Note


### Things left to do

None

### Labels
- `-Dependencies`
- `L-Docker`