### PR TITLE
Fix images being out of sync with sensors

### DIFF
--- a/module/input/Camera/src/Camera.cpp
+++ b/module/input/Camera/src/Camera.cpp
@@ -416,7 +416,7 @@ namespace module::input {
                         auto Hwp_it = std::lower_bound(reactor.Hwps.begin(),
                                                        reactor.Hwps.end(),
                                                        std::make_pair(msg->timestamp, Eigen::Isometry3d::Identity()),
-                                                       [](const auto& a, const auto& b) { return a.first > b.first; });
+                                                       [](const auto& a, const auto& b) { return a.first < b.first; });
 
                         if (Hwp_it == reactor.Hwps.end()) {
                             // Image is newer than most recent sensors


### PR DESCRIPTION
This PR fixes an issue with the latching method in `Camera.cpp` having incorrect logic for associating a sensors message to an image. 

