### PR TITLE
Add a unit test for Director self intersection and a fix

### DIFF
--- a/module/extension/Director/src/Director.hpp
+++ b/module/extension/Director/src/Director.hpp
@@ -322,12 +322,14 @@ namespace module::extension {
          * Solves each of a series of Solutions and returns a list of OkSolutions that represents the first solution
          * that can execute, or a blocked solution if none of the solutions can execute.
          *
-         * @param solutions the set of solutions that we are trying to find an OkSolution for
+         * @param solutions  the set of solutions that we are trying to find an OkSolution for
+         * @param used_types types that have already been used higher in the solution tree that are blocked to us
          *
          * @return a list of OkSolutions that represents the first solution that can execute, or a blocked solution if
          *         none of the solutions can execute.
          */
-        std::vector<OkSolution> find_ok_solutions(const std::vector<Solution>& solutions);
+        std::vector<OkSolution> find_ok_solutions(const std::vector<Solution>& solutions,
+                                                  const std::set<std::type_index>& used_types);
 
         /**
          * Runs the passed task on the passed provider.
@@ -353,6 +355,16 @@ namespace module::extension {
         };
 
         /**
+         * The result of running a set of tasks
+         */
+        struct RunResult {
+            /// The level of execution that we were able to do
+            RunLevel run_level;
+            /// The set of provider groups that we used
+            std::set<std::type_index> used;
+        };
+
+        /**
          * Tries to execute tasks in the pack, but only up to the passed run level.
          *
          * The passed run level will limit what types of execution are open to us. For example, if the required pack was
@@ -362,10 +374,14 @@ namespace module::extension {
          * @param group     the provider group that created this pack
          * @param pack      the pack of tasks that we are trying to execute
          * @param run_level the level of execution that we are allowed to do
+         * @param used      the set of provider groups that are already used that we can't use again
          *
-         * @return the run level that we were able to execute up to
+         * @return the run level that we were able to execute up to and the set of provider groups that we used
          */
-        RunLevel run_tasks(component::ProviderGroup& group, const TaskList& pack, const RunLevel& run_level);
+        RunResult run_tasks(component::ProviderGroup& group,
+                            const TaskList& pack,
+                            const RunLevel& run_level,
+                            const std::set<std::type_index>& used);
 
         /**
          * Looks at all the tasks that are in the pack and determines if they should run, and if so runs them.

--- a/module/extension/Director/src/director/find_ok_solution.cpp
+++ b/module/extension/Director/src/director/find_ok_solution.cpp
@@ -101,11 +101,12 @@ namespace module::extension {
                           std::move(blocking_groups));
     }
 
-    std::vector<Director::OkSolution> Director::find_ok_solutions(const std::vector<Solution>& solutions) {
+    std::vector<Director::OkSolution> Director::find_ok_solutions(const std::vector<Solution>& solutions,
+                                                                  const std::set<std::type_index>& used) {
 
         // Find each one individually but pass through the used types
         std::vector<OkSolution> ok_solutions;
-        std::set<std::type_index> used_types;
+        std::set<std::type_index> used_types = used;
         for (const auto& solution : solutions) {
 
             // Choose an option

--- a/module/extension/Director/src/director/run_task_pack.cpp
+++ b/module/extension/Director/src/director/run_task_pack.cpp
@@ -26,11 +26,14 @@ namespace module::extension {
     using component::ProviderGroup;
     using ::extension::behaviour::RunInfo;
 
-    Director::RunLevel Director::run_tasks(ProviderGroup& our_group, const TaskList& tasks, const RunLevel& run_level) {
+    Director::RunResult Director::run_tasks(ProviderGroup& our_group,
+                                            const TaskList& tasks,
+                                            const RunLevel& run_level,
+                                            const std::set<std::type_index>& used) {
 
         // This might happen if only optional tasks are emitted, in that case we successfully run nothing here
         if (tasks.empty()) {
-            return RunLevel::OK;
+            return RunResult{RunLevel::OK, {}};
         }
 
         // Create the solution tree for each of the tasks in the pack
@@ -42,7 +45,7 @@ namespace module::extension {
 
         if (run_level >= RunLevel::OK) {
             // Try to find an ok solution for the pack
-            auto ok_solutions = find_ok_solutions(solutions);
+            auto ok_solutions = find_ok_solutions(solutions, used);
 
             // Loop through the solutions and add watches for the things we want
             for (int i = 0; i < int(tasks.size()); ++i) {
@@ -129,7 +132,12 @@ namespace module::extension {
                     reevaluate_group(providers.at(t->requester_id)->group);
                 }
 
-                return RunLevel::OK;
+                // Accumulate all the used types
+                std::set<std::type_index> used_types;
+                for (const auto& s : ok_solutions) {
+                    used_types.insert(s.used.begin(), s.used.end());
+                }
+                return {RunLevel::OK, used_types};
             }
         }
 
@@ -139,7 +147,7 @@ namespace module::extension {
         }
 
         // If we reach here, we have already queued into everything that could possibly change our state
-        return RunLevel::BLOCKED;
+        return RunResult{RunLevel::BLOCKED, {}};
     }
 
     void Director::run_task_pack(const TaskPack& pack) {
@@ -254,23 +262,32 @@ namespace module::extension {
             }
         }
 
+        // Once we start running tasks we need to keep track of providers that we are using
+        // Future optional tasks might try to run and because priority says that you can replace existing tasks from
+        // your current provider they would be allowed (incorrectly) to take over. We can't change this behaviour as
+        // this would be correct behaviour if we emitted a new task. We should be able to replace our old tasks.
+        std::set<std::type_index> used;
+
         // Run the first task pack segment as all tasks that are not optional
         auto first_optional = std::find_if(tasks.begin(), tasks.end(), [](const auto& t) { return t->optional; });
-        auto run_level      = run_tasks(group, TaskList(tasks.begin(), first_optional), RunLevel::OK);
+        auto result         = run_tasks(group, TaskList(tasks.begin(), first_optional), RunLevel::OK, used);
+        used.insert(result.used.begin(), result.used.end());
 
         // If we are not running normally now and were previously we might still have active tasks that need removing
-        if (run_level != RunLevel::OK) {
+        if (result.run_level != RunLevel::OK) {
             for (auto& t : group.subtasks) {
                 remove_task(t);
             }
         }
 
         // Run each of the optional tasks but only to the level the main task ran or pushed
-        if (run_level <= RunLevel::PUSH) {
+        if (result.run_level <= RunLevel::PUSH) {
             for (auto it = first_optional; it != tasks.end(); ++it) {
                 // Run each optional task in turn as its own pack
                 // but if the main group was pushed, we can at most push in optional
-                if (run_tasks(group, TaskList({*it}), run_level) != RunLevel::OK) {
+                auto optional_result = run_tasks(group, TaskList({*it}), result.run_level, used);
+                used.insert(optional_result.used.begin(), optional_result.used.end());
+                if (optional_result.run_level != RunLevel::OK) {
                     // If we can't run this optional task, remove it in case we were previously running it
                     auto original = std::find_if(group.subtasks.begin(), group.subtasks.end(), [&](const auto& t) {
                         return t->type == (*it)->type;

--- a/module/extension/Director/tests/self_intersection.cpp
+++ b/module/extension/Director/tests/self_intersection.cpp
@@ -1,0 +1,141 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2022 NUbots <nubots@nubots.net>
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <fmt/format.h>
+#include <nuclear>
+
+#include "Director.hpp"
+#include "TestBase.hpp"
+#include "util/diff_string.hpp"
+
+// Anonymous namespace to avoid name collisions
+namespace {
+
+    struct MainTask {};
+
+    template <int I>
+    struct SubTask {
+        SubTask() : subtask_id(I) {}
+        int subtask_id;
+    };
+
+    struct Dependency {
+        Dependency(const int& subtask_id_) : subtask_id(subtask_id_) {}
+        int subtask_id;
+    };
+
+    std::vector<std::string> events;
+
+    class TestReactor : public TestBase<TestReactor> {
+    public:
+        explicit TestReactor(std::unique_ptr<NUClear::Environment> environment)
+            : TestBase<TestReactor>(std::move(environment)) {
+
+            on<Provide<MainTask>>().then([this] {
+                // Emit optional tasks with one blocking the other
+                events.push_back("emitting task 1");
+                emit<Task>(std::make_unique<SubTask<1>>(), 0, true);
+                events.push_back("emitting task 2");
+                emit<Task>(std::make_unique<SubTask<2>>(), 0, true);
+            });
+
+            on<Provide<SubTask<1>>, Needs<Dependency>>().then([this](const SubTask<1>& t) {
+                events.push_back(fmt::format("subtask {} executed", t.subtask_id));
+
+                // Emit the dependency task
+                events.push_back(fmt::format("emitting dependency from subtask {}", t.subtask_id));
+                emit<Task>(std::make_unique<Dependency>(t.subtask_id));
+            });
+
+            on<Provide<SubTask<2>>, Needs<Dependency>>().then([this](const SubTask<2>& t) {
+                events.push_back(fmt::format("subtask {} executed", t.subtask_id));
+
+                // Emit the dependency task
+                events.push_back(fmt::format("emitting dependency from subtask {}", t.subtask_id));
+                emit<Task>(std::make_unique<Dependency>(t.subtask_id));
+            });
+
+            on<Provide<Dependency>>().then([this](const Dependency& t) {
+                events.push_back(fmt::format("dependency from subtask {}", t.subtask_id));
+            });
+
+            /**************
+             * TEST STEPS *
+             **************/
+            on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+                events.push_back("emitting main task");
+                emit<Task>(std::make_unique<MainTask>());
+            });
+            on<Trigger<Step<2>>, Priority::LOW>().then([this] {
+                events.push_back("removing main task");
+                emit<Task>(std::unique_ptr<MainTask>());
+            });
+            on<Trigger<Step<3>>, Priority::LOW>().then([this] {
+                events.push_back("emitting main task");
+                emit<Task>(std::make_unique<MainTask>());
+            });
+            on<Trigger<Step<4>>, Priority::LOW>().then([this] {
+                events.push_back("removing main task");
+                emit<Task>(std::unique_ptr<MainTask>());
+            });
+            on<Startup>().then([this] {
+                emit(std::make_unique<Step<1>>());
+                emit(std::make_unique<Step<2>>());
+                emit(std::make_unique<Step<3>>());
+                emit(std::make_unique<Step<4>>());
+            });
+        }
+    };
+
+}  // namespace
+
+TEST_CASE("Test that when a task has self intersection it applies priority correctly",
+          "[director][priority][optional][self_intersection]") {
+    // Run the module
+    NUClear::PowerPlant::Configuration config;
+    config.thread_count = 1;
+    NUClear::PowerPlant powerplant(config);
+    powerplant.install<module::extension::Director>();
+    powerplant.install<TestReactor>();
+    powerplant.start();
+
+    std::vector<std::string> expected = {
+        "emitting main task",
+        "emitting task 1",
+        "emitting task 2",
+        "subtask 1 executed",
+        "emitting dependency from subtask 1",
+        "dependency from subtask 1",
+        "removing main task",
+        "emitting main task",
+        "emitting task 1",
+        "emitting task 2",
+        "subtask 1 executed",
+        "emitting dependency from subtask 1",
+        "dependency from subtask 1",
+        "removing main task",
+    };
+
+    // Make an info print the diff in an easy to read way if we fail
+    INFO(util::diff_string(expected, events));
+
+    // Check the events fired in order and only those events
+    REQUIRE(events == expected);
+}

--- a/module/extension/Director/tests/self_intersection.cpp
+++ b/module/extension/Director/tests/self_intersection.cpp
@@ -85,7 +85,7 @@ namespace {
             });
             on<Trigger<Step<2>>, Priority::LOW>().then([this] {
                 events.push_back("removing main task");
-                emit<Task>(std::unique_ptr<MainTask>());
+                emit<Task>(std::unique_ptr<MainTask>(nullptr));
             });
             on<Trigger<Step<3>>, Priority::LOW>().then([this] {
                 events.push_back("emitting main task");
@@ -93,7 +93,7 @@ namespace {
             });
             on<Trigger<Step<4>>, Priority::LOW>().then([this] {
                 events.push_back("removing main task");
-                emit<Task>(std::unique_ptr<MainTask>());
+                emit<Task>(std::unique_ptr<MainTask>(nullptr));
             });
             on<Startup>().then([this] {
                 emit(std::make_unique<Step<1>>());


### PR DESCRIPTION
Adds a unit test for Director self-intersection and provides a fix.

When a single Provider intersected with itself before with optional tasks, all of them would run even though they shouldn't.

E.g. if two optional tasks A and B were both emitted that needed C they would both run even though they intersected with each other.

This test was pulled out from #1108 as the way that test was written relies on this behaviour being correct