### PR TITLE
Fix rendered visual mesh aspect ratio in NUsight

### DIFF
--- a/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.vert
+++ b/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.vert
@@ -9,6 +9,7 @@ uniform float focalLength;
 uniform vec2 centre;
 uniform vec2 k;
 uniform int projection;
+uniform float imageAspectRatio;
 
 attribute vec3 position;
 
@@ -39,5 +40,12 @@ void main() {
     vField       = field;
     vEnvironment = environment;
 
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 0.0, 1.0);
+    // Aspect ratio of GL view
+    float viewRatio = viewSize.x / viewSize.y;
+
+    // In the case where the GL view's aspect ratio is wider than the image's,
+    // the point should be scaled to align with the image.
+    float scale = (viewRatio > imageAspectRatio) ? (imageAspectRatio / viewRatio) : 1.0;
+
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos * scale, 0.0, 1.0);
 }

--- a/nusight2/src/client/components/vision/vision_camera/view_model.ts
+++ b/nusight2/src/client/components/vision/vision_camera/view_model.ts
@@ -56,6 +56,6 @@ export class VisionCameraViewModel extends CameraViewModel {
   @computed
   private get visualMesh(): VisualMeshViewModel | undefined {
     const { visualMesh, params } = this.model;
-    return visualMesh && VisualMeshViewModel.of(visualMesh, params, this.canvas);
+    return visualMesh && VisualMeshViewModel.of(visualMesh, params, this.canvas, this.imageAspectRatio);
   }
 }

--- a/nusight2/src/client/components/vision/vision_camera/visual_mesh.ts
+++ b/nusight2/src/client/components/vision/vision_camera/visual_mesh.ts
@@ -18,7 +18,7 @@ export class VisualMeshViewModel {
   private readonly model: VisualMeshModel;
   private readonly params: CameraParams;
   private readonly canvas: Canvas;
-  private readonly imageAspectRatio: number
+  private readonly imageAspectRatio: number;
 
   constructor(model: VisualMeshModel, params: CameraParams, canvas: Canvas, imageAspectRatio: number) {
     this.model = model;

--- a/nusight2/src/client/components/vision/vision_camera/visual_mesh.ts
+++ b/nusight2/src/client/components/vision/vision_camera/visual_mesh.ts
@@ -18,15 +18,17 @@ export class VisualMeshViewModel {
   private readonly model: VisualMeshModel;
   private readonly params: CameraParams;
   private readonly canvas: Canvas;
+  private readonly imageAspectRatio: number
 
-  constructor(model: VisualMeshModel, params: CameraParams, canvas: Canvas) {
+  constructor(model: VisualMeshModel, params: CameraParams, canvas: Canvas, imageAspectRatio: number) {
     this.model = model;
     this.params = params;
     this.canvas = canvas;
+    this.imageAspectRatio = imageAspectRatio;
   }
 
-  static of(model: VisualMeshModel, params: CameraParams, canvas: Canvas) {
-    return new VisualMeshViewModel(model, params, canvas);
+  static of(model: VisualMeshModel, params: CameraParams, canvas: Canvas, imageAspectRatio: number) {
+    return new VisualMeshViewModel(model, params, canvas, imageAspectRatio);
   }
 
   readonly visualMesh = mesh(() => ({
@@ -77,6 +79,7 @@ export class VisualMeshViewModel {
       focalLength: { value: this.params.lens.focalLength },
       centre: { value: this.params.lens.centre.toThree() },
       k: { value: this.params.lens.distortionCoeffecients.toThree() },
+      imageAspectRatio: { value: this.imageAspectRatio },
       projection: { value: this.params.lens.projection },
     },
     depthTest: false,


### PR DESCRIPTION
Currently when the GL view's aspect ratio is wider than the image (usually the case when zoomed in), the mesh is rendered past the edges of the image. This PR fixes that by correcting the aspect ratio of the rendered mesh to match the image.

This is what it looked like before: 

![image](https://github.com/NUbots/NUbots/assets/5924865/1c5cd18e-5bfe-4f77-9e74-90d8fcd07d4b)

And here's after:

![image](https://github.com/NUbots/NUbots/assets/5924865/e2db18fa-7fc4-467b-981f-8da79cf6da83)


