### PR TITLE
Add missing modules to robocup

### DIFF
--- a/roles/robocup.role
+++ b/roles/robocup.role
@@ -38,7 +38,7 @@ nuclear_role(
   planning::GetUpPlanner
   planning::FallingRelaxPlanner
   # Strategies
-  # strategy::FallRecovery
+  strategy::FallRecovery
   strategy::StandStill
   strategy::WalkToFieldPosition
   strategy::StrategiseLook

--- a/roles/robocup.role
+++ b/roles/robocup.role
@@ -16,7 +16,9 @@ nuclear_role(
   vision::VisualMesh
   vision::GreenHorizonDetector
   vision::BallDetector
+  vision::FieldLineDetector
   # Localisation
+  localisation::FieldLocalisation
   localisation::BallLocalisation
   # Director
   extension::Director
@@ -36,14 +38,17 @@ nuclear_role(
   planning::GetUpPlanner
   planning::FallingRelaxPlanner
   # Strategies
-  strategy::FallRecovery
+  # strategy::FallRecovery
   strategy::StandStill
+  strategy::WalkToFieldPosition
   strategy::StrategiseLook
   strategy::WalkToBall
   strategy::FindObject
-  strategy::Ready
+  strategy::KickToGoal
+  strategy::AlignBallToGoal
   strategy::DiveToBall
   # Purposes
   purpose::Striker
+  purpose::Goalie
   purpose::Soccer
 )


### PR DESCRIPTION
Some modules were missing from RoboCup and so things weren't working. Probs shows a problem with Director, it seems a high priority task that has no Provider will block all other tasks (has been added to the Director bugs issue).