### PR TITLE
Add Director tests for no-priority watchers and missing providers

### DIFF
--- a/module/extension/Director/src/director/reevaluate_group.cpp
+++ b/module/extension/Director/src/director/reevaluate_group.cpp
@@ -37,8 +37,9 @@ namespace module::extension {
         std::vector<std::shared_ptr<DirectorTask>> watchers = group.watchers;
 
         // Sort the interested parties by priority with highest first
-        std::sort(watchers.begin(), watchers.end(), [this](const auto& a, const auto& b) {
-            return !challenge_priority(a, b);
+        std::stable_sort(watchers.begin(), watchers.end(), [this](const auto& a, const auto& b) {
+            // If b wins against a, then we swap
+            return challenge_priority(b, a);
         });
 
         // Store our initial task to see if it changed later

--- a/module/extension/Director/tests/missing_provider.cpp
+++ b/module/extension/Director/tests/missing_provider.cpp
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2023 NUbots <nubots@nubots.net>
+ */
+
+#include <catch.hpp>
+#include <nuclear>
+
+#include "Director.hpp"
+#include "TestBase.hpp"
+#include "util/diff_string.hpp"
+
+// Anonymous namespace to avoid name collisions
+namespace {
+
+    template <int i>
+    struct SimpleTask {};
+
+    std::vector<std::string> events;
+
+    class TestReactor : public TestBase<TestReactor> {
+    public:
+        explicit TestReactor(std::unique_ptr<NUClear::Environment> environment)
+            : TestBase<TestReactor>(std::move(environment)) {
+
+            on<Provide<SimpleTask<2>>>().then([this] { events.push_back("simple task 2"); });
+
+            /**************
+             * TEST STEPS *
+             **************/
+            // PrimaryTask takes ahold of SubTask and SubSubTask
+            on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+                events.push_back("emitting simple task 1");
+                emit<Task>(std::make_unique<SimpleTask<1>>());
+            });
+
+            on<Trigger<Step<2>>, Priority::LOW>().then([this] {
+                events.push_back("emitting simple task 2");
+                emit<Task>(std::make_unique<SimpleTask<2>>());
+            });
+
+            on<Trigger<Step<3>>, Priority::LOW>().then([this] {
+                events.push_back("emitting simple task 3");
+                emit<Task>(std::make_unique<SimpleTask<3>>());
+            });
+
+            on<Startup>().then([this] {
+                emit(std::make_unique<Step<1>>());
+                emit(std::make_unique<Step<2>>());
+                emit(std::make_unique<Step<3>>());
+            });
+        }
+    };
+
+}  // namespace
+
+TEST_CASE("Test that a Task can be emitted when no Provider exists for it", "[director][provider][missing]") {
+
+    NUClear::PowerPlant::Configuration config;
+    config.thread_count = 1;
+    NUClear::PowerPlant powerplant(config);
+    powerplant.install<module::extension::Director>();
+    powerplant.install<TestReactor>();
+    powerplant.start();
+
+    std::vector<std::string> expected = {"emitting simple task 1",
+                                         "emitting simple task 2",
+                                         "simple task 2",
+                                         "emitting simple task 3"};
+
+    // Make an info print the diff in an easy to read way if we fail
+    INFO(util::diff_string(expected, events));
+
+    // Check the events fired in order and only those events
+    REQUIRE(events == expected);
+}

--- a/module/extension/Director/tests/watcher_removal_double_priority.cpp
+++ b/module/extension/Director/tests/watcher_removal_double_priority.cpp
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2023 NUbots <nubots@nubots.net>
+ */
+
+#include <catch.hpp>
+#include <nuclear>
+
+#include "Director.hpp"
+#include "TestBase.hpp"
+#include "util/diff_string.hpp"
+
+// Anonymous namespace to avoid name collisions
+namespace {
+
+    struct PrimaryTask {};
+    struct SecondaryTask {};
+    struct TertiaryTask {};
+
+    struct SubTask {
+        SubTask(const std::string& msg_) : msg(msg_) {}
+        std::string msg;
+    };
+
+    struct SubSubTask {
+        SubSubTask(const std::string& msg_) : msg(msg_) {}
+        std::string msg;
+    };
+
+    std::vector<std::string> events;
+
+    class TestReactor : public TestBase<TestReactor> {
+    public:
+        explicit TestReactor(std::unique_ptr<NUClear::Environment> environment)
+            : TestBase<TestReactor>(std::move(environment)) {
+
+            on<Provide<PrimaryTask>>().then([this] { emit<Task>(std::make_unique<SubTask>("primary task")); });
+
+            on<Provide<SubTask>, Needs<SubSubTask>>().then(
+                [this](const SubTask& t) { emit<Task>(std::make_unique<SubSubTask>(t.msg)); });
+
+            on<Provide<SubSubTask>>().then([this](const SubSubTask& t) { events.push_back(t.msg); });
+
+            on<Provide<SecondaryTask>, Needs<SubTask>>().then(
+                [this] { emit<Task>(std::make_unique<SubTask>("secondary task")); });
+
+            on<Provide<TertiaryTask>, Needs<SubTask>>().then(
+                [this] { emit<Task>(std::make_unique<SubTask>("tertiary task")); });
+
+            /**************
+             * TEST STEPS *
+             **************/
+            // PrimaryTask takes ahold of SubTask and SubSubTask
+            on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+                events.push_back("emitting primary task");
+                emit<Task>(std::make_unique<PrimaryTask>());
+            });
+
+            // SecondaryTask needs SubTask, so it will watch
+            on<Trigger<Step<2>>, Priority::LOW>().then([this] {
+                events.push_back("emitting secondary task");
+                emit<Task>(std::make_unique<SecondaryTask>());
+            });
+
+            // TertiaryTask needs SubTask, so it will watch
+            on<Trigger<Step<3>>, Priority::LOW>().then([this] {
+                events.push_back("emitting tertiary task");
+                emit<Task>(std::make_unique<TertiaryTask>());
+            });
+
+            // Remove PrimaryTask so SecondaryTask can take over
+            on<Trigger<Step<4>>, Priority::LOW>().then([this] {
+                events.push_back("removing primary task");
+                emit<Task>(std::unique_ptr<PrimaryTask>(nullptr));
+            });
+
+            on<Startup>().then([this] {
+                emit(std::make_unique<Step<1>>());
+                emit(std::make_unique<Step<2>>());
+                emit(std::make_unique<Step<3>>());
+                emit(std::make_unique<Step<4>>());
+            });
+        }
+    };
+
+}  // namespace
+
+TEST_CASE(
+    "Test that a watcher can take over from another provider while there is another watcher and no priority is set",
+    "[director][remove][watcher][double][priority]") {
+
+    NUClear::PowerPlant::Configuration config;
+    config.thread_count = 1;
+    NUClear::PowerPlant powerplant(config);
+    powerplant.install<module::extension::Director>();
+    powerplant.install<TestReactor>();
+    powerplant.start();
+
+    std::vector<std::string> expected = {"emitting primary task",
+                                         "primary task",
+                                         "emitting secondary task",
+                                         "emitting tertiary task",
+                                         "removing primary task",
+                                         "secondary task"};
+
+    // Make an info print the diff in an easy to read way if we fail
+    INFO(util::diff_string(expected, events));
+
+    // Check the events fired in order and only those events
+    REQUIRE(events == expected);
+}


### PR DESCRIPTION
We had some bug/s associated with these tests (mentioned in #975) that appear to have been fixed since I wrote down that they were an issue. In the spirit of having as many tests as possible so we don't reintroduce any bugs, I've created tests for these.

One test involves emitting a Task for which no Providers exist. 

The other test involves an existing test but without setting priority. It involves having two watchers. I have also changed the logic so that the order of equal watchers isn't changed, so that we can enforce that the first watcher will run over the second in the test. Otherwise the test is ambiguous as either watcher could run first. 