### PR TITLE
NUsight: Add matrix methods

### DIFF
--- a/nusight2/src/client/components/localisation/robot_model.ts
+++ b/nusight2/src/client/components/localisation/robot_model.ts
@@ -164,21 +164,7 @@ export class LocalisationRobotModel {
 
   /** Torso to field transformation */
   @computed
-  get Hft() {
-    const Hwf = this.Hfw.toThree().invert();
-    const Htf = this.Htw.toThree().multiply(Hwf);
-    return Matrix4.fromThree(Htf.invert());
+  get Hft(): Matrix4 {
+    return this.Hfw.multiply(this.Htw.invert());
   }
-}
-
-function decompose(m: THREE.Matrix4): { translation: Vector3; rotation: Quaternion; scale: Vector3 } {
-  const translation = new THREE.Vector3();
-  const rotation = new THREE.Quaternion();
-  const scale = new THREE.Vector3();
-  m.decompose(translation, rotation, scale);
-  return {
-    translation: Vector3.from(translation),
-    rotation: Quaternion.from(rotation),
-    scale: Vector3.from(scale),
-  };
 }

--- a/nusight2/src/shared/math/matrix3.ts
+++ b/nusight2/src/shared/math/matrix3.ts
@@ -30,6 +30,14 @@ export class Matrix3 {
     return this.x.x + this.y.y + this.z.z;
   }
 
+  multiply(m: Matrix3): Matrix3 {
+    return Matrix3.fromThree(this.toThree().multiply(m.toThree()));
+  }
+
+  invert(): Matrix3 {
+    return Matrix3.fromThree(this.toThree().invert());
+  }
+
   static fromThree(mat4: THREE.Matrix3) {
     return new Matrix3(
       new Vector3(mat4.elements[0], mat4.elements[1], mat4.elements[2]),

--- a/nusight2/src/shared/math/matrix4.ts
+++ b/nusight2/src/shared/math/matrix4.ts
@@ -34,6 +34,14 @@ export class Matrix4 {
     return this.x.x + this.y.y + this.z.z + this.t.t;
   }
 
+  multiply(m: Matrix4): Matrix4 {
+    return Matrix4.fromThree(this.toThree().multiply(m.toThree()));
+  }
+
+  invert(): Matrix4 {
+    return Matrix4.fromThree(this.toThree().invert());
+  }
+
   decompose() {
     const translation = new THREE.Vector3();
     const rotation = new THREE.Quaternion();

--- a/nusight2/src/shared/math/matrix4.ts
+++ b/nusight2/src/shared/math/matrix4.ts
@@ -42,7 +42,11 @@ export class Matrix4 {
     return Matrix4.fromThree(this.toThree().invert());
   }
 
-  decompose() {
+  decompose(): {
+    translation: Vector3;
+    rotation: Quaternion;
+    scale: Vector3;
+  } {
     const translation = new THREE.Vector3();
     const rotation = new THREE.Quaternion();
     const scale = new THREE.Vector3();


### PR DESCRIPTION
This PR adds multiply and invert methods to `Matrix4` and `Matrix3`.

No need to complicate consumers when we can hide the THREE conversions internally.

If performance was ever an issue we could also easily inline the math operations.