### PR TITLE
Add ability to specifiy initial orientation for Mahony/Kalman filter

### DIFF
--- a/module/input/SensorFilter/data/config/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/SensorFilter.yaml
@@ -66,8 +66,6 @@ kalman:
   Q: [1e-6, 1e-6, 1e-5, 1e-5]
   # Measurement model noise
   R: [0.000011025, 0.000011025, 0.0018284176, 0.0018284176]
-  # Mahony Filter initial deadreckoned position and height
-  initial_rTWw: [0, 0, 0.49]
 
 mahony:
   # Mahony "Proportional" Gain on error
@@ -76,11 +74,13 @@ mahony:
   Ki: 0.3
   # Mahony Filter initial bias
   bias: [0, 0, 0]
-  # Mahony Filter initial deadreckoned position and height
-  initial_rTWw: [0, 0, 0.49]
 
 # Tuning parameters to scale walk command to match actual achieved velocity for deckreckoning x, y, theta
 deadreckoning_scale: [1, 1, 0.6]
+
+# Kalman/Mahony filter initial pose
+initial_rTWw: [0, 0, 0.49]
+initial_rpy: [0, 0.3839, 0]
 
 # Specify which filtering method to use, either UKF, KF or MAHONY
 filtering_method: MAHONY

--- a/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
@@ -61,8 +61,6 @@ kalman:
   Q: [1e-6, 1e-6, 1e-5, 1e-5]
   # Measurement model noise
   R: [0.000011025, 0.000011025, 0.0018284176, 0.0018284176]
-  # Mahony Filter initial deadreckoned position and height
-  initial_rTWw: [0, 0, 0.49]
 
 mahony:
   # Mahony "Proportional" Gain on error
@@ -71,11 +69,13 @@ mahony:
   Ki: 0.3
   # Mahony Filter initial bias
   bias: [0, 0, 0]
-  # Mahony Filter initial deadreckoned position and height
-  initial_rTWw: [0, 0, 0.49]
 
 # Tuning parameters to scale walk command to match actual achieved velocity for deckreckoning x, y, theta
 deadreckoning_scale: [1, 1, 0.6]
+
+# Kalman/Mahony filter initial pose
+initial_rTWw: [0, 0, 0.49]
+initial_rpy: [0, 0.3839, 0]
 
 # Specify which filtering method to use, either UKF, KF, MAHONY or GROUND_TRUTH
 filtering_method: MAHONY

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -20,6 +20,7 @@
 #include "SensorFilter.hpp"
 
 #include "message/actuation/BodySide.hpp"
+#include "message/localisation/Field.hpp"
 
 #include "utility/input/ServoID.hpp"
 #include "utility/math/euler.hpp"
@@ -36,6 +37,7 @@ namespace module::input {
 
     using message::behaviour::state::Stability;
     using message::behaviour::state::WalkState;
+    using message::localisation::ResetFieldLocalisation;
 
     using extension::Configuration;
 
@@ -143,6 +145,13 @@ namespace module::input {
                           emit(std::move(sensors));
                       })
                 .disable();
+
+        on<Trigger<ResetFieldLocalisation>>().then([this] {
+            // Reset the translation and yaw of odometry
+            Hwt.translation().x() = 0;
+            Hwt.translation().y() = 0;
+            yaw                   = 0;
+        });
     }
 
     void SensorFilter::integrate_walkcommand(const double dt, const Stability& stability, const WalkState& walk_state) {

--- a/module/input/SensorFilter/src/sensorfilter/KalmanFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/KalmanFilter.cpp
@@ -49,7 +49,8 @@ namespace module::input {
         // Initialise the Kalman filter
         kf.update(cfg.Ac, cfg.Bc, cfg.C, cfg.Q, cfg.R);
         kf.reset(Eigen::VectorXd::Zero(n_states), Eigen::MatrixXd::Identity(n_states, n_states));
-        Hwt.translation() = Eigen::VectorXd(config["kalman"]["initial_rTWw"].as<Expression>());
+        Hwt.translation() = Eigen::VectorXd(config["initial_rTWw"].as<Expression>());
+        Hwt.linear()      = EulerIntrinsicToMatrix(Eigen::Vector3d(config["initial_rpy"].as<Expression>()));
         update_loop.enable();
     }
 

--- a/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
@@ -46,7 +46,8 @@ namespace module::input {
         cfg.Ki            = config["mahony"]["Ki"].as<Expression>();
         cfg.Kp            = config["mahony"]["Kp"].as<Expression>();
         cfg.bias          = Eigen::Vector3d(config["mahony"]["bias"].as<Expression>());
-        Hwt.translation() = Eigen::VectorXd(config["mahony"]["initial_rTWw"].as<Expression>());
+        Hwt.translation() = Eigen::VectorXd(config["initial_rTWw"].as<Expression>());
+        Hwt.linear()      = EulerIntrinsicToMatrix(Eigen::Vector3d(config["initial_rpy"].as<Expression>()));
     }
 
     void SensorFilter::update_odometry_mahony(std::unique_ptr<Sensors>& sensors,


### PR DESCRIPTION
This PR does the following:

- Adds ability to specifiy initial orientation for Mahony/Kalman filter
- Resets the dead-reckoned position of the robot on ResetFieldLocalisation