### PR TITLE
Ball Detector Tuning Robocup2023

### DIFF
--- a/module/vision/BallDetector/data/config/BallDetector.yaml
+++ b/module/vision/BallDetector/data/config/BallDetector.yaml
@@ -1,11 +1,11 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-confidence_threshold: 0.7 # Minimum confidence required for a ball point to be a ball point
+confidence_threshold: 0.67 # Minimum confidence required for a ball point to be a ball point
 cluster_points: 3 # Minimum number of points for a cluster to be a viable ball
 minimum_ball_distance: 0.20 # Minimum distance for a cluster to be a viable ball
 distance_disagreement:
-  0.30 # Percentage difference between width and projection based distances. 0.0 means
+  0.78 # Percentage difference between width and projection based distances. 0.0 means
   # the distance measurements must match perfectly
 maximum_deviation:
   0.17 # A threshold on how large the standard deviation of the angle between ray and


### PR DESCRIPTION
Tuning for ball detector for Robocup2023.
Slightly reduces confidence threshold and increases distance disagreement substantially.