### PR TITLE
Fix webots image timestamps

### DIFF
--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -805,7 +805,7 @@ namespace module::platform {
             image->data           = camera.image;
 
             image->id        = camera_context[camera.name].id;
-            image->timestamp = NUClear::clock::time_point(std::chrono::nanoseconds(sensor_measurements.time));
+            image->timestamp = NUClear::clock::now();
 
             Eigen::Isometry3d Hcw;
 


### PR DESCRIPTION
Webots is creating NBS files with incorrect length due to using the simulation time for webots images.

This PR updates the webots image timestamps to use `NUClear::clock::now()` which fixes the problem and I don't believe this introduces any problems.