### PR TITLE
Walk bug fixes and tuning

### DIFF
--- a/module/planning/PlanWalkPath/data/config/PlanWalkPath.yaml
+++ b/module/planning/PlanWalkPath/data/config/PlanWalkPath.yaml
@@ -2,11 +2,11 @@
 log_level: INFO
 
 # General playing tuning values for approaching ball
-max_translational_velocity_magnitude: 0.1
-min_translational_velocity_magnitude: 0.1
-max_angular_velocity: 0.1
-min_angular_velocity: -0.1
-acceleration: 0.005 # maximum increment in walk command velocity
+max_translational_velocity_magnitude: 0.15
+min_translational_velocity_magnitude: 0.05
+max_angular_velocity: 0.25
+min_angular_velocity: -0.25
+acceleration: 0.004 # maximum increment in walk command velocity
 approach_radius: 0.75 # region around ball to begin decelerating
 
 # Rotate on the spot tuning values

--- a/module/skill/Walk/data/config/Walk.yaml
+++ b/module/skill/Walk/data/config/Walk.yaml
@@ -16,7 +16,7 @@ walk:
     # Torso height (in meters)
     height: 0.46
     # Torso pitch (in radians)
-    pitch: 23 * pi / 180
+    pitch: 22 * pi / 180
     # Torso constant position offset
     position_offset: [0.05, 0, 0]
     # Torso offset from the planted foot [x,y,z] (in meters), at time = torso_sway_ratio*step_period

--- a/module/skill/Walk/data/config/Walk.yaml
+++ b/module/skill/Walk/data/config/Walk.yaml
@@ -16,7 +16,7 @@ walk:
     # Torso height (in meters)
     height: 0.46
     # Torso pitch (in radians)
-    pitch: 22 * pi / 180
+    pitch: 23 * pi / 180
     # Torso constant position offset
     position_offset: [0.05, 0, 0]
     # Torso offset from the planted foot [x,y,z] (in meters), at time = torso_sway_ratio*step_period

--- a/module/skill/Walk/data/config/nugus4/Walk.yaml
+++ b/module/skill/Walk/data/config/nugus4/Walk.yaml
@@ -1,0 +1,41 @@
+log_level: INFO
+
+walk:
+  # Time for one complete step (in seconds).
+  period: 0.39
+  step:
+    # Maximum step limits in x and y (in meters), and theta (in radians).
+    limits: [0.5, 0.2, 0.4]
+    # Step height (in meters)
+    height: 0.075
+    # Lateral distance in meters between feet (how spread apart the feet should be)
+    width: 0.235
+    # Ratio of the step_period where the foot should be at its highest point, between [0 1].
+    apex_ratio: 0.4
+  torso:
+    # Torso height (in meters)
+    height: 0.46
+    # Torso pitch (in radians)
+    pitch: 20 * pi / 180
+    # Torso constant position offset
+    position_offset: [0.05, 0, 0]
+    # Torso offset from the planted foot [x,y,z] (in meters), at time = torso_sway_ratio*step_period
+    sway_offset: [0, 0.05, 0]
+    # Ratio of the step_period where the torso should be at its maximum sway, between [0 1]
+    sway_ratio: 0.5
+    # Determines where to position the torso at the end of the step using a ratio of the next step placement.
+    # For example, a value of [0.5, 0.5, 1] would position the torso halfway between the planted and swing foot and with
+    # torso yaw rotation equal to swing foot yaw
+    final_position_ratio: [0.5, 0.5, 1]
+
+gains:
+  arms: 8
+
+# Fixed position of the arm joints during walking
+arms:
+  right_shoulder_pitch: 1.7
+  left_shoulder_pitch: 1.7
+  right_shoulder_roll: -0.4
+  left_shoulder_roll: 0.35
+  right_elbow: -0.7
+  left_elbow: -0.7

--- a/roles/test/behaviour.role
+++ b/roles/test/behaviour.role
@@ -1,0 +1,53 @@
+nuclear_role(
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher
+  support::SignalCatcher
+  support::logging::ConsoleLogHandler
+  # Config
+  support::configuration::SoccerConfig
+  actuation::KinematicsConfiguration
+  support::configuration::GlobalConfig
+  # Sensors
+  platform::${SUBCONTROLLER}::HardwareIO
+  input::SensorFilter
+  input::Camera
+  input::GameController
+  # Vision
+  vision::VisualMesh
+  vision::GreenHorizonDetector
+  vision::BallDetector
+  vision::FieldLineDetector
+  # Localisation
+  localisation::FieldLocalisation
+  localisation::BallLocalisation
+  # Director
+  extension::Director
+  # Servos
+  actuation::Kinematics
+  actuation::Servos
+  actuation::FootController
+  # Skills
+  skill::Walk
+  skill::SplineKick
+  skill::GetUp
+  skill::Look
+  skill::Dive
+  # Planners
+  planning::PlanWalkPath
+  planning::PlanLook
+  planning::PlanKick
+  planning::GetUpPlanner
+  planning::FallingRelaxPlanner
+  # Strategies
+  strategy::FallRecovery
+  strategy::StandStill
+  strategy::WalkToFieldPosition
+  strategy::StrategiseLook
+  strategy::WalkToBall
+  strategy::FindObject
+  strategy::KickToGoal
+  strategy::AlignBallToGoal
+  strategy::DiveToBall
+  # Purposes
+  purpose::Tester
+)

--- a/shared/utility/skill/WalkGenerator.hpp
+++ b/shared/utility/skill/WalkGenerator.hpp
@@ -156,6 +156,9 @@ namespace utility::skill {
             // Start time at end of step period to avoid taking a step when starting.
             t = step_period;
 
+            // Generate trajectories for swing foot and torso with zero velocity target
+            generate_walking_trajectories(Eigen::Matrix<Scalar, 3, 1>::Zero());
+
             // Set engine state to stopped
             engine_state = WalkState::State::STOPPED;
         }

--- a/shared/utility/skill/WalkGenerator.hpp
+++ b/shared/utility/skill/WalkGenerator.hpp
@@ -275,17 +275,17 @@ namespace utility::skill {
         /// @brief 6D piecewise polynomial trajectory for torso.
         Trajectory<Scalar> torso_trajectory{};
 
-        /// @brief Get the lateral distance between feet in current planted foot frame.
-        /// @return Lateral distance between feet.
+        /**
+         * @brief Get the lateral distance between feet in current planted foot frame.
+         * @return Lateral distance between feet.
+         */
         Scalar get_foot_width_offset() const {
             return left_foot_is_planted ? -step_width : step_width;
         }
 
         /**
-         * @brief Generate swing foot trajectory.
+         * @brief Generate walking trajectories for the torso and swing foot.
          * @param velocity_target Requested velocity target (dx, dy, dtheta).
-         * @param Hps_end Next foot placement.
-         * @return Trajectory of swing foot to follow to reach next foot placement.
          */
         void generate_walking_trajectories(const Eigen::Matrix<Scalar, 3, 1>& velocity_target) {
             // Compute the next step placement in the planted foot frame based on the requested velocity target
@@ -294,7 +294,7 @@ namespace utility::skill {
             step.y() = std::max(std::min(velocity_target.y() * step_period, step_limits.y()), -step_limits.y());
             step.z() = std::max(std::min(velocity_target.z() * step_period, step_limits.z()), -step_limits.z());
 
-            // Stores the waypoints for the torso and swing foot trajectories
+            // Create a waypoint variable to use for all waypoints
             Waypoint<Scalar> waypoint;
 
             // ******************************** Swing Foot Trajectory ********************************
@@ -314,7 +314,7 @@ namespace utility::skill {
             waypoint.velocity   = Eigen::Matrix<Scalar, 3, 1>(velocity_target.x(), velocity_target.y(), 0);
             waypoint.orientation =
                 Eigen::Matrix<Scalar, 3, 1>(0.0, 0.0, velocity_target.z() * step_apex_ratio * step_period);
-            waypoint.angular_velocity.z() = velocity_target.z();
+            waypoint.angular_velocity = Eigen::Matrix<Scalar, 3, 1>(0.0, 0.0, velocity_target.z());
             swingfoot_trajectory.add_waypoint(waypoint);
 
             // End waypoint: End at next foot placement on ground at time = step_period
@@ -345,7 +345,7 @@ namespace utility::skill {
             waypoint.velocity = Eigen::Matrix<Scalar, 3, 1>(velocity_target.x(), velocity_target.y(), 0);
             waypoint.orientation =
                 Eigen::Matrix<Scalar, 3, 1>(0.0, torso_pitch, velocity_target.z() * torso_sway_ratio * step_period);
-            waypoint.angular_velocity.z() = velocity_target.z();
+            waypoint.angular_velocity = Eigen::Matrix<Scalar, 3, 1>(0.0, 0.0, velocity_target.z());
             torso_trajectory.add_waypoint(waypoint);
 
             // End waypoint: Shift torso back to the final torso position at time = step_period


### PR DESCRIPTION
This PR does the following:

- Fixes a bug with the `WalkGenerator` introduced when switching to the use of `Waypoint`. The z translational velocity of the swing foot and torso middle waypoint  was being set to `velocity_target.z()` when it is actually the angular yaw velocity.
- Simplifies generating trajectories slightly by merging three functions into a single one as they are only used once
- Slightly tunes billie walk params by adjusting pitch
- Tunes walk path planner (for walking to ball)