### PR TITLE
Set ccache directory to the build directory so it is saved

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -373,4 +373,7 @@ RUN install -d -m 0755 /home/nubots/NUbots \
     && install -d -m 0777 /home/nubots/build \
     && install -d -m 0777 /home/nubots/NUbots/nusight2/node_modules
 
+# Configure the cache directories
+ENV CCACHE_DIR /home/nubots/build/ccache
+
 WORKDIR /home/nubots/NUbots


### PR DESCRIPTION
Changes the ccache directory to the build directory so it persists between docker containers