### PR TITLE
Fix stack overflow in Director where StandStill runs task pack in infinite loop with its dying child

### DIFF
--- a/module/extension/Director/src/director/run_task_pack.cpp
+++ b/module/extension/Director/src/director/run_task_pack.cpp
@@ -282,17 +282,20 @@ namespace module::extension {
             }
         }
 
+
+        // Make a copy of group.subtasks so we can remove tasks from it with updated subtasks
+        auto old_subtasks = group.subtasks;
+        // Update the group's subtasks to the new subtasks
+        group.subtasks = tasks;
+
         // Remove any tasks that were marked as dying earlier
         // This is at the end, so that if one of our new tasks uses something the old tasks did then we won't run other
         // tasks with lower priority for a single cycle until this one runs
-        for (const auto& t : group.subtasks) {
+        for (const auto& t : old_subtasks) {
             if (t->dying) {
                 remove_task(t);
             }
         }
-
-        // Update the new subtasks
-        group.subtasks = tasks;
     }
 
 }  // namespace module::extension


### PR DESCRIPTION
We've had a problem in Director where in webots, if keyboardwalk is started with the robot fallen over there is a stack overflow.
This same problem appears on the real robot in both robocup and keyboardwalk pretty much all of the time.

The problem is to do with dying tasks. When the dying tasks are removed, the groups are reevaluated. The group with the dying task still has it as a subtask. This causes an infinite loop of trying to run the task pack with the dying task, only to do nothing except delete the dying task, running the reevaluate group again... running the task pack with a dying task again...

The fix I found was to make sure that our group's subtasks are updated, then we remove the dying tasks.
With this, all existing tests pass, webots keyboardwalk on ground works, and the real robot works.

@TrentHouliston feel free to figure out a test for this :stuck_out_tongue: 