### PR TITLE
Stop at desired field position/heading

### DIFF
--- a/module/strategy/WalkToFieldPosition/data/config/WalkToFieldPosition.yaml
+++ b/module/strategy/WalkToFieldPosition/data/config/WalkToFieldPosition.yaml
@@ -1,4 +1,8 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
+# Radius to begin aligning with desired field heading
 align_radius: 0.5
+
+# Error tolerance for stopping at desired field position
+stop_tolerance: 0.25

--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
@@ -6,52 +6,66 @@
 #include "message/input/Sensors.hpp"
 #include "message/localisation/Field.hpp"
 #include "message/planning/WalkPath.hpp"
+#include "message/strategy/StandStill.hpp"
 #include "message/strategy/WalkToFieldPosition.hpp"
 
 namespace module::strategy {
 
     using extension::Configuration;
-    using message::planning::WalkTo;
-    using WalkToFieldPositionTask = message::strategy::WalkToFieldPosition;
     using message::input::Sensors;
     using message::localisation::Field;
+    using message::planning::WalkTo;
+    using message::strategy::StandStill;
+    using WalkToFieldPositionTask = message::strategy::WalkToFieldPosition;
 
     WalkToFieldPosition::WalkToFieldPosition(std::unique_ptr<NUClear::Environment> environment)
         : BehaviourReactor(std::move(environment)) {
 
         on<Configuration>("WalkToFieldPosition.yaml").then([this](const Configuration& config) {
             // Use configuration here from file WalkToFieldPosition.yaml
-            this->log_level  = config["log_level"].as<NUClear::LogLevel>();
-            cfg.align_radius = config["align_radius"].as<float>();
+            this->log_level    = config["log_level"].as<NUClear::LogLevel>();
+            cfg.align_radius   = config["align_radius"].as<float>();
+            cfg.stop_tolerance = config["stop_tolerance"].as<float>();
         });
 
         on<Provide<WalkToFieldPositionTask>, With<Field>, With<Sensors>, Every<30, Per<std::chrono::seconds>>>().then(
             [this](const WalkToFieldPositionTask& walk_to_field_position, const Field& field, const Sensors& sensors) {
-                // Transform the desired field {f} position into ground {g} space
                 const Eigen::Isometry3f Hfw = Eigen::Isometry3f(field.Hfw.cast<float>());
                 const Eigen::Isometry3f Hrw = Eigen::Isometry3f(sensors.Hrw.cast<float>());
                 const Eigen::Isometry3f Hrf = Hrw * Hfw.inverse();
+                const Eigen::Isometry3f Hfr = Hrf.inverse();
                 const Eigen::Vector3f rPFf(walk_to_field_position.rPFf.x(), walk_to_field_position.rPFf.y(), 0.0f);
+
+                // Create a unit vector in the direction of the desired heading in field space
+                const Eigen::Vector3f uHFf(std::cos(walk_to_field_position.heading),
+                                           std::sin(walk_to_field_position.heading),
+                                           0.0f);
+
+                // Transform the field position from field {f} space to robot {r} space
                 const Eigen::Vector3f rPRr(Hrf * rPFf);
 
-                // If we are close to the field position, align with the desired heading
-                float heading;
-                if (rPRr.head(2).norm() < cfg.align_radius) {
-                    // Create a unit vector in the direction of the desired heading in field space
-                    const Eigen::Vector3f uHFf(std::cos(walk_to_field_position.heading),
-                                               std::sin(walk_to_field_position.heading),
-                                               0.0f);
-                    // Rotate the desired heading in field space to robot space
+                // Compute the current position error and heading error in field {f} space
+                const float position_error = (Hfr.translation().head(2) - rPFf.head(2)).norm();
+                const Eigen::Vector3f uXRf = Hfr.linear().col(0).head(2);
+                const float heading_error  = std::acos(std::max(-1.0f, std::min(1.0f, uXRf.dot(uHFf.head(2)))));
+                log<NUClear::DEBUG>("Position error: ", position_error, " Heading error: ", heading_error);
+
+                // If the error in the desired field position and heading is low enough, stand still
+                if (position_error < cfg.stop_tolerance && heading_error < cfg.stop_tolerance) {
+                    emit<Task>(std::make_unique<StandStill>());
+                }
+                // If we are getting close to the field position begin to align with the desired heading in field space
+                else if (position_error < cfg.align_radius) {
+                    // Rotate the desired heading in field {f} space to robot space
                     const Eigen::Vector3f uHRr(Hrf.linear() * uHFf);
-                    heading = std::atan2(uHRr.y(), uHRr.x());
+                    const float desired_heading = std::atan2(uHRr.y(), uHRr.x());
+                    emit<Task>(std::make_unique<WalkTo>(rPRr, desired_heading));
                 }
                 // Otherwise, walk directly to the field position
                 else {
-                    heading = std::atan2(rPRr.y(), rPRr.x());
+                    const float desired_heading = std::atan2(rPRr.y(), rPRr.x());
+                    emit<Task>(std::make_unique<WalkTo>(rPRr, desired_heading));
                 }
-
-                // Emit a task to walk to the field position
-                emit<Task>(std::make_unique<WalkTo>(rPRr, heading));
             });
     }
 

--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.hpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.hpp
@@ -13,6 +13,8 @@ namespace module::strategy {
         struct Config {
             /// @brief Radius to begin aligning with desired field heading
             float align_radius = 0.0f;
+            /// @brief Tolerance for stopping at the field position
+            float stop_tolerance = 0.0f;
         } cfg;
 
     public:


### PR DESCRIPTION
This PR adds to the WalkToFieldPosition strategy functionality to stop when close to the desired position/heading in field space. 

The error between the current and desired position/heading is computed and when it is lower then a config specified tolerance the stand still task is requested.