### PR TITLE
Add buzzer functionality for the OpenCR board

### DIFF
--- a/module/platform/OpenCR/HardwareIO/data/config/HardwareIO.yaml
+++ b/module/platform/OpenCR/HardwareIO/data/config/HardwareIO.yaml
@@ -94,3 +94,9 @@ servos:
     direction: 1
     offset: 0.0
     simulated: false
+
+servo:
+  temp_tol: 60.0
+
+buzzer:
+  freq: 880

--- a/module/platform/OpenCR/HardwareIO/data/config/nugus1/HardwareIO.yaml
+++ b/module/platform/OpenCR/HardwareIO/data/config/nugus1/HardwareIO.yaml
@@ -94,3 +94,9 @@ servos:
     direction: 1
     offset: -9 * pi / 180
     simulated: false
+
+servo:
+  temp_tol: 60.0
+
+buzzer:
+  freq: 880

--- a/module/platform/OpenCR/HardwareIO/data/config/nugus2/HardwareIO.yaml
+++ b/module/platform/OpenCR/HardwareIO/data/config/nugus2/HardwareIO.yaml
@@ -94,3 +94,9 @@ servos:
     direction: 1
     offset: 0.0
     simulated: false
+
+servo:
+  temp_tol: 60.0
+
+buzzer:
+  freq: 880

--- a/module/platform/OpenCR/HardwareIO/data/config/nugus3/HardwareIO.yaml
+++ b/module/platform/OpenCR/HardwareIO/data/config/nugus3/HardwareIO.yaml
@@ -94,3 +94,9 @@ servos:
     direction: 1
     offset: 0.0
     simulated: false
+
+servo:
+  temp_tol: 60.0
+
+buzzer:
+  freq: 880

--- a/module/platform/OpenCR/HardwareIO/data/config/nugus4/HardwareIO.yaml
+++ b/module/platform/OpenCR/HardwareIO/data/config/nugus4/HardwareIO.yaml
@@ -94,3 +94,9 @@ servos:
     direction: 1
     offset: 0.17
     simulated: false
+
+servo:
+  temp_tol: 60.0
+
+buzzer:
+  freq: 880

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -1,7 +1,7 @@
 #include "HardwareIO.hpp"
 
 #include <fmt/format.h>
-
+#include "message/output/Buzzer.hpp"
 #include "Convert.hpp"
 #include "dynamixel/v2/Dynamixel.hpp"
 
@@ -23,6 +23,8 @@ namespace module::platform::OpenCR {
     using utility::support::Expression;
 
     using message::platform::ButtonMiddleDown;
+
+    using message::output::Buzzer;
 
     HardwareIO::HardwareIO(std::unique_ptr<NUClear::Environment> environment)
         : Reactor(std::move(environment)), opencr(), nugus(), byte_wait(0), packet_wait(0), packet_queue() {
@@ -105,6 +107,9 @@ namespace module::platform::OpenCR {
                 nugus.servo_direction[i]  = config["servos"][i]["direction"].as<Expression>();
                 servo_states[i].simulated = config["servos"][i]["simulated"].as<bool>();
             }
+
+            cfg.max_tol_temp = config["servo"]["temp_tol"].as<float>();
+            cfg.buzzer_freq = config["buzzer"]["freq"].as<float>();
         });
 
         on<Startup>().then("HardwareIO Startup", [this] {
@@ -287,6 +292,12 @@ namespace module::platform::OpenCR {
             opencr_state.led_panel.led4 = led.led4;
             opencr_state.dirty          = true;
         });
+
+        on<Trigger<Buzzer>>().then([this]() {
+            // Fill the necessary field within the opencr_state struct
+            opencr_state.buzzer = cfg.buzzer_freq;
+        });
+
     }
 
 }  // namespace module::platform::OpenCR

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
@@ -223,6 +223,17 @@ namespace module::platform::OpenCR {
 
         /// @brief Handle for our watchdog timer for packet handling
         ReactionHandle packet_watchdog;
+
+        /// @brief Stores configuration values
+        struct Config {
+
+            /// @brief Container for the max tolerable temp for all servos
+            float max_tol_temp = 0.0;
+
+            /// @brief Container for the buzzer frequency, used if a Buzzer message is emitted
+            float buzzer_freq = 0.0;
+
+        } cfg;
     };
 
 }  // namespace module::platform::OpenCR

--- a/module/platform/OpenCR/HardwareIO/src/NUgus.hpp
+++ b/module/platform/OpenCR/HardwareIO/src/NUgus.hpp
@@ -167,7 +167,7 @@ namespace module::platform::OpenCR {
     struct OpenCRWriteData {
         uint8_t led;
         uint16_t rgb_led;
-        uint8_t buzzer;
+        uint16_t buzzer;
     } __attribute__((packed));
 
     /// @brief The data to read from the OpenCR device

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
@@ -130,19 +130,12 @@ namespace module::platform::OpenCR {
         servo_states[servo_index].voltage     = convert::voltage(data.present_voltage);
         servo_states[servo_index].temperature = convert::temperature(data.present_temperature);
 
-        // If any servo exceeds the tolerable temperature in the config we emit a buzzer message
-        // so we know that we might be about to burn a servo
-        // const bool any_servo_hot = std::any_of(
-        //         servo_states.cbegin(),
-        //         servo_states.cend(),
-        //         [](const ServoState& servo) -> bool { return ;});
         for(const auto& servo : servo_states ) {
             if (servo.temperature > cfg.max_tol_temp){
                 emit(std::make_unique<Buzzer>());
                 break;
             }
         }
-
 
         // If this servo has not been initialised yet, set the goal states to the current states
         if (!servo_states[servo_index].initialised) {

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/send_request.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/send_request.cpp
@@ -88,7 +88,18 @@ namespace module::platform::OpenCR {
             data.rgb_led = (uint8_t(0x000000FF & opencr_state.head_led.RGB) & 0x1F) << 10;         // R
             data.rgb_led |= ((uint8_t(0x0000FF00 & opencr_state.head_led.RGB) >> 8) & 0x1F) << 5;  // G
             data.rgb_led |= (uint8_t(0x00FF0000 & opencr_state.head_led.RGB) >> 16) & 0x1F;        // B
-            data.buzzer = opencr_state.buzzer;
+
+            // Rewrite this in a cleaner way
+            // Run through all of the servo states and if even one motor is above the temeperature
+            // threshold, fill the buzzer field
+            data.buzzer = std::any_of(
+                servo_states.begin(),
+                servo_states.cend(),
+                [](const ServoState& servo) -> bool { return servo.temperature > 70.0; }
+            ) ? 880u : 0u;
+
+            // This line serves as a naive test
+            data.buzzer = 880u;
 
             // Write our data
             opencr.write(dynamixel::v2::WriteCommand<OpenCRWriteData>(uint8_t(NUgus::ID::OPENCR),

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/send_request.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/send_request.cpp
@@ -88,18 +88,7 @@ namespace module::platform::OpenCR {
             data.rgb_led = (uint8_t(0x000000FF & opencr_state.head_led.RGB) & 0x1F) << 10;         // R
             data.rgb_led |= ((uint8_t(0x0000FF00 & opencr_state.head_led.RGB) >> 8) & 0x1F) << 5;  // G
             data.rgb_led |= (uint8_t(0x00FF0000 & opencr_state.head_led.RGB) >> 16) & 0x1F;        // B
-
-            // Rewrite this in a cleaner way
-            // Run through all of the servo states and if even one motor is above the temeperature
-            // threshold, fill the buzzer field
-            data.buzzer = std::any_of(
-                servo_states.begin(),
-                servo_states.cend(),
-                [](const ServoState& servo) -> bool { return servo.temperature > 70.0; }
-            ) ? 880u : 0u;
-
-            // This line serves as a naive test
-            data.buzzer = 880u;
+            data.buzzer = opencr_state.buzzer;
 
             // Write our data
             opencr.write(dynamixel::v2::WriteCommand<OpenCRWriteData>(uint8_t(NUgus::ID::OPENCR),

--- a/shared/message/output/Buzzer.proto
+++ b/shared/message/output/Buzzer.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package message.output;
+
+message Buzzer {
+}


### PR DESCRIPTION
This pull request aims to add a functionality for the OpenCR's buzzer. It cycles through all the servo motors and if it finds one servo that has a temperature that is above the configurable value, it writes the frequency value to the board and plays the sound of the buzzer.


Currently, a frequency of 0 is written to the board's buzzer but the functionality for the firmware  is already implemented in the firmware