### PR TITLE
Separate model and packet watchdogs to prevent dropped packets stopping the robot's motions

### DIFF
--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -76,7 +76,7 @@ namespace module::platform::OpenCR {
             }
         });
 
-        on<Watchdog<HardwareIO, 2, std::chrono::seconds>, Sync<HardwareIO>>().then([this] {
+        packet_watchdog = on<Watchdog<HardwareIO, 20, std::chrono::milliseconds>, Sync<HardwareIO>>().then([this] {
             // First, check if this is the model info packet, because if it is, the system
             // startup failed, and we need to re-trigger it.
             if (opencr_waiting() && packet_queue[NUgus::ID::OPENCR].front() == PacketTypes::MODEL_INFORMATION) {

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -29,6 +29,49 @@ namespace module::platform::OpenCR {
     HardwareIO::HardwareIO(std::unique_ptr<NUClear::Environment> environment)
         : Reactor(std::move(environment)), opencr(), nugus(), byte_wait(0), packet_wait(0), packet_queue() {
 
+
+        packet_watchdog =
+            on<Watchdog<PacketWatchdog, 20, std::chrono::milliseconds>, Sync<PacketWatchdog>>()
+                .then([this] {
+                    if (model_watchdog.enabled()) {
+                        log<NUClear::WARN>("Packet watchdog cannot be enabled while model watchdog is enabled");
+                        packet_watchdog.disable();
+                        return;
+                    }
+                    log<NUClear::WARN>("Packet watchdog", packet_watchdog.enabled(), model_watchdog.enabled());
+                    // Check what the hangup was
+                    bool packet_dropped = false;
+                    // The result of the assignment is 0 (NUgus::ID::NO_ID) if we aren't waiting on
+                    // any packets, otherwise is the nonzero ID of the timed out device
+                    for (NUgus::ID dropout_id; (dropout_id = queue_item_waiting()) != NUgus::ID::NO_ID;) {
+                        // Delete the packet we're waiting on
+                        packet_queue[dropout_id].erase(packet_queue[dropout_id].begin());
+                        log<NUClear::WARN>(fmt::format("Dropped packet from ID {}", int(dropout_id)));
+                        // Set flag
+                        packet_dropped = true;
+                    }
+
+                    // Send a request for all servo packets, only if there were packets dropped
+                    // In case the system stops for some other reason, we don't want the watchdog
+                    // to make it automatically restart
+                    if (packet_dropped) {
+                        log<NUClear::WARN>("Requesting servo packets to restart system");
+                        send_servo_request();
+                    }
+                })
+                .disable();
+        model_watchdog =
+            on<Watchdog<ModelWatchdog, 500, std::chrono::milliseconds>, Sync<ModelWatchdog>>()
+                .then([this] {
+                    log<NUClear::WARN>(fmt::format("OpenCR model information not received, restarting system"));
+                    // Clear all packet queues just in case
+                    queue_clear_all();
+                    // Restart the system and exit the watchdog
+                    startup();
+                    return;
+                })
+                .enable();
+
         on<Configuration>("HardwareIO.yaml").then([this](const Configuration& config) {
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
 
@@ -58,53 +101,17 @@ namespace module::platform::OpenCR {
                 servo_states[i].simulated = config["servos"][i]["simulated"].as<bool>();
             }
 
-            model_watchdog.disable();
+            model_watchdog.enable();
             packet_watchdog.disable();
             log<NUClear::INFO>("Packet watchdog disabled", packet_watchdog.enabled());
         });
 
-        model_watchdog =
-            on<Watchdog<ModelWatchdog, 500, std::chrono::milliseconds>, Sync<ModelWatchdog>>()
-                .then([this] {
-                    log<NUClear::WARN>(fmt::format("OpenCR model information not received, restarting system"));
-                    // Clear all packet queues just in case
-                    queue_clear_all();
-                    // Restart the system and exit the watchdog
-                    startup();
-                    return;
-                })
-                .disable();
-
-        packet_watchdog = on<Watchdog<PacketWatchdog, 20, std::chrono::milliseconds>, Sync<PacketWatchdog>>()
-                              .then([this] {
-                                  log<NUClear::WARN>("Packet watchdog", packet_watchdog.enabled());
-                                  // Check what the hangup was
-                                  bool packet_dropped = false;
-                                  // The result of the assignment is 0 (NUgus::ID::NO_ID) if we aren't waiting on
-                                  // any packets, otherwise is the nonzero ID of the timed out device
-                                  for (NUgus::ID dropout_id; (dropout_id = queue_item_waiting()) != NUgus::ID::NO_ID;) {
-                                      // Delete the packet we're waiting on
-                                      packet_queue[dropout_id].erase(packet_queue[dropout_id].begin());
-                                      log<NUClear::WARN>(fmt::format("Dropped packet from ID {}", int(dropout_id)));
-                                      // Set flag
-                                      packet_dropped = true;
-                                  }
-
-                                  // Send a request for all servo packets, only if there were packets dropped
-                                  // In case the system stops for some other reason, we don't want the watchdog
-                                  // to make it automatically restart
-                                  if (packet_dropped) {
-                                      log<NUClear::WARN>("Requesting servo packets to restart system");
-                                      send_servo_request();
-                                  }
-                              })
-                              .disable();
 
         on<Startup>().then("HardwareIO Startup", [this] {
             // The first thing to do is get the model information
             // The model watchdog is started, which has a longer time than the packet watchdog
             // The packet watchdog is disabled until we start the main loop
-            model_watchdog.disable();
+            model_watchdog.enable();
             packet_watchdog.disable();
             log<NUClear::INFO>("Packet watchdog disabled", packet_watchdog.enabled());
             startup();
@@ -178,7 +185,7 @@ namespace module::platform::OpenCR {
                         // Start the packet watchdog since the main loop is now starting
                         model_watchdog.disable();
                         log<NUClear::WARN>("Packet watchdog enabled");
-                        // packet_watchdog.enable();
+                        packet_watchdog.enable();
 
                         // At the start, we want to query the motors so we can store their state internally
                         // This will start the loop of reading and writing to the servos and opencr

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -80,6 +80,12 @@ namespace module::platform::OpenCR {
             // First, check if this is the model info packet, because if it is, the system
             // startup failed, and we need to re-trigger it.
             if (opencr_waiting() && packet_queue[NUgus::ID::OPENCR].front() == PacketTypes::MODEL_INFORMATION) {
+                // gross solution to let model information take longer
+                static int counter = 0;
+                // model info can take up to 100 ms
+                if (counter++ < 5)
+                    return;
+                // after 100 ms, actually trigger the watchdog
                 log<NUClear::WARN>(fmt::format("OpenCR model information not recieved, restarting system"));
                 // Clear all packet queues just in case
                 queue_clear_all();

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -187,7 +187,7 @@ namespace module::platform::OpenCR {
 
                         // Stop the model watchdog since we have it now
                         // Start the packet watchdog since the main loop is now starting
-                        model_watchdog.disable();
+                        model_watchdog.unbind();
                         log<NUClear::WARN>("Packet watchdog enabled");
                         packet_watchdog.enable();
 

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
@@ -24,6 +24,9 @@ namespace module::platform::OpenCR {
         explicit HardwareIO(std::unique_ptr<NUClear::Environment> environment);
 
     private:
+        struct PacketWatchdog {};
+        struct ModelWatchdog {};
+
         /// @brief Manages the connection with OpenCR
         utility::io::uart opencr{};
 
@@ -215,6 +218,8 @@ namespace module::platform::OpenCR {
         /// @returns the number of packets cleared
         int queue_clear_all();
 
+        /// @brief Handle for the watchdog timer for the model information
+        ReactionHandle model_watchdog;
         /// @brief Handle for our watchdog timer for packet handling
         ReactionHandle packet_watchdog;
     };

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
@@ -24,9 +24,6 @@ namespace module::platform::OpenCR {
         explicit HardwareIO(std::unique_ptr<NUClear::Environment> environment);
 
     private:
-        struct PacketWatchdog {};
-        struct ModelWatchdog {};
-
         /// @brief Manages the connection with OpenCR
         utility::io::uart opencr{};
 
@@ -217,6 +214,9 @@ namespace module::platform::OpenCR {
         /// @brief clear all packet queues
         /// @returns the number of packets cleared
         int queue_clear_all();
+
+        struct PacketWatchdog {};
+        struct ModelWatchdog {};
 
         /// @brief Handle for the watchdog timer for the model information
         ReactionHandle model_watchdog;

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
@@ -220,6 +220,7 @@ namespace module::platform::OpenCR {
 
         /// @brief Handle for the watchdog timer for the model information
         ReactionHandle model_watchdog;
+
         /// @brief Handle for our watchdog timer for packet handling
         ReactionHandle packet_watchdog;
     };

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
@@ -214,6 +214,9 @@ namespace module::platform::OpenCR {
         /// @brief clear all packet queues
         /// @returns the number of packets cleared
         int queue_clear_all();
+
+        /// @brief Handle for our watchdog timer for packet handling
+        ReactionHandle packet_watchdog;
     };
 
 }  // namespace module::platform::OpenCR

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/startup.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/startup.cpp
@@ -3,6 +3,9 @@
 namespace module::platform::OpenCR {
 
     void HardwareIO::startup() {
+        // first, disable the packet watchdog as we haven't sent anything yet and don't want it to trigger
+        packet_watchdog.disable();
+
         // Set the OpenCR to not return a status packet when written to (to allow consecutive writes)
         opencr.write(dynamixel::v2::WriteCommand<uint8_t>(uint8_t(NUgus::ID::OPENCR),
                                                           uint16_t(OpenCR::Address::STATUS_RETURN_LEVEL),
@@ -137,6 +140,9 @@ namespace module::platform::OpenCR {
         for (auto& servo_state : servo_states) {
             servo_state.initialised = false;
         }
+
+        // Now, enable the packet watchdog before we send anything.
+        packet_watchdog.enable();
 
         // Find OpenCR firmware and model versions
         // This has to be called last, as we need to wait for the response packet before starting


### PR DESCRIPTION
This PR splits the watchdog into two so if we get dropped servo packets we recover quickly.

At the beginning, we get the OpenCR model. A model watchdog watches for this and times out after 300ms. This watchdog is disabled once the model is received.
When the model watchdog is disabled and the model is received, we enable the packet watchdog. This times out after 20ms of not getting a packet.

I've tested this under normal circumstances and it looks good. I've tested it under packet dropping circumstances and it also looks good, minimal impact on the walk. I did notice a slight impact on the walk but I'd say that is expected when all packets are dropping constantly.

There is an issue where the packet watchdog isn't disabling quickly enough at the beginning before the watchdog triggers (twice). This may just be NUClear being slow or maybe it's the NUClear bug/feature with out of order packets. We can check when the bug fix goes in. I have a work around that works fine and shouldn't cause any issues.