### PR TITLE
Change webots image format from BGR3 to RGBA

### DIFF
--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -801,7 +801,7 @@ namespace module::platform {
             image->name           = camera.name;
             image->dimensions.x() = camera.width;
             image->dimensions.y() = camera.height;
-            image->format         = fourcc("BGR3");  // Change to "JPEG" when webots compression is implemented
+            image->format         = fourcc("RGBA");  // Change to "JPEG" when webots compression is implemented
             image->data           = camera.image;
 
             image->id        = camera_context[camera.name].id;


### PR DESCRIPTION
This PR changes webots image format from BGR3 to RGBA.

Requires https://github.com/NUbots/NUWebots/pull/103
