### PR TITLE
Fix Kalman Filter test

### DIFF
--- a/shared/tests/utility/math/filter/TestFilters.cpp
+++ b/shared/tests/utility/math/filter/TestFilters.cpp
@@ -217,7 +217,7 @@ TEST_CASE("Test the KalmanFilter", "[utility][math][filter][KalmanFilter]") {
     Eigen::Matrix3d A = config["kalman"]["A"].as<Expression>();
 
     // Define the input model
-    Eigen::MatrixXd B;
+    Eigen::MatrixXd B = Eigen::Matrix<double, n_states, n_inputs>::Zero();
 
     // Define the measurement model
     Eigen::MatrixXd C = config["kalman"]["C"].as<Expression>();


### PR DESCRIPTION
I don't know why CI isn't picking up on this, but for me locally the Kalman Filter test fails.

It doesn't like that the B matrix is not being set a size and is then being passed into the constructor which expects a specific size. 