### PR TITLE
Add type checking to nusight

### DIFF
--- a/.github/workflows/nusight.yaml
+++ b/.github/workflows/nusight.yaml
@@ -95,6 +95,10 @@ jobs:
         working-directory: nusight2
         run: yarn --prefer-offline
 
+      - name: Type Check NUsight
+        working-directory: nusight2
+        run: yarn tscheck
+
       - name: Build NUsight
         working-directory: nusight2
         run: yarn build:ci
@@ -188,10 +192,6 @@ jobs:
       - name: Install Dependencies
         working-directory: nusight2
         run: yarn --prefer-offline
-
-      - name: Type Check NUsight
-        working-directory: nusight2
-        run: yarn tscheck
 
       - name: Build NUsight
         working-directory: nusight2

--- a/.github/workflows/nusight.yaml
+++ b/.github/workflows/nusight.yaml
@@ -189,6 +189,10 @@ jobs:
         working-directory: nusight2
         run: yarn --prefer-offline
 
+      - name: Type Check NUsight
+        working-directory: nusight2
+        run: yarn tscheck
+
       - name: Build NUsight
         working-directory: nusight2
         run: yarn test:ci

--- a/nusight2/src/client/components/localisation/network.ts
+++ b/nusight2/src/client/components/localisation/network.ts
@@ -38,7 +38,7 @@ export class LocalisationNetwork {
   @action.bound
   private onFieldLines(robotModel: RobotModel, fieldLines: message.vision.FieldLines) {
     const robot = LocalisationRobotModel.of(robotModel);
-    robot.fieldLinesDots.rPWw = fieldLines.rPCw.map((rPWw) => Vector3.from(rPWw).applyMatrix4(robot.Hfw));
+    robot.fieldLinesDots.rPWw = fieldLines.rPWw.map((rPWw) => Vector3.from(rPWw).applyMatrix4(robot.Hfw));
   }
 
   @action


### PR DESCRIPTION
With the swap over to vite build no longer performs a type check. This adds type-checking back into CI
