### PR TITLE
Move cameras around with nucs 

### DIFF
--- a/module/input/Camera/data/config/nugus1/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus1/Cameras/Left.yaml
@@ -1,4 +1,4 @@
-serial_number: 0115138C
+serial_number: 01188260
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,11 +15,11 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.3485051149492453
+  focal_length: 0.34767878619271286
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [0.024648748488062908, 0.003206197425052844]
+  centre: [-0.01370165657132854, -0.013645629277120971]
   # The polynomial distortion coefficients for the lens
-  k: [0.35593577408411464, 0.12711003594280923]
+  k: [0.46673390301927425, 0.15017118169604132]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location

--- a/module/input/Camera/data/config/nugus1/Cameras/Right.yaml
+++ b/module/input/Camera/data/config/nugus1/Cameras/Right.yaml
@@ -1,4 +1,4 @@
-serial_number: 011885A9
+serial_number: 0118847F
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,11 +15,11 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.34690945742400775
+  focal_length: 0.34407470485610553
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [0.02072339174622414, -0.0011612242293956145]
+  centre: [0.0037393686683910104, -0.007110721366947057]
   # The polynomial distortion coefficients for the lens
-  k: [0.38553542593448015, 0.1498415334589703]
+  k: [0.4739103438574755, 0.1549602920025024]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location

--- a/module/input/Camera/data/config/nugus2/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus2/Cameras/Left.yaml
@@ -1,4 +1,4 @@
-serial_number: 01188260
+serial_number: 011885B0
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,11 +15,11 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.34767878619271286
+  focal_length: 0.34607022208588906
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [-0.01370165657132854, -0.013645629277120971]
+  centre: [-0.008429632815260277, 0.003767345048721181]
   # The polynomial distortion coefficients for the lens
-  k: [0.46673390301927425, 0.15017118169604132]
+  k: [0.4718296027381958, 0.22726744036437643]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location

--- a/module/input/Camera/data/config/nugus3/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus3/Cameras/Left.yaml
@@ -1,4 +1,4 @@
-serial_number: 011885B0
+serial_number: 01188483
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,16 +15,16 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.34607022208588906
+  focal_length: 0.3379603020878361
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [-0.008429632815260277, 0.003767345048721181]
+  centre: [-0.014463461390834174, -0.024161253939202938]
   # The polynomial distortion coefficients for the lens
-  k: [0.4718296027381958, 0.22726744036437643]
+  k: [0.5008855578146484, 0.25712627828352613]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location
   Hpc:
     - [0.9997403694613228, -0.016551656784825577, -0.01566002262642871, 0.08893612063588988]
-    - [0.01728764296000275, 0.9986932814319833, 0.04809227613146373, 0.03529909622045881]
+    - [0.01728764296000275, 0.9986932814319833, 0.04809227613146373, -0.03529909622045881]
     - [0.014843552535558163, -0.04835051478781678, 0.9987201292902445, 0.0713674563254241]
     - [0.0, 0.0, 0.0, 1.0]

--- a/module/input/Camera/data/config/nugus4/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus4/Cameras/Left.yaml
@@ -1,4 +1,4 @@
-serial_number: 01188483
+serial_number: 0115138C
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,16 +15,16 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.3379603020878361
+  focal_length: 0.3485051149492453
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [-0.014463461390834174, -0.024161253939202938]
+  centre: [0.024648748488062908, 0.003206197425052844]
   # The polynomial distortion coefficients for the lens
-  k: [0.5008855578146484, 0.25712627828352613]
+  k: [0.35593577408411464, 0.12711003594280923]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location
   Hpc:
     - [0.9997403694613228, -0.016551656784825577, -0.01566002262642871, 0.08893612063588988]
-    - [0.01728764296000275, 0.9986932814319833, 0.04809227613146373, -0.03529909622045881]
+    - [0.01728764296000275, 0.9986932814319833, 0.04809227613146373, 0.03529909622045881]
     - [0.014843552535558163, -0.04835051478781678, 0.9987201292902445, 0.0713674563254241]
     - [0.0, 0.0, 0.0, 1.0]

--- a/module/input/Camera/data/config/nugus4/Cameras/Right.yaml
+++ b/module/input/Camera/data/config/nugus4/Cameras/Right.yaml
@@ -1,4 +1,4 @@
-serial_number: 0118847F
+serial_number: 011885A9
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,11 +15,11 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.34407470485610553
+  focal_length: 0.34690945742400775
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [0.0037393686683910104, -0.007110721366947057]
+  centre: [0.02072339174622414, -0.0011612242293956145]
   # The polynomial distortion coefficients for the lens
-  k: [0.4739103438574755, 0.1549602920025024]
+  k: [0.38553542593448015, 0.1498415334589703]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location


### PR DESCRIPTION
We've got new nucs (new nucs! new nucs!) and the robots have got different numbers to what they had before. We also have a fourth robot now. This is mostly from the top of my head so someone might want to check on each of the robots, but this does work for the fourth robot (currently Sarah). Frankie doesn't have a nuc yet but if all the others are right, then that one will be right too, since we haven't added any cameras, they've just moved about. 

- Sarah was number 1, is now number 4
- Kevin was number 3, is now number 2 (only has one camera)
- Sasha was number 2, now is Billie and is number 1
- Frankie will be number 3 and has one camera
