### PR TITLE
Fix sizing of matrices in Kalman Filter intialisation to fix resizing error/crash

### DIFF
--- a/module/input/SensorFilter/src/SensorFilter.hpp
+++ b/module/input/SensorFilter/src/SensorFilter.hpp
@@ -65,7 +65,7 @@ namespace module::input {
         static const size_t n_measurements = 4;
 
         /// @brief Kalman filter for pose estimation
-        utility::math::filter::KalmanFilter<double, n_states, n_inputs, n_measurements> kf;
+        utility::math::filter::KalmanFilter<double, n_states, n_inputs, n_measurements> kf{};
 
         struct FootDownMethod {
             enum Value { UNKNOWN = 0, Z_HEIGHT = 1, LOAD = 2, FSR = 3 };
@@ -225,13 +225,13 @@ namespace module::input {
             Eigen::Vector3d deadreckoning_scale = Eigen::Vector3d::Zero();
 
             //  **************************************** Kalman Filter Config ****************************************
-            /// @brief Kalman Continuos time process model
+            /// @brief Kalman Continuous time process model
             Eigen::Matrix<double, n_states, n_states> Ac;
 
-            /// @brief Kalman Continuos time input model
-            Eigen::Matrix<double, n_inputs, n_inputs> Bc;
+            /// @brief Kalman Continuous time input model
+            Eigen::Matrix<double, n_states, n_inputs> Bc;
 
-            /// @brief Kalman Continuos time measurement model
+            /// @brief Kalman Continuous time measurement model
             Eigen::Matrix<double, n_measurements, n_states> C;
 
             /// @brief Kalman Process noise


### PR DESCRIPTION
Issue appears specifically when running `webots/directorkeyboardwalk` and the robot has fallen, for some unknown reason. 

SensorFilter will crash with an Eigen cannot resize matrices error. 

Problem is that we're trying to give it `Bc` which is of size `n_inputs` by `n_inputs`, when it wants something of size n_states by n_inputs. Tbh n_inputs seems to be zero anyway.

Edit to add that there is still another bug making it crash (probably Director), but this happens first.