### PR TITLE
Tune Sarah's camera horizon

### DIFF
--- a/module/input/Camera/data/config/nugus3/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus3/Cameras/Left.yaml
@@ -1,4 +1,4 @@
-serial_number: 0115138C
+serial_number: 011885A9
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -15,16 +15,16 @@ lens:
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.3485051149492453
+  focal_length: 0.34690945742400775
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [0.024648748488062908, 0.003206197425052844]
+  centre: [0.02072339174622414, -0.0011612242293956145]
   # The polynomial distortion coefficients for the lens
-  k: [0.35593577408411464, 0.12711003594280923]
+  k: [0.38553542593448015, 0.1498415334589703]
   # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
   # The homogenous transform from the rigid platform this camera is attached to to its optical location
   Hpc:
     - [0.9997403694613228, -0.016551656784825577, -0.01566002262642871, 0.08893612063588988]
-    - [0.01728764296000275, 0.9986932814319833, 0.04809227613146373, 0.03529909622045881]
+    - [0.01728764296000275, 0.9986932814319833, 0.04809227613146373, -0.03529909622045881]
     - [0.014843552535558163, -0.04835051478781678, 0.9987201292902445, 0.0713674563254241]
     - [0.0, 0.0, 0.0, 1.0]

--- a/module/platform/OpenCR/HardwareIO/data/config/nugus3/HardwareIO.yaml
+++ b/module/platform/OpenCR/HardwareIO/data/config/nugus3/HardwareIO.yaml
@@ -92,5 +92,5 @@ servos:
     simulated: false
   - # [19] HEAD_PITCH
     direction: 1
-    offset: 0.17
+    offset: 0.0
     simulated: false


### PR DESCRIPTION
HardwareIO pitch offset was causing problems with the horizon, so it is gone
Moved around the camera since the nucs changed
horizon line looked okay and field lines looked alright.