### PR TITLE
Update plan look search positions

### DIFF
--- a/module/planning/PlanLook/data/config/PlanLook.yaml
+++ b/module/planning/PlanLook/data/config/PlanLook.yaml
@@ -2,19 +2,10 @@
 log_level: INFO
 
 # Time lingering at each position in search (seconds)
-search_fixation_time: 0.5
+search_fixation_time: 1.1
 
 # List of positions for search
 min_yaw: &min_yaw -0.7
 max_yaw: &max_yaw 0.7
-min_pitch: &min_pitch 0.63 # note that the pitch servo rotates down for positive
-max_pitch: &max_pitch 0.0
-search_positions:
-  [
-    [*min_yaw, *min_pitch],
-    [0, *min_pitch],
-    [*max_yaw, *min_pitch],
-    [*max_yaw, *max_pitch],
-    [0, *max_pitch],
-    [*min_yaw, *max_pitch],
-  ]
+pitch: &pitch 0.2 # note that the pitch servo rotates down for positive
+search_positions: [[*min_yaw, *pitch], [0, *pitch], [*max_yaw, *pitch], [0, *pitch]]

--- a/module/planning/PlanLook/data/config/webots/PlanLook.yaml
+++ b/module/planning/PlanLook/data/config/webots/PlanLook.yaml
@@ -1,0 +1,20 @@
+# Controls the minimum log level that NUClear log will display
+log_level: INFO
+
+# Time lingering at each position in search (seconds)
+search_fixation_time: 0.5
+
+# List of positions for search
+min_yaw: &min_yaw -0.7
+max_yaw: &max_yaw 0.7
+min_pitch: &min_pitch 0.63 # note that the pitch servo rotates down for positive
+max_pitch: &max_pitch 0.0
+search_positions:
+  [
+    [*min_yaw, *min_pitch],
+    [0, *min_pitch],
+    [*max_yaw, *min_pitch],
+    [*max_yaw, *max_pitch],
+    [0, *max_pitch],
+    [*min_yaw, *max_pitch],
+  ]


### PR DESCRIPTION
This PR adds the plan look search positions from competition which simply looks left and right due to larger FOV on real robot. 