### PR TITLE
NUsight localisation: Add world to field transformation

### DIFF
--- a/nusight2/src/client/components/localisation/controller.ts
+++ b/nusight2/src/client/components/localisation/controller.ts
@@ -217,9 +217,9 @@ export class LocalisationController {
 
     // This camera position hack will not work with orientation/head movement.
     // TODO (Annable): Sync camera position/rotation properly using kinematic chain.
-    model.camera.position = new Vector3(target.rWTt.x, target.rWTt.y, target.rWTt.z + 0.15);
-    const Rwt = new THREE.Quaternion(target.Rwt.x, target.Rwt.y, target.Rwt.z, target.Rwt.w);
-    model.camera.yaw = new THREE.Euler().setFromQuaternion(Rwt).z;
+    model.camera.position = new Vector3(target.rTFf.x, target.rTFf.y, target.rTFf.z + 0.15);
+    const Rtf = new THREE.Quaternion(target.Rtf.x, target.Rtf.y, target.Rtf.z, target.Rtf.w);
+    model.camera.yaw = new THREE.Euler().setFromQuaternion(Rtf).z;
     model.camera.pitch = 0;
   }
 
@@ -237,7 +237,7 @@ export class LocalisationController {
 
     const distance = model.camera.distance;
 
-    const targetPosition = new Vector3(target.rWTt.x, target.rWTt.y, target.rWTt.z);
+    const targetPosition = new Vector3(target.rTFf.x, target.rTFf.y, target.rTFf.z);
 
     const yaw = -model.controls.yaw;
     const pitch = -model.controls.pitch + Math.PI / 2;

--- a/nusight2/src/client/components/localisation/network.ts
+++ b/nusight2/src/client/components/localisation/network.ts
@@ -45,9 +45,7 @@ export class LocalisationNetwork {
 
     const robot = LocalisationRobotModel.of(robotModel);
 
-    const { rotation: Rwt } = decompose(
-      new THREE.Matrix4().copy(fromProtoMat44(sensors.Htw!)).invert(),
-    );
+    const { rotation: Rwt } = decompose(new THREE.Matrix4().copy(fromProtoMat44(sensors.Htw!)).invert());
     robot.Htw = Matrix4.from(sensors.Htw);
     robot.Rwt = new Quaternion(Rwt.x, Rwt.y, Rwt.z, Rwt.w);
 

--- a/nusight2/src/client/components/localisation/network.ts
+++ b/nusight2/src/client/components/localisation/network.ts
@@ -45,7 +45,7 @@ export class LocalisationNetwork {
 
     const robot = LocalisationRobotModel.of(robotModel);
 
-    const { translation: rWTt, rotation: Rwt } = decompose(
+    const { rotation: Rwt } = decompose(
       new THREE.Matrix4().copy(fromProtoMat44(sensors.Htw!)).invert(),
     );
     robot.Htw = Matrix4.from(sensors.Htw);

--- a/nusight2/src/client/components/localisation/nugus_robot/view_model.ts
+++ b/nusight2/src/client/components/localisation/nugus_robot/view_model.ts
@@ -30,10 +30,10 @@ export class NUgusViewModel {
     // TODO (Annable): Baking the offsets into the model geometries would be ideal.
     const PI = Math.PI;
     const PI_2 = PI / 2;
-    robot.position.x = this.model.rWTt.x;
-    robot.position.y = this.model.rWTt.y;
-    robot.position.z = this.model.rWTt.z;
-    const rotation = new Quaternion(this.model.Rwt.x, this.model.Rwt.y, this.model.Rwt.z, this.model.Rwt.w);
+    robot.position.x = this.model.rTFf.x;
+    robot.position.y = this.model.rTFf.y;
+    robot.position.z = this.model.rTFf.z;
+    const rotation = new Quaternion(this.model.Rtf.x, this.model.Rtf.y, this.model.Rtf.z, this.model.Rtf.w);
     rotation.multiply(new Quaternion().setFromEuler(new Euler(PI_2, 0, 0)));
     robot.setRotationFromQuaternion(rotation);
     findMesh(robot, "R_Shoulder").rotation.set(0, 0, PI_2 - motors.rightShoulderPitch.angle);

--- a/nusight2/src/shared/math/quaternion.ts
+++ b/nusight2/src/shared/math/quaternion.ts
@@ -4,4 +4,11 @@ export class Quaternion {
   static of() {
     return new Quaternion(0, 0, 0, 1);
   }
+
+  static from(q?: { x?: number | null; y?: number | null; z?: number | null; w?: number | null } | null): Quaternion {
+    if (!q) {
+      return Quaternion.of();
+    }
+    return new Quaternion(q.x || 0, q.y || 0, q.z || 0, q.w || 0);
+  }
 }


### PR DESCRIPTION
Currently the localisation tab in NUsight doesn't show localisation. This PR fixes that!

It applies `message.localisation.Field.Hfw` to the robot's position.

Confirmed as matching the overview tab, which I'm assuming to be correct.

Attached is an nbs file recorded from running webots: [nbs_example.zip](https://github.com/NUbots/NUbots/files/11521928/nbs_example.zip)
