### PR TITLE
NUsight Localisation: Fix rotation by simplification

### DIFF
--- a/nusight2/src/client/components/localisation/controller.ts
+++ b/nusight2/src/client/components/localisation/controller.ts
@@ -217,9 +217,9 @@ export class LocalisationController {
 
     // This camera position hack will not work with orientation/head movement.
     // TODO (Annable): Sync camera position/rotation properly using kinematic chain.
-    model.camera.position = new Vector3(target.rTFf.x, target.rTFf.y, target.rTFf.z + 0.15);
-    const Rtf = new THREE.Quaternion(target.Rtf.x, target.Rtf.y, target.Rtf.z, target.Rtf.w);
-    model.camera.yaw = new THREE.Euler().setFromQuaternion(Rtf).z;
+    const { translation, rotation } = target.Hft.decompose();
+    model.camera.position = translation.add(new Vector3(0, 0, 0.15));
+    model.camera.yaw = new THREE.Euler().setFromQuaternion(rotation.toThree()).z;
     model.camera.pitch = 0;
   }
 
@@ -237,7 +237,7 @@ export class LocalisationController {
 
     const distance = model.camera.distance;
 
-    const targetPosition = new Vector3(target.rTFf.x, target.rTFf.y, target.rTFf.z);
+    const targetPosition = target.Hft.decompose().translation;
 
     const yaw = -model.controls.yaw;
     const pitch = -model.controls.pitch + Math.PI / 2;

--- a/nusight2/src/client/components/localisation/model.ts
+++ b/nusight2/src/client/components/localisation/model.ts
@@ -1,5 +1,6 @@
 import { observable } from "mobx";
 import { computed } from "mobx";
+import { Matrix4 } from "../../../shared/math/matrix4";
 
 import { Vector3 } from "../../../shared/math/vector3";
 import { memoize } from "../../base/memoize";
@@ -42,7 +43,7 @@ class CameraModel {
   @observable pitch: number;
   @observable distance: number;
 
-  constructor({ position, yaw, pitch, distance }: CameraModel) {
+  constructor({ position, yaw, pitch, distance }: { position: Vector3; yaw: number; pitch: number; distance: number }) {
     this.position = position;
     this.yaw = yaw;
     this.pitch = pitch;

--- a/nusight2/src/client/components/localisation/nugus_robot/view_model.ts
+++ b/nusight2/src/client/components/localisation/nugus_robot/view_model.ts
@@ -30,12 +30,8 @@ export class NUgusViewModel {
     // TODO (Annable): Baking the offsets into the model geometries would be ideal.
     const PI = Math.PI;
     const PI_2 = PI / 2;
-    robot.position.x = this.model.rTFf.x;
-    robot.position.y = this.model.rTFf.y;
-    robot.position.z = this.model.rTFf.z;
-    const rotation = new Quaternion(this.model.Rtf.x, this.model.Rtf.y, this.model.Rtf.z, this.model.Rtf.w);
-    rotation.multiply(new Quaternion().setFromEuler(new Euler(PI_2, 0, 0)));
-    robot.setRotationFromQuaternion(rotation);
+    robot.matrix = this.model.Hft.toThree().multiply(new Matrix4().makeRotationX(PI_2));
+    robot.matrixAutoUpdate = false;
     findMesh(robot, "R_Shoulder").rotation.set(0, 0, PI_2 - motors.rightShoulderPitch.angle);
     findMesh(robot, "L_Shoulder").rotation.set(0, 0, -PI_2 - motors.leftShoulderPitch.angle);
     findMesh(robot, "R_Arm_Upper").rotation.set(0, PI_2, motors.rightShoulderRoll.angle);

--- a/nusight2/src/client/components/localisation/robot_model.ts
+++ b/nusight2/src/client/components/localisation/robot_model.ts
@@ -162,24 +162,12 @@ export class LocalisationRobotModel {
     return this.model.enabled;
   }
 
-  /** Field to torso translation in field space. */
-  @computed get rTFf(): Vector3 {
-    return this.position.rTFf;
-  }
-
-  /* Field to torso rotation in field space. */
-  @computed get Rtf(): Quaternion {
-    return this.position.Rtf;
-  }
-
+  /** Torso to field transformation */
   @computed
-  private get position() {
+  get Hft() {
     const Hwf = this.Hfw.toThree().invert();
     const Htf = this.Htw.toThree().multiply(Hwf);
-    const { rotation: Rtf } = decompose(Htf);
-    const Hft = Htf.invert();
-    const { translation: rTFf } = decompose(Hft);
-    return { Htf, rTFf, Rtf };
+    return Matrix4.fromThree(Htf.invert());
   }
 }
 

--- a/nusight2/src/shared/math/matrix4.ts
+++ b/nusight2/src/shared/math/matrix4.ts
@@ -1,4 +1,6 @@
 import * as THREE from "three";
+import { Quaternion } from "./quaternion";
+import { Vector3 } from "./vector3";
 
 import { Vector4 } from "./vector4";
 
@@ -30,6 +32,18 @@ export class Matrix4 {
 
   get trace(): number {
     return this.x.x + this.y.y + this.z.z + this.t.t;
+  }
+
+  decompose() {
+    const translation = new THREE.Vector3();
+    const rotation = new THREE.Quaternion();
+    const scale = new THREE.Vector3();
+    this.toThree().decompose(translation, rotation, scale);
+    return {
+      translation: Vector3.fromThree(translation),
+      rotation: Quaternion.fromThree(rotation),
+      scale: Vector3.fromThree(scale),
+    };
   }
 
   static fromThree(mat4: THREE.Matrix4) {

--- a/nusight2/src/shared/math/quaternion.ts
+++ b/nusight2/src/shared/math/quaternion.ts
@@ -1,3 +1,5 @@
+import * as THREE from "three";
+
 export class Quaternion {
   constructor(readonly x: number, readonly y: number, readonly z: number, readonly w: number) {}
 
@@ -10,5 +12,13 @@ export class Quaternion {
       return Quaternion.of();
     }
     return new Quaternion(q.x || 0, q.y || 0, q.z || 0, q.w || 0);
+  }
+
+  static fromThree(q: THREE.Quaternion) {
+    return new Quaternion(q.x, q.y, q.z, q.w);
+  }
+
+  toThree() {
+    return new THREE.Quaternion(this.x, this.y, this.z, this.w);
   }
 }


### PR DESCRIPTION
An alternative to #1077 which fixes the problem by simplification.

We instead use the matrix directly to the three.js model, reducing this risk of anything being wrong.

Deletes a bunch of code and simplifies what is left.