### PR TITLE
Odometry ground truth method

### DIFF
--- a/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
@@ -77,5 +77,5 @@ mahony:
 # Tuning parameters to scale walk command to match actual achieved velocity for deckreckoning x, y, theta
 deadreckoning_scale: [1, 1, 0.6]
 
-# Specify which filtering method to use, either UKF, KF or MAHONY
+# Specify which filtering method to use, either UKF, KF, MAHONY or GROUND_TRUTH
 filtering_method: MAHONY

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -167,6 +167,9 @@ namespace module::input {
                                         case FilteringMethod::MAHONY:
                                             update_odometry_mahony(sensors, previous_sensors, raw_sensors);
                                             break;
+                                        case FilteringMethod::GROUND_TRUTH:
+                                            update_odometry_ground_truth(sensors, raw_sensors);
+                                            break;
                                         default: log<NUClear::WARN>("Unknown Filtering Method"); break;
                                     }
 

--- a/module/input/SensorFilter/src/SensorFilter.hpp
+++ b/module/input/SensorFilter/src/SensorFilter.hpp
@@ -102,7 +102,7 @@ namespace module::input {
         };
 
         struct FilteringMethod {
-            enum Value { UNKNOWN = 0, UKF = 1, KF = 2, MAHONY = 3 };
+            enum Value { UNKNOWN = 0, UKF = 1, KF = 2, MAHONY = 3, GROUND_TRUTH = 4 };
             Value value = Value::UNKNOWN;
 
             // Constructors
@@ -114,6 +114,7 @@ namespace module::input {
                         if      (str == "UKF") { value = Value::UKF; }
                         else if (str == "KF") { value = Value::KF; }
                         else if (str == "MAHONY")  { value = Value::MAHONY; }
+                        else if (str == "GROUND_TRUTH")  { value = Value::GROUND_TRUTH; }
                         else {
                             value = Value::UNKNOWN;
                             throw std::runtime_error("String " + str + " did not match any enum for FilteringMethod");
@@ -130,6 +131,7 @@ namespace module::input {
                     case Value::UKF: return "UKF";
                     case Value::KF: return "KF";
                     case Value::MAHONY: return "MAHONY";
+                    case Value::GROUND_TRUTH: return "GROUND_TRUTH";
                     default: throw std::runtime_error("enum Method's value is corrupt, unknown value stored");
                 }
             }
@@ -314,6 +316,13 @@ namespace module::input {
         void update_odometry_mahony(std::unique_ptr<Sensors>& sensors,
                                     const std::shared_ptr<const Sensors>& previous_sensors,
                                     const RawSensors& raw_sensors);
+
+        /// @brief Updates the sensors message with odometry data filtered using ground truth from WeBots. This includes
+        /// the position, orientation, velocity and rotational velocity of the torso in world space.
+        /// @param sensors The sensors message to update
+        /// @param previous_sensors The previous sensors message
+        /// @param raw_sensors The raw sensor data
+        void update_odometry_ground_truth(std::unique_ptr<Sensors>& sensors, const RawSensors& raw_sensors);
 
         /// @brief Display debug information
         /// @param sensors The sensors message to update

--- a/module/input/SensorFilter/src/sensorfilter/GroundTruth.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/GroundTruth.cpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2023 NUbots <nubots@nubots.net>
+ */
+
+#include "SensorFilter.hpp"
+
+#include "utility/math/euler.hpp"
+
+namespace module::input {
+
+    using utility::math::euler::MatrixToEulerIntrinsic;
+
+    void SensorFilter::update_odometry_ground_truth(std::unique_ptr<Sensors>& sensors, const RawSensors& raw_sensors) {
+        // **************** Construct Odometry Output ****************
+        Eigen::Isometry3d Hwt = Eigen::Isometry3d(raw_sensors.odometry_ground_truth.Htw).inverse();
+        sensors->Htw          = Hwt.inverse().matrix();
+
+        Eigen::Vector3d Hwt_rpy = MatrixToEulerIntrinsic(Hwt.rotation());
+        Eigen::Isometry3d Hwr   = Eigen::Isometry3d::Identity();
+        Hwr.linear()            = Eigen::AngleAxisd(Hwt_rpy.z(), Eigen::Vector3d::UnitZ()).toRotationMatrix();
+        Hwr.translation()       = Eigen::Vector3d(Hwt.translation().x(), Hwt.translation().y(), 0.0);
+        sensors->Hrw            = Hwr.inverse().matrix();
+    }
+}  // namespace module::input

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -819,7 +819,7 @@ namespace module::platform {
                     auto Hwp_it = std::lower_bound(Hwps.begin(),
                                                    Hwps.end(),
                                                    std::make_pair(image->timestamp, Eigen::Isometry3d::Identity()),
-                                                   [](const auto& a, const auto& b) { return a.first > b.first; });
+                                                   [](const auto& a, const auto& b) { return a.first < b.first; });
 
                     if (Hwp_it == Hwps.end()) {
                         // Image is newer than most recent sensors


### PR DESCRIPTION
This PR adds a ground truth method to `SensorFilter` which allows the use of webots ground truth information for odometry which is useful for testing purposes. 


Note, this will only work when using our webots controller.

Something I'm unsure on is it seems the recent timestamp changes https://github.com/NUbots/NUbots/pull/1116/files#diff-fc0b2b2d580a7b5d606168708dc45d1b335285a24d5c80f1f4ef7846672cc8b4 required the change in `Webots.cpp`. Maybe we should still be using `sensor_measurements.time` for the comparison, I need to look into it more. 