### PR TITLE
Add react three fiber

### DIFF
--- a/nusight2/NUsight2/package.json
+++ b/nusight2/NUsight2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "NUsight2",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/nusight2/NUsight2/package.json
+++ b/nusight2/NUsight2/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "NUsight2",
-  "version": "1.0.0",
-  "dependencies": {}
-}

--- a/nusight2/package.json
+++ b/nusight2/package.json
@@ -104,6 +104,8 @@
     "vite": "^3.0.9"
   },
   "dependencies": {
+    "@react-three/fiber": "^8.13.0",
+    "@use-it/interval": "1.0.0",
     "binary": "0.3.0",
     "binary-search-bounds": "2.0.5",
     "bindings": "1.5.0",

--- a/nusight2/src/client/components/three/stories/three_fiber.stories.tsx
+++ b/nusight2/src/client/components/three/stories/three_fiber.stories.tsx
@@ -1,10 +1,10 @@
-import { observable } from "mobx";
-import { observer } from "mobx-react";
 import React from "react";
-import { Meta, StoryObj } from "@storybook/react";
-import { reaction } from "mobx";
-import { now } from "mobx-utils";
 import { useEffect } from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import { observable } from "mobx";
+import { reaction } from "mobx";
+import { observer } from "mobx-react";
+import { now } from "mobx-utils";
 
 import { Vector2 } from "../../../../shared/math/vector2";
 import { Vector3 } from "../../../../shared/math/vector3";

--- a/nusight2/src/client/components/three/stories/three_fiber.stories.tsx
+++ b/nusight2/src/client/components/three/stories/three_fiber.stories.tsx
@@ -1,0 +1,92 @@
+import { observable } from "mobx";
+import { observer } from "mobx-react";
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import { reaction } from "mobx";
+import { now } from "mobx-utils";
+import { useEffect } from "react";
+
+import { Vector2 } from "../../../../shared/math/vector2";
+import { Vector3 } from "../../../../shared/math/vector3";
+import { fullscreen } from "../../storybook/fullscreen";
+import { meshPhongMaterial } from "../builders";
+import { mesh } from "../builders";
+import { PerspectiveCamera, ThreeFiber } from "../three_fiber";
+
+type Story = StoryObj<typeof BoxVisualiser>;
+
+const meta: Meta<typeof BoxVisualiser> = {
+  title: "components/ThreeFiber",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [fullscreen],
+};
+
+export default meta;
+
+export const StaticScene: Story = {
+  name: "static scene",
+  render: () => <BoxVisualiser />,
+};
+
+export const AnimatedScene: Story = {
+  name: "animated scene",
+  render: () => <BoxVisualiser animate />,
+};
+
+type Model = { boxes: BoxModel[] };
+type BoxModel = { id: string; color: string; size: number; position: Vector3; rotation: Vector3 };
+
+const BoxVisualiser = (props: { animate?: boolean }) => {
+  // TODO: Use `useLocalObservable` when mobx is updated.
+  const model = observable({
+    boxes: [
+      { id: "1", color: "red", size: 1, position: Vector3.of(), rotation: Vector3.of() },
+      { id: "2", color: "green", size: 1, position: Vector3.of(), rotation: Vector3.of() },
+      { id: "3", color: "blue", size: 1, position: Vector3.of(), rotation: Vector3.of() },
+    ],
+  });
+  useEffect(() => {
+    function update(now: number) {
+      const t = (2 * Math.PI * now) / (20 * 1000);
+      const n = model.boxes.length;
+      for (const [i, box] of model.boxes.entries()) {
+        const position = Vector2.fromPolar(1, (i * 2 * Math.PI) / n + t);
+        box.position = new Vector3(position.x, position.y, 0);
+        box.rotation = new Vector3(Math.cos(3 * t + i), Math.cos(5 * t + i), Math.cos(7 * t + i));
+      }
+    }
+
+    update(0);
+    if (props.animate) {
+      return reaction(() => now("frame"), update);
+    }
+  }, []);
+  return (
+    <ThreeFiber>
+      <Scene model={model} />
+    </ThreeFiber>
+  );
+};
+
+const Scene = observer(({ model }: { model: Model }) => (
+  <>
+    <PerspectiveCamera args={[60, 1, 0.5, 10]} position={[0, 0, 4]} />
+    <pointLight position={[0, 0, 4]} />
+    {model.boxes.map((box) => (
+      <BoxView key={box.id} box={box} />
+    ))}
+  </>
+));
+
+const BoxView = observer(({ box }: { box: BoxModel }) => (
+  <mesh
+    position={box.position.toArray()}
+    rotation={box.rotation.toArray()}
+    scale={Vector3.fromScalar(box.size).toArray()}
+  >
+    <boxGeometry args={[1, 1, 1]} />
+    <meshPhongMaterial color={box.color} />
+  </mesh>
+));

--- a/nusight2/src/client/components/three/stories/three_fiber.stories.tsx
+++ b/nusight2/src/client/components/three/stories/three_fiber.stories.tsx
@@ -9,8 +9,6 @@ import { useEffect } from "react";
 import { Vector2 } from "../../../../shared/math/vector2";
 import { Vector3 } from "../../../../shared/math/vector3";
 import { fullscreen } from "../../storybook/fullscreen";
-import { meshPhongMaterial } from "../builders";
-import { mesh } from "../builders";
 import { PerspectiveCamera, ThreeFiber } from "../three_fiber";
 
 type Story = StoryObj<typeof BoxVisualiser>;

--- a/nusight2/src/client/components/three/three_fiber.tsx
+++ b/nusight2/src/client/components/three/three_fiber.tsx
@@ -1,5 +1,5 @@
-import { Canvas, useThree } from "@react-three/fiber";
 import React from "react";
+import { Canvas, useThree } from "@react-three/fiber";
 import * as THREE from "three";
 
 export const ThreeFiber = ({ children }: { children: React.ReactNode }) => (

--- a/nusight2/src/client/components/three/three_fiber.tsx
+++ b/nusight2/src/client/components/three/three_fiber.tsx
@@ -1,0 +1,27 @@
+import { Canvas, useThree } from "@react-three/fiber";
+import React from "react";
+import * as THREE from "three";
+
+export const ThreeFiber = ({ children }: { children: React.ReactNode }) => (
+  <Canvas frameloop="demand" linear flat gl={{ antialias: true }} style={{ background: "black" }}>
+    {children}
+  </Canvas>
+);
+
+export const PerspectiveCamera = (
+  props: JSX.IntrinsicElements["perspectiveCamera"] & {
+    /** Making it manual will stop responsiveness, and you have to calculate aspect ratio yourself. */
+    manual?: boolean;
+  },
+) => {
+  const ref = React.useRef<THREE.PerspectiveCamera>(null);
+  const three = useThree();
+  React.useEffect(() => {
+    const camera = ref.current;
+    if (camera) {
+      three.set({ camera });
+      three.setSize(three.gl.domElement.clientWidth, three.gl.domElement.clientHeight);
+    }
+  }, []);
+  return <perspectiveCamera ref={ref} {...props} />;
+};

--- a/nusight2/yarn.lock
+++ b/nusight2/yarn.lock
@@ -32,7 +32,7 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/code-frame@^7.21.4":
+"@babel/code-frame@^7.14.5", "@babel/code-frame@^7.21.4":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.21.4.tgz#d0fa9e4413aca81f2b23b9442797bda1826edb39"
   integrity sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==
@@ -334,6 +334,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
+"@babel/helper-string-parser@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
+  integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
+
 "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
@@ -395,6 +400,11 @@
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.4.tgz#94003fdfc520bbe2875d4ae557b43ddb6d880f17"
   integrity sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==
+
+"@babel/parser@^7.14.5":
+  version "7.22.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.4.tgz#a770e98fd785c231af9d93f6459d36770993fb32"
+  integrity sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==
 
 "@babel/parser@^7.20.15":
   version "7.21.3"
@@ -1147,10 +1157,10 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.17.8", "@babel/runtime@^7.8.4":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
-  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+"@babel/runtime@^7.17.8":
+  version "7.22.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.3.tgz#0a7fce51d43adbf0f7b517a71f4c3aaca92ebcbb"
+  integrity sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==
   dependencies:
     regenerator-runtime "^0.13.11"
 
@@ -1161,7 +1171,14 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.18.10", "@babel/template@^7.3.3":
+"@babel/runtime@^7.8.4":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
+"@babel/template@^7.18.10":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
   integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
@@ -1178,6 +1195,15 @@
     "@babel/code-frame" "^7.18.6"
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
+
+"@babel/template@^7.3.3":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
+  integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
 "@babel/traverse@^7.1.6", "@babel/traverse@^7.20.5", "@babel/traverse@^7.20.7", "@babel/traverse@^7.21.0", "@babel/traverse@^7.21.2", "@babel/traverse@^7.21.4", "@babel/traverse@~7.21.2":
   version "7.21.4"
@@ -1218,6 +1244,15 @@
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.14.5":
+  version "7.22.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.4.tgz#56a2653ae7e7591365dabf20b76295410684c071"
+  integrity sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.21.5"
+    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.18.9", "@babel/types@^7.2.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.2", "@babel/types@^7.21.4", "@babel/types@^7.4.4", "@babel/types@~7.21.2":
@@ -1891,6 +1926,20 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
+"@react-three/fiber@^8.13.0":
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-8.13.0.tgz#c9eabe60f2276a66d7ce9a3b927083894f4202f9"
+  integrity sha512-hPFzFNgikEMyEbL+NpSA7q+UWZxInrrkJldWaCR2w34Fwf20x9p68bsyN0/yn9oM2VlWoJcJjR8hw1tN9AxHuA==
+  dependencies:
+    "@babel/runtime" "^7.17.8"
+    "@types/react-reconciler" "^0.26.7"
+    its-fine "^1.0.6"
+    react-reconciler "^0.27.0"
+    react-use-measure "^2.1.1"
+    scheduler "^0.21.0"
+    suspend-react "^0.0.8"
+    zustand "^3.7.1"
 
 "@rollup/plugin-node-resolve@^13.0.6":
   version "13.3.0"
@@ -3043,6 +3092,20 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-reconciler@^0.26.7":
+  version "0.26.7"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.26.7.tgz#0c4643f30821ae057e401b0d9037e03e8e9b2a36"
+  integrity sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-reconciler@^0.28.0":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.2.tgz#f16b0e8cc4748af70ca975eaaace0d79582c71fa"
+  integrity sha512-8tu6lHzEgYPlfDf/J6GOQdIc+gs+S2yAqlby3zTsB3SP2svlqTYe5fwZNtZyfactP74ShooP2vvi1BOp9ZemWw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@4.4.5":
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
@@ -3236,6 +3299,11 @@
   dependencies:
     "@typescript-eslint/types" "5.36.1"
     eslint-visitor-keys "^3.3.0"
+
+"@use-it/interval@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@use-it/interval/-/interval-1.0.0.tgz#c42c68f22ca29a0dc929041746373d94496d2b3a"
+  integrity sha512-WQFcnSt/xM/mS8ZtJ0ut5lhPrl+V0HDPPcI/J0eUClsfiD+/r8A7IeW/pVcfpSVGWRmN3+WnjNteWuKyWs2WZg==
 
 "@vitejs/plugin-react@^2.0.1":
   version "2.1.0"
@@ -4275,6 +4343,11 @@ cuint@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
   integrity sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==
+
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
 debug@2.6.9, debug@^2.6.9:
   version "2.6.9"
@@ -6144,6 +6217,13 @@ istanbul-reports@^3.1.3, istanbul-reports@^3.1.4:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+its-fine@^1.0.6:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.1.1.tgz#e74b93fddd487441f978a50f64f0f5af4d2fc38e"
+  integrity sha512-v1Ia1xl20KbuSGlwoaGsW0oxsw8Be+TrXweidxD9oT/1lAh6O3K3/GIM95Tt6WCiv6W+h2M7RB1TwdoAjQyyKw==
+  dependencies:
+    "@types/react-reconciler" "^0.28.0"
 
 jake@^10.8.5:
   version "10.8.5"
@@ -8105,6 +8185,14 @@ react-outside-click-handler@1.3.0:
     object.values "^1.1.0"
     prop-types "^15.7.2"
 
+react-reconciler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.27.0.tgz#360124fdf2d76447c7491ee5f0e04503ed9acf5b"
+  integrity sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "^0.21.0"
+
 react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
@@ -8141,6 +8229,13 @@ react-transition-group@4.4.5:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-use-measure@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.1.1.tgz#5824537f4ee01c9469c45d5f7a8446177c6cc4ba"
+  integrity sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==
+  dependencies:
+    debounce "^1.2.1"
 
 react@18.2.0:
   version "18.2.0"
@@ -8492,6 +8587,13 @@ safe-regex-test@^1.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+scheduler@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0.tgz#6fd2532ff5a6d877b6edb12f00d8ab7e8f308820"
+  integrity sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 scheduler@^0.23.0:
   version "0.23.0"
@@ -8962,6 +9064,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+suspend-react@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/suspend-react/-/suspend-react-0.0.8.tgz#b0740c1386b4eb652f17affe4339915ee268bd31"
+  integrity sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==
 
 synchronous-promise@^2.0.15:
   version "2.0.17"
@@ -9763,3 +9870,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^3.7.1:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.7.2.tgz#7b44c4f4a5bfd7a8296a3957b13e1c346f42514d"
+  integrity sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==


### PR DESCRIPTION
This PR adds react three fiber as a nusight dependency, and demonstrates its utility in a storybook.

It takes advantage of React's JSX, providing us a declarative language to describe threejs scenes.

I'm pretty convinced its superior to our current implementation is nearly every way, but the real proof will come when we rewrite the various components that use threejs (e.g. vision and localisation). I'm pretty confident it will simplify a lot, and that we should be able to maintain similar performance. See #938 for a previous attempt at porting vision.

Electing to keep this PR as minimal as possible for now.