### PR TITLE
Add robot mesh detections to NUsight visual mesh display

### DIFF
--- a/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.frag
+++ b/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.frag
@@ -12,12 +12,12 @@ varying float vEnvironment;
 
 void main() {
 
-    vec3 colour = vBall * vec3(1.0, 0.0, 0.0)           // Red
-                  + vGoal * vec3(1.0, 1.0, 0.0)         // Yellow
-                  + vFieldLine * vec3(0.2, 0.2, 1.0)    // Light Blue
-                  + vField * vec3(0.0, 1.0, 0.0)        // Green
-                  + vRobot * vec3(1.0, 0.0, 1.0)        // Magenta
-                  + vEnvironment * vec3(0.0, 0.0, 0.0); // Black
+    vec3 colour = vBall * vec3(1.0, 0.0, 0.0)            // Red
+                  + vGoal * vec3(1.0, 1.0, 0.0)          // Yellow
+                  + vFieldLine * vec3(0.2, 0.2, 1.0)     // Light Blue
+                  + vField * vec3(0.0, 1.0, 0.0)         // Green
+                  + vRobot * vec3(1.0, 0.0, 1.0)         // Magenta
+                  + vEnvironment * vec3(0.0, 0.0, 0.0);  // Black
 
     gl_FragColor = vec4(colour, 0.5 * (1.0 - vEnvironment));
 }

--- a/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.frag
+++ b/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.frag
@@ -16,7 +16,7 @@ void main() {
                   + vGoal * vec3(1.0, 1.0, 0.0)         // Yellow
                   + vFieldLine * vec3(0.2, 0.2, 1.0)    // Light Blue
                   + vField * vec3(0.0, 1.0, 0.0)        // Green
-                  + vRobot * vec3(0.4, 0.0, 0.4)        // Dark Magenta
+                  + vRobot * vec3(1.0, 0.0, 1.0)        // Magenta
                   + vEnvironment * vec3(0.0, 0.0, 0.0); // Black
 
     gl_FragColor = vec4(colour, 0.5 * (1.0 - vEnvironment));

--- a/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.frag
+++ b/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.frag
@@ -7,15 +7,17 @@ varying float vBall;
 varying float vGoal;
 varying float vFieldLine;
 varying float vField;
+varying float vRobot;
 varying float vEnvironment;
 
 void main() {
 
-    vec3 colour = vBall * vec3(1.0, 0.0, 0.0)         //
-                  + vGoal * vec3(1.0, 1.0, 0.0)       //
-                  + vFieldLine * vec3(0.2, 0.2, 1.0)  //
-                  + vField * vec3(0.0, 1.0, 0.0)      //
-                  + vEnvironment * vec3(0.0, 0.0, 0.0);
+    vec3 colour = vBall * vec3(1.0, 0.0, 0.0)           // Red
+                  + vGoal * vec3(1.0, 1.0, 0.0)         // Yellow
+                  + vFieldLine * vec3(0.2, 0.2, 1.0)    // Light Blue
+                  + vField * vec3(0.0, 1.0, 0.0)        // Green
+                  + vRobot * vec3(0.4, 0.0, 0.4)        // Dark Magenta
+                  + vEnvironment * vec3(0.0, 0.0, 0.0); // Black
 
     gl_FragColor = vec4(colour, 0.5 * (1.0 - vEnvironment));
 }

--- a/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.vert
+++ b/nusight2/src/client/components/vision/vision_camera/shaders/visual_mesh.vert
@@ -17,12 +17,14 @@ attribute float ball;
 attribute float goal;
 attribute float field;
 attribute float fieldLine;
+attribute float robot;
 attribute float environment;
 
 varying float vBall;
 varying float vGoal;
 varying float vFieldLine;
 varying float vField;
+varying float vRobot;
 varying float vEnvironment;
 
 #include "../../../camera/objects/shaders/projection.glsl"
@@ -37,6 +39,7 @@ void main() {
     vBall        = ball;
     vGoal        = goal;
     vFieldLine   = fieldLine;
+    vRobot       = robot;
     vField       = field;
     vEnvironment = environment;
 

--- a/nusight2/src/client/components/vision/vision_camera/visual_mesh.ts
+++ b/nusight2/src/client/components/vision/vision_camera/visual_mesh.ts
@@ -67,7 +67,8 @@ export class VisualMeshViewModel {
         { name: "goal", buffer: new THREE.InterleavedBufferAttribute(buffer, 1, 1) },
         { name: "fieldLine", buffer: new THREE.InterleavedBufferAttribute(buffer, 1, 2) },
         { name: "field", buffer: new THREE.InterleavedBufferAttribute(buffer, 1, 3) },
-        { name: "environment", buffer: new THREE.InterleavedBufferAttribute(buffer, 1, 4) },
+        { name: "robot", buffer: new THREE.InterleavedBufferAttribute(buffer, 1, 4) },
+        { name: "environment", buffer: new THREE.InterleavedBufferAttribute(buffer, 1, 5) },
       ],
     };
   });

--- a/nusight2/src/client/components/visual_mesh/camera/shaders/mesh.vert
+++ b/nusight2/src/client/components/visual_mesh/camera/shaders/mesh.vert
@@ -9,6 +9,7 @@ attribute float ball;
 attribute float goal;
 attribute float field;
 attribute float fieldLine;
+attribute float robot;
 attribute float environment;
 attribute vec2 uv;
 
@@ -30,6 +31,7 @@ void main() {
     vGoal        = goal;
     vFieldLine   = fieldLine;
     vField       = field;
+    vRobot   = robot;
     vEnvironment = environment;
 
     // Calculate our position in the mesh

--- a/nusight2/src/client/components/visual_mesh/camera/shaders/mesh.vert
+++ b/nusight2/src/client/components/visual_mesh/camera/shaders/mesh.vert
@@ -31,7 +31,7 @@ void main() {
     vGoal        = goal;
     vFieldLine   = fieldLine;
     vField       = field;
-    vRobot   = robot;
+    vRobot       = robot;
     vEnvironment = environment;
 
     // Calculate our position in the mesh

--- a/nusight2/src/client/components/visual_mesh/camera/view_model.ts
+++ b/nusight2/src/client/components/visual_mesh/camera/view_model.ts
@@ -164,7 +164,8 @@ export class CameraViewModel {
       geometry.addAttribute("goal", new InterleavedBufferAttribute(buffer, 1, 1));
       geometry.addAttribute("fieldLine", new InterleavedBufferAttribute(buffer, 1, 2));
       geometry.addAttribute("field", new InterleavedBufferAttribute(buffer, 1, 3));
-      geometry.addAttribute("environment", new InterleavedBufferAttribute(buffer, 1, 4));
+      geometry.addAttribute("robot", new InterleavedBufferAttribute(buffer, 1, 4));
+      geometry.addAttribute("environment", new InterleavedBufferAttribute(buffer, 1, 5));
 
       return geometry;
     },


### PR DESCRIPTION
The NUsight mesh colours are hardcoded with environment in the fourth position. Now that the network has an extra class, robots are the fourth index and environment is the fifth. This is consistent across the networks we have currently. 
NUsight has been displaying robots as black and ignoring environment (resulting in also black). 
This PR changes this so that robots appear in a different colour to the environment. 
Robots set to magenta.

![image](https://github.com/NUbots/NUbots/assets/35280100/87cfa8bc-fbc2-42e2-ab9b-a0587daccdee)
![image](https://github.com/NUbots/NUbots/assets/35280100/a099fe31-aaeb-45a4-a211-37d29eb4f0ec)
