### PR TITLE
Correct the visual mesh triangle index to correct for the new neighbour order

### DIFF
--- a/nusight2/src/client/components/vision/vision_camera/visual_mesh.ts
+++ b/nusight2/src/client/components/vision/vision_camera/visual_mesh.ts
@@ -44,13 +44,14 @@ export class VisualMeshViewModel {
     const triangles = [];
     for (let i = 0; i < nElem; i++) {
       const ni = i * 6;
-      if (neighbours[ni + 0] < nElem) {
-        if (neighbours[ni + 2] < nElem) {
-          triangles.push(i, neighbours[ni + 0], neighbours[ni + 2]);
-        }
-        if (neighbours[ni + 1] < nElem) {
-          triangles.push(i, neighbours[ni + 1], neighbours[ni + 0]);
-        }
+
+      if(neighbours[ni + 0] < nElem && neighbours[ni + 1] < nElem) {
+        triangles.push(i, neighbours[ni + 0], neighbours[ni + 1]);
+        triangles.push(i, neighbours[ni + 1], neighbours[ni + 0])
+      }
+      if(neighbours[ni + 1] < nElem && neighbours[ni + 2] < nElem) {
+        triangles.push(i, neighbours[ni + 1], neighbours[ni + 2]);
+        triangles.push(i, neighbours[ni + 2], neighbours[ni + 1])
       }
     }
     const buffer = new THREE.InterleavedBuffer(


### PR DESCRIPTION
When the visual mesh was upgraded to a new version a while ago the order of neighbours changed.
Previously the order was

```
  1  2
   \/
3 ---- 4
   /\
  5  6
```

The new order of indexes is like this
```
  2  3
   \/
1 ---- 4
   /\
  6  5
```

This PR fixes the triangle indexes so it correctly shows the visual mesh as a coloured mesh again

Before
![image](https://github.com/NUbots/NUbots/assets/957962/ae098078-30fc-4104-b4b9-2aef776b9169)
After
![image](https://github.com/NUbots/NUbots/assets/957962/8e044c79-fc1d-437e-a8e5-0ef36a7ddc2d)
