### PR TITLE
Set hostname to webots if binary name has 'webots' in it

### DIFF
--- a/tools/utility/dockerise/run.py
+++ b/tools/utility/dockerise/run.py
@@ -116,6 +116,14 @@ def run(func, image, hostname="docker", ports=[], docker_context=None):
             func(**kwargs)
             exit(0)
 
+        # If this is the run command, then use the binary name to determine if
+        # the hostname should be docker or webots
+        # Binaries containing 'webots' (ie in the webots folder) should be given the hostname 'webots'
+        # to ensure the config files are chosen correctly
+        is_webots = False
+        if len(kwargs["args"]) > 0 and func.__name__ == "run":
+            is_webots = re.search("webots", kwargs["args"][0])
+
         # Docker arguments
         docker_args = [
             "docker",
@@ -130,7 +138,7 @@ def run(func, image, hostname="docker", ports=[], docker_context=None):
             "--attach",
             "stderr",
             "--hostname",
-            hostname,
+            "webots" if is_webots else hostname,
             "--interactive",
             "--env",
             f"EDITOR={os.environ.get('EDITOR', 'nano')}",


### PR DESCRIPTION
This functionality disappeared in #1090. I've added it in similarly to how it was before. Alternative to fix #1104, which is a bit yikes. 
Would be better if we could use cmake and check for the Webots module per-binary but this is hard.