### PR TITLE
Remove Right camera in visualmesh config

### DIFF
--- a/module/vision/VisualMesh/data/config/nugus/VisualMesh.yaml
+++ b/module/vision/VisualMesh/data/config/nugus/VisualMesh.yaml
@@ -17,12 +17,3 @@ cameras:
       height: [0.5, 1.0]
       max_distance: 15
       intersection_tolerance: 0.25
-  Right:
-    concurrent: 1
-    network: config/networks/LabNetwork.yaml
-    engine: opencl
-    cache_directory: "./vision_cache/"
-    classifier:
-      height: [0.5, 1.0]
-      max_distance: 15
-      intersection_tolerance: 0.25


### PR DESCRIPTION
We are only running the left camera because the usbs are on the same bus, preventing us running two (lags too much). 
So this removes the right camera from the visual mesh config. 