### PR TITLE
Make the WalkState and Stability messages optional in SensorFilter

### DIFF
--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -109,7 +109,7 @@ namespace module::input {
                Optional<With<Sensors>>,
                With<KinematicsModel>,
                With<Stability>,
-               With<WalkState>,
+               Optional<With<WalkState>>,
                Single,
                Priority::HIGH>()
                 .then("Main Sensors Loop",
@@ -117,7 +117,7 @@ namespace module::input {
                              const std::shared_ptr<const Sensors>& previous_sensors,
                              const KinematicsModel& kinematics_model,
                              const Stability& stability,
-                             const WalkState& walk_state) {
+                             const std::shared_ptr<const WalkState>& walk_state) {
                           auto sensors = std::make_unique<Sensors>();
 
                           // Updates message with raw sensor data

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -108,7 +108,7 @@ namespace module::input {
             on<Trigger<RawSensors>,
                Optional<With<Sensors>>,
                With<KinematicsModel>,
-               With<Stability>,
+               Optional<With<Stability>>,
                Optional<With<WalkState>>,
                Single,
                Priority::HIGH>()
@@ -116,7 +116,7 @@ namespace module::input {
                       [this](const RawSensors& raw_sensors,
                              const std::shared_ptr<const Sensors>& previous_sensors,
                              const KinematicsModel& kinematics_model,
-                             const Stability& stability,
+                             const std::shared_ptr<const Stability>& stability,
                              const std::shared_ptr<const WalkState>& walk_state) {
                           auto sensors = std::make_unique<Sensors>();
 

--- a/module/input/SensorFilter/src/SensorFilter.hpp
+++ b/module/input/SensorFilter/src/SensorFilter.hpp
@@ -308,7 +308,7 @@ namespace module::input {
         void update_odometry_kf(std::unique_ptr<Sensors>& sensors,
                                 const std::shared_ptr<const Sensors>& previous_sensors,
                                 const RawSensors& raw_sensors,
-                                const Stability& stability,
+                                const std::shared_ptr<const Stability>& stability,
                                 const std::shared_ptr<const WalkState>& walk_state);
 
 
@@ -320,7 +320,7 @@ namespace module::input {
         void update_odometry_mahony(std::unique_ptr<Sensors>& sensors,
                                     const std::shared_ptr<const Sensors>& previous_sensors,
                                     const RawSensors& raw_sensors,
-                                    const Stability& stability,
+                                    const std::shared_ptr<const Stability>& stability,
                                     const std::shared_ptr<const WalkState>& walk_state);
 
         /// @brief Updates the sensors message with odometry data filtered using ground truth from WeBots. This includes

--- a/module/input/SensorFilter/src/SensorFilter.hpp
+++ b/module/input/SensorFilter/src/SensorFilter.hpp
@@ -309,7 +309,7 @@ namespace module::input {
                                 const std::shared_ptr<const Sensors>& previous_sensors,
                                 const RawSensors& raw_sensors,
                                 const Stability& stability,
-                                const WalkState& walk_state);
+                                const std::shared_ptr<const WalkState>& walk_state);
 
 
         /// @brief Updates the sensors message with odometry data filtered using MahonyFilter. This includes the
@@ -321,7 +321,7 @@ namespace module::input {
                                     const std::shared_ptr<const Sensors>& previous_sensors,
                                     const RawSensors& raw_sensors,
                                     const Stability& stability,
-                                    const WalkState& walk_state);
+                                    const std::shared_ptr<const WalkState>& walk_state);
 
         /// @brief Updates the sensors message with odometry data filtered using ground truth from WeBots. This includes
         /// the position, orientation, velocity and rotational velocity of the torso in world space.

--- a/module/input/SensorFilter/src/sensorfilter/KalmanFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/KalmanFilter.cpp
@@ -56,7 +56,7 @@ namespace module::input {
     void SensorFilter::update_odometry_kf(std::unique_ptr<Sensors>& sensors,
                                           const std::shared_ptr<const Sensors>& previous_sensors,
                                           const RawSensors& raw_sensors,
-                                          const Stability& stability,
+                                          const std::shared_ptr<const Stability>& stability,
                                           const std::shared_ptr<const WalkState>& walk_state) {
         // **************** Time Update ****************
         // Calculate our time offset from the last read then update the filter's time
@@ -67,8 +67,8 @@ namespace module::input {
             0.0);
 
         // Integrate the walk command to estimate the change in position (x,y) and yaw orientation
-        if (walk_state != nullptr) {
-            integrate_walkcommand(dt, stability, *walk_state);
+        if (walk_state != nullptr && stability != nullptr) {
+            integrate_walkcommand(dt, *stability, *walk_state);
         }
 
         // Integrate the rotational velocity to predict the change in orientation (roll, pitch)

--- a/module/input/SensorFilter/src/sensorfilter/KalmanFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/KalmanFilter.cpp
@@ -57,7 +57,7 @@ namespace module::input {
                                           const std::shared_ptr<const Sensors>& previous_sensors,
                                           const RawSensors& raw_sensors,
                                           const Stability& stability,
-                                          const WalkState& walk_state) {
+                                          const std::shared_ptr<const WalkState>& walk_state) {
         // **************** Time Update ****************
         // Calculate our time offset from the last read then update the filter's time
         const double dt = std::max(
@@ -67,7 +67,9 @@ namespace module::input {
             0.0);
 
         // Integrate the walk command to estimate the change in position (x,y) and yaw orientation
-        integrate_walkcommand(dt, stability, walk_state);
+        if (walk_state != nullptr) {
+            integrate_walkcommand(dt, stability, *walk_state);
+        }
 
         // Integrate the rotational velocity to predict the change in orientation (roll, pitch)
         Eigen::Matrix<double, n_inputs, 1> u;

--- a/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
@@ -52,7 +52,7 @@ namespace module::input {
     void SensorFilter::update_odometry_mahony(std::unique_ptr<Sensors>& sensors,
                                               const std::shared_ptr<const Sensors>& previous_sensors,
                                               const RawSensors& raw_sensors,
-                                              const Stability& stability,
+                                              const std::shared_ptr<const Stability>& stability,
                                               const std::shared_ptr<const WalkState>& walk_state) {
         // **************** Time Update ****************
         // Calculate our time offset from the last read then update the filter's time
@@ -63,8 +63,8 @@ namespace module::input {
             0.0);
 
         // Integrate the walk command to estimate the change in position (x,y) and yaw orientation
-        if (walk_state != nullptr) {
-            integrate_walkcommand(dt, stability, *walk_state);
+        if (walk_state != nullptr && stability != nullptr) {
+            integrate_walkcommand(dt, *stability, *walk_state);
         }
 
         // **************** Roll/Pitch Orientation Measurement Update ****************

--- a/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
@@ -66,7 +66,7 @@ namespace module::input {
                                               const std::shared_ptr<const Sensors>& previous_sensors,
                                               const RawSensors& raw_sensors,
                                               const Stability& stability,
-                                              const WalkState& walk_state) {
+                                              const std::shared_ptr<const WalkState>& walk_state) {
         // **************** Time Update ****************
         // Calculate our time offset from the last read then update the filter's time
         const double dt = std::max(
@@ -76,7 +76,9 @@ namespace module::input {
             0.0);
 
         // Integrate the walk command to estimate the change in position (x,y) and yaw orientation
-        integrate_walkcommand(dt, stability, walk_state);
+        if (walk_state != nullptr) {
+            integrate_walkcommand(dt, stability, *walk_state);
+        }
 
         // **************** Roll/Pitch Orientation Measurement Update ****************
         utility::math::filter::MahonyUpdate(sensors->accelerometer,

--- a/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
@@ -41,19 +41,6 @@ namespace module::input {
     using utility::math::filter::MahonyUpdate;
     using utility::support::Expression;
 
-    void SensorFilter::integrate_walkcommand(const double dt, const Stability& stability, const WalkState& walk_state) {
-        // Check if we are not currently falling and walking
-        if (stability == Stability::DYNAMIC && walk_state.state == WalkState::State::WALKING) {
-            // Integrate the walk command to estimate the change in position and yaw orientation
-            double dx = walk_state.velocity_target.x() * dt * cfg.deadreckoning_scale.x();
-            double dy = walk_state.velocity_target.y() * dt * cfg.deadreckoning_scale.y();
-            yaw += walk_state.velocity_target.z() * dt * cfg.deadreckoning_scale.z();
-            // Rotate the change in position into world coordinates before adding it to the current position
-            Hwt.translation().x() += dx * cos(yaw) - dy * sin(yaw);
-            Hwt.translation().y() += dy * cos(yaw) + dx * sin(yaw);
-        }
-    }
-
     void SensorFilter::configure_mahony(const Configuration& config) {
         // Mahony Filter Config
         cfg.Ki            = config["mahony"]["Ki"].as<Expression>();


### PR DESCRIPTION
SensorFilter couldn't run without these messages before, making it hard to run smaller roles testing singular things eg the test/visualmesh role. This PR makes those optional in SensorFilter so it doesn't need them to run. The messages are only used to utilise the walk for positional odometry so if they don't exist it will skip that step. This works similar to how it skips it when the robot isn't walk/stable.