### PR TITLE
Update localisation to use particle filter utility

### DIFF
--- a/module/localisation/RobotLocalisation/data/config/RobotLocalisation.yaml
+++ b/module/localisation/RobotLocalisation/data/config/RobotLocalisation.yaml
@@ -7,6 +7,10 @@ grid_size: 0.01
 # Number of particles
 n_particles: 1000
 
+n_rogues: 0
+
+reset_range: [2, 2, 0]
+
 # Initial guess of where the robot starts on the field
 initial_state:
   - [3.0, 3.26, -1.571]

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
@@ -3,6 +3,8 @@
 
 #include <nuclear>
 
+#include "RobotModel.hpp"
+
 #include "message/eye/DataPoint.hpp"
 #include "message/localisation/Field.hpp"
 #include "message/motion/GetupCommand.hpp"
@@ -11,38 +13,41 @@
 #include "message/vision/FieldLines.hpp"
 
 #include "utility/localisation/OccupancyMap.hpp"
+#include "utility/math/filter/ParticleFilter.hpp"
 #include "utility/math/stats/multivariate.hpp"
 #include "utility/nusight/NUhelpers.hpp"
 #include "utility/support/yaml_expression.hpp"
 
-
 namespace module::localisation {
-
-    // Particle struct
-    struct Particle {
-        Eigen::Matrix<double, 3, 1> state =
-            Eigen::Matrix<double, 3, 1>::Zero();  // (x, y, theta) of world space in field space
-        double weight = 1.0;
-    };
 
     class RobotLocalisation : public NUClear::Reactor {
     private:
+        /// @brief Particle filter
+        utility::math::filter::ParticleFilter<double, RobotModel> filter;
+
         /// @brief Stores configuration values
         struct Config {
             /// @brief Size of the grid cells in the occupancy grid [m]
             double grid_size = 0.0;
+
             /// @brief Number of particles to use in the particle filter
             int n_particles = 0;
+
             /// @brief Uncertainty in the process model
             Eigen::Matrix<double, 3, 3> process_noise = Eigen::Matrix<double, 3, 3>::Zero();
+
             /// @brief Uncertainty in the measurement model
             double measurement_noise = 0;
+
             /// @brief Maximum distance a field line can be from a particle to be considered an observation [m]
             double max_range = 0;
+
             /// @brief Initial state (x,y,theta) of the robot, saved for resetting
             std::vector<Eigen::Matrix<double, 3, 1>> initial_state{};
+
             /// @brief Initial covariance matrix of the robot's state, saved for resetting
             Eigen::Matrix<double, 3, 3> initial_covariance = Eigen::Matrix<double, 3, 3>::Identity();
+
             /// @brief Bool to enable/disable saving the generated map as a csv file
             bool save_map = false;
         } cfg;
@@ -51,19 +56,6 @@ namespace module::localisation {
 
         /// @brief Occupancy grid map of the field lines
         OccupancyMap fieldline_map;
-
-        /// @brief State (x,y,theta) of the robot
-        Eigen::Matrix<double, 3, 1> state = Eigen::Matrix<double, 3, 1>::Zero();
-
-        /// @brief Covariance matrix of the robot's state
-        Eigen::Matrix<double, 3, 3> covariance = Eigen::Matrix<double, 3, 3>::Identity();
-
-        /// @brief Status of if the robot is falling
-        bool falling = false;
-
-        /// @brief Particles used in the particle filter
-        std::vector<Particle> particles{};
-
 
     public:
         /// @brief Called by the powerplant to build and setup the RobotLocalisation reactor.
@@ -88,29 +80,6 @@ namespace module::localisation {
         /// @return The weight of the particle
         double calculate_weight(const Eigen::Matrix<double, 3, 1> particle,
                                 const std::vector<Eigen::Vector2d>& observations);
-
-        /// @brief Get the current mean (state) of the robot
-        // @return The current mean (state) of the robot
-        Eigen::Matrix<double, 3, 1> compute_mean();
-
-        /// @brief Get the current covariance matrix of the robot's state
-        // @return The current covariance matrix of the robot's state
-        Eigen::Matrix<double, 3, 3> compute_covariance();
-
-        /// @brief Perform a time update on the particles
-        /// @param walk_command The walk command (dx, dy, dtheta)
-        /// @param dt The time since the last time update
-        void time_update();
-
-        /// @brief Resample the particles based on their weights
-        /// @param particles Vector of particles to be resampled
-        /// @return The resampled particles
-        void resample();
-
-        /// @brief Add some noise to the particles to compensate for the fact that we don't have a perfect model
-        /// @param particles Vector of particles to be resampled
-        /// @return The particles with noise added
-        void add_noise();
     };
 }  // namespace module::localisation
 

--- a/module/localisation/RobotLocalisation/src/RobotModel.hpp
+++ b/module/localisation/RobotLocalisation/src/RobotModel.hpp
@@ -1,0 +1,89 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2023 NUBots <nubots@nubots.net>
+ */
+
+#ifndef MODULES_LOCALISATION_ROBOTMODEL_HPP
+#define MODULES_LOCALISATION_ROBOTMODEL_HPP
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace module::localisation {
+
+    template <typename Scalar>
+    class RobotModel {
+    public:
+        /// @brief Size of the state vector (x, y, theta)
+        static constexpr size_t size = 3;
+
+        using StateVec = Eigen::Matrix<Scalar, size, 1>;
+        using StateMat = Eigen::Matrix<Scalar, size, size>;
+
+        enum Components : int {
+            /// @brief World {w} x position from field {f}
+            x = 0,
+
+            /// @brief World {w} y position from field {f}
+            y = 1,
+
+            /// @brief Angle of world {w} from field {f}
+            theta = 2
+        };
+
+        /// @brief Number of reset particles
+        int n_rogues = 0;
+
+        /// @brief Number of particles
+        int n_particles = 100;
+
+        /// @brief Range of reset particles
+        Eigen::Matrix<Scalar, 3, 1> reset_range;
+
+        /// @brief Diagonal for 3x3 noise matrix (which is diagonal)
+        Eigen::Matrix<Scalar, 3, 1> process_noise_diagonal;
+
+        RobotModel()
+            : reset_range(Eigen::Matrix<Scalar, 3, 1>::Zero())
+            , process_noise_diagonal(Eigen::Matrix<Scalar, 3, 1>::Ones()) {}
+
+        StateVec time(const StateVec& state, double /*deltaT*/) {
+            return state;
+        }
+
+        StateVec limit(const StateVec& state) {
+            return state;
+        }
+
+        StateMat noise(const Scalar& deltaT) {
+            return process_noise_diagonal.asDiagonal() * deltaT;
+        }
+
+        // Getters
+        [[nodiscard]] int get_rogue_count() const {
+            return n_rogues;
+        }
+        [[nodiscard]] StateVec get_rogue() const {
+            return reset_range;
+        }
+
+        [[nodiscard]] int get_particle_count() const {
+            return n_particles;
+        }
+    };
+}  // namespace module::localisation
+#endif

--- a/roles/webots/localisation.role
+++ b/roles/webots/localisation.role
@@ -34,11 +34,22 @@ nuclear_role(
   # Localisation
   localisation::BallFilter
   localisation::RobotLocalisation
-  # Behaviour
-  behaviour::Controller
-  behaviour::skills::Getup
-  behaviour::skills::Stand
-  behaviour::skills::KickScript
-  behaviour::skills::DirectWalkController
-  behaviour::strategy::KeyboardWalk
+  # Director
+  extension::Director
+  # Servos
+  actuation::Kinematics
+  actuation::Servos
+  # Skills
+  skill::QuinticWalk
+  skill::ScriptKick
+  skill::GetUp
+  skill::Look
+  # Planners
+  planning::GetUpPlanner
+  planning::FallingRelaxPlanner
+  # Strategies
+  strategy::FallRecovery
+  strategy::StandStill
+  # Purpose
+  purpose::KeyboardWalk
 )

--- a/shared/utility/math/filter/ParticleFilter.hpp
+++ b/shared/utility/math/filter/ParticleFilter.hpp
@@ -304,6 +304,8 @@ namespace utility::math::filter {
             throw std::runtime_error("Invalid setting for resample method.");
         }
 
+
+    public:
         /**
          * @brief Do a weighted resampling of all of the particles in the filter. The model is also asked to provide new
          * rogues. All particle weights are reset to 1.
@@ -336,7 +338,6 @@ namespace utility::math::filter {
             std::fill(weights.begin(), weights.end(), Scalar(1));
         }
 
-    public:
         /**
          * @brief Resample all particles in the filter and set their weights back to 1. The model is asked to give a
          * prediction on what happens to each particle after dt time has elapsed (using model::time).
@@ -413,6 +414,13 @@ namespace utility::math::filter {
         }
 
         /**
+         * @brief Manually set a particles weight.
+         */
+        void set_particle_weight(const Scalar& weight, const int& idx) {
+            weights[idx] = weight;
+        }
+
+        /**
          * @brief Calculates and returns the mean of all particles.
          */
         [[nodiscard]] StateVec get_state() const {
@@ -428,16 +436,23 @@ namespace utility::math::filter {
         }
 
         /**
+         * @brief Returns the particle at the given index.
+         */
+        [[nodiscard]] const Eigen::Matrix<Scalar, Model::size, 1> get_particle(int idx) const {
+            return particles.col(idx);
+        }
+
+        /**
          * @brief Returns the underlying particle list.
          */
-        [[nodiscard]] const ParticleList& getParticles() const {
+        [[nodiscard]] const ParticleList& get_particles() const {
             return particles;
         }
 
         /**
          * @brief Returns the underlying particle weights.
          */
-        [[nodiscard]] const ParticleWeights& getParticleWeights() const {
+        [[nodiscard]] const ParticleWeights& get_particle_weights() const {
             return weights;
         }
     };


### PR DESCRIPTION
The following PR updates robot localisation to use particle filter utility rather then a local implementation.

In order to achieve this I have made following changes the particle filter utility:
- Add function to manually set particles weight
- Made `resample()` a public function

The reason the above changes are needed is because the method we currently use to weight particles is not straight forward (I can't think of a way to do it in its current form) to implement as typical measurement models are posed. We encode the "innovation" within the occupancy map directly so we don't need to compute the measurement error online. 