### PR TITLE
Improve RawSensors error handling [HW-16]

### DIFF
--- a/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
@@ -26,9 +26,6 @@ namespace module::input {
     using utility::platform::getRawServo;
     using utility::platform::make_packet_error_string;
     using utility::platform::make_servo_hardware_error_string;
-    /* compatibility with v1 protocol only */
-    using utility::platform::make_error_string_v1;
-    using utility::platform::make_servo_error_string_v1;
 
     using message::platform::ButtonLeftDown;
     using message::platform::ButtonLeftUp;
@@ -42,16 +39,6 @@ namespace module::input {
         if (raw_sensors.subcontroller_error != RawSensors::PacketError::PACKET_OK) {
             NUClear::log<NUClear::WARN>(make_packet_error_string("Platform", raw_sensors.subcontroller_error));
         }
-        /* COMPATIBILITY WITH OLD PROTOCOL V1 STUFF */
-        if (raw_sensors.platform_error_flags != RawSensors::Error::OK_) {
-            NUClear::log<NUClear::WARN>(make_error_string_v1("Platform", raw_sensors.platform_error_flags));
-        }
-        if (raw_sensors.fsr.left.error_flags != RawSensors::Error::OK_) {
-            NUClear::log<NUClear::WARN>(make_error_string_v1("Left FSR", raw_sensors.fsr.left.error_flags));
-        }
-        if (raw_sensors.fsr.right.error_flags != RawSensors::Error::OK_) {
-            NUClear::log<NUClear::WARN>(make_error_string_v1("Right FSR", raw_sensors.fsr.right.error_flags));
-        }
 
         // **************** Servos ****************
         for (uint32_t id = 0; id < 20; ++id) {
@@ -63,24 +50,11 @@ namespace module::input {
                 NUClear::log<NUClear::WARN>(make_servo_hardware_error_string(original, id));
             }
 
-            /* COMPATIBILITY WITH OLD PROTOCOL V1 STUFF */
-            const auto& error = original.error_flags;
-            // Check for an error on the servo and report it
-            if (error != RawSensors::Error::OK_) {
-                NUClear::log<NUClear::WARN>(make_servo_error_string_v1(original, id));
-            }
-
-            // normally we would just check the error field here, but we need to be ready to accept one of both error
-            // fields as we don't know if we are working with protoco v1 or protocol v2. So set the field to whichever
-            // error is active, or zero if none.
-            const uint32_t message_error = (hardware_status != RawSensors::HardwareError::HARDWARE_OK) ? hardware_status
-                                           : (error != RawSensors::Error::OK_)                         ? error
-                                                                                                       : 0;
             // If current Sensors message for this servo has an error and we have a previous sensors
             // message available, then we use our previous sensor values with some updates
-            if (message_error && previous_sensors) {
+            if ((hardware_status != RawSensors::HardwareError::HARDWARE_OK) && previous_sensors) {
                 // Add the sensor values to the system properly
-                sensors->servo.emplace_back(message_error,
+                sensors->servo.emplace_back(hardware_status,
                                             id,
                                             original.torque_enabled,
                                             original.position_p_gain,
@@ -97,7 +71,7 @@ namespace module::input {
             // Otherwise we can just use the new values as is
             else {
                 // Add the sensor values to the system properly
-                sensors->servo.emplace_back(message_error,
+                sensors->servo.emplace_back(hardware_status,
                                             id,
                                             original.torque_enabled,
                                             original.position_p_gain,
@@ -161,12 +135,10 @@ namespace module::input {
         int middle_count = 0;
         // If we have any downs in the last 20 frames then we are button pushed
         for (const auto& s : sensors) {
-            /* note: platform_error_flags is included for v1 compatibility */
-            if (s->buttons.left && (s->platform_error_flags == 0u) && (s->subcontroller_error == 0u)) {
+            if (s->buttons.left && (s->subcontroller_error == 0u)) {
                 ++left_count;
             }
-            /* note: platform_error_flags is included for v1 compatibility */
-            if (s->buttons.middle && (s->platform_error_flags == 0u) && (s->subcontroller_error == 0u)) {
+            if (s->buttons.middle && (s->subcontroller_error == 0u)) {
                 ++middle_count;
             }
         }

--- a/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
@@ -38,7 +38,7 @@ namespace module::input {
 
         // Mask to ignore the alert bit (because servo errors are handled separately)
         bool subcontroller_packet_error =
-            (raw_sensors.subcontroller_error & ~RawSensors::PacketError::ALERT) == RawSensors::PacketError::PACKET_OK;
+            (raw_sensors.subcontroller_error & ~RawSensors::PacketError::ALERT) != RawSensors::PacketError::PACKET_OK;
 
         // Check for errors on the platform and FSRs
         if (subcontroller_packet_error) {

--- a/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
@@ -85,23 +85,22 @@ namespace module::input {
         // accelerometer
         if ((raw_sensors.subcontroller_error != RawSensors::PacketError::PACKET_OK) && previous_sensors) {
             sensors->accelerometer = previous_sensors->accelerometer;
+            sensors->gyroscope     = previous_sensors->gyroscope;
         }
         else {
             sensors->accelerometer = raw_sensors.accelerometer.cast<double>();
+            sensors->gyroscope     = raw_sensors.gyroscope.cast<double>();
         }
 
         // If we have a previous Sensors message AND (our platform has errors OR the gyro is spinning too fast) then
         // reuse our last sensor value of the gyroscope. Note: One of the gyros would occasionally
         // throw massive numbers without an error flag and if our hardware is working as intended, it should never
         // read that we're spinning at 2 revs/s
-        if (previous_sensors
-            && ((raw_sensors.subcontroller_error != RawSensors::PacketError::PACKET_OK)
-                || raw_sensors.gyroscope.norm() > 4.0 * M_PI)) {
+        if (raw_sensors.gyroscope.norm() > 4.0 * M_PI) {
             NUClear::log<NUClear::WARN>("Bad gyroscope value", raw_sensors.gyroscope.norm());
-            sensors->gyroscope = previous_sensors->gyroscope;
-        }
-        else {
-            sensors->gyroscope = raw_sensors.gyroscope.cast<double>();
+            if (previous_sensors) {
+                sensors->gyroscope = previous_sensors->gyroscope;
+            }
         }
 
         // **************** Timestamp ****************

--- a/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
@@ -37,8 +37,8 @@ namespace module::input {
                                           const RawSensors& raw_sensors) {
 
         // Mask to ignore the alert bit (because servo errors are handled separately)
-        RawSensors::PacketError subcontroller_packet_error =
-            raw_sensors.subcontroller_error & ~RawSensors::PacketError::ALERT;
+        bool subcontroller_packet_error =
+            (raw_sensors.subcontroller_error & ~RawSensors::PacketError::ALERT) == RawSensors::PacketError::PACKET_OK;
 
         // Check for errors on the platform and FSRs
         if (subcontroller_packet_error) {

--- a/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
@@ -111,28 +111,30 @@ namespace module::input {
                                             original.voltage,
                                             static_cast<float>(original.temperature));
             }
+        }
 
-            // **************** Accelerometer and Gyroscope ****************
-            // If we have a previous Sensors and our platform has errors then reuse our last sensor value of the
-            // accelerometer
-            if (message_error && previous_sensors) {
-                sensors->accelerometer = previous_sensors->accelerometer;
-            }
-            else {
-                sensors->accelerometer = raw_sensors.accelerometer.cast<double>();
-            }
+        // **************** Accelerometer and Gyroscope ****************
+        // If we have a previous Sensors and our platform has errors then reuse our last sensor value of the
+        // accelerometer
+        if ((raw_sensors.subcontroller_error != RawSensors::PacketError::PACKET_OK) && previous_sensors) {
+            sensors->accelerometer = previous_sensors->accelerometer;
+        }
+        else {
+            sensors->accelerometer = raw_sensors.accelerometer.cast<double>();
+        }
 
-            // If we have a previous Sensors message, our platform has errors, and the gyro is spinning too fast then
-            // reuse our last sensor value of the gyroscope. Note: One of the gyros would occasionally
-            // throw massive numbers without an error flag and if our hardware is working as intended, it should never
-            // read that we're spinning at 2 revs/s
-            if (previous_sensors && (message_error || raw_sensors.gyroscope.norm() > 4.0 * M_PI)) {
-                NUClear::log<NUClear::WARN>("Bad gyroscope value", raw_sensors.gyroscope.norm());
-                sensors->gyroscope = previous_sensors->gyroscope;
-            }
-            else {
-                sensors->gyroscope = raw_sensors.gyroscope.cast<double>();
-            }
+        // If we have a previous Sensors message, our platform has errors, and the gyro is spinning too fast then
+        // reuse our last sensor value of the gyroscope. Note: One of the gyros would occasionally
+        // throw massive numbers without an error flag and if our hardware is working as intended, it should never
+        // read that we're spinning at 2 revs/s
+        if (previous_sensors
+            && ((raw_sensors.subcontroller_error != RawSensors::PacketError::PACKET_OK)
+                || raw_sensors.gyroscope.norm() > 4.0 * M_PI)) {
+            NUClear::log<NUClear::WARN>("Bad gyroscope value", raw_sensors.gyroscope.norm());
+            sensors->gyroscope = previous_sensors->gyroscope;
+        }
+        else {
+            sensors->gyroscope = raw_sensors.gyroscope.cast<double>();
         }
 
         // **************** Timestamp ****************

--- a/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
@@ -70,21 +70,14 @@ namespace module::input {
                 ((hardware_status == RawSensors::HardwareError::MOTOR_ENCODER) && previous_sensors)
                     ? previous_sensors->servo[id].present_velocity
                     : raw_servo.present_velocity,
-                /* I'm unsure about this one, it's here because that's how it previously was, but i'm not sure if it
-                   makes sense to use the last known "good" load value if the servo is overloaded - because that gives
-                   us no useful information. Surely if the servo is overloaded we still want to know the true load */
-                ((hardware_status == RawSensors::HardwareError::OVERLOAD) && previous_sensors)
-                    ? previous_sensors->servo[id].load
-                    : raw_servo.present_current,
-                /* Same argument here... Seems dubious to have the system be fed a fake last known "safe" voltage if
-                   there is an input voltage error. What do we stand to gain from that? */
-                ((hardware_status == RawSensors::HardwareError::INPUT_VOLTAGE) && previous_sensors)
-                    ? previous_sensors->servo[id].voltage
-                    : raw_servo.voltage,
-                /* And again for the temperature, I don't think it makes sense here either */
-                ((hardware_status == RawSensors::HardwareError::OVERHEATING) && previous_sensors)
-                    ? previous_sensors->servo[id].temperature
-                    : static_cast<float>(raw_servo.temperature));
+                /* We may get a RawSensors::HardwareError::OVERLOAD error, but in this case the load value isn't *wrong*
+                   so it doesn't make sense to use the last "good" value */
+                raw_servo.present_current,
+                /* Similarly for a RawSensors::HardwareError::INPUT_VOLTAGE error, no special action is needed */
+                raw_servo.voltage,
+                /* And similarly here for a RawSensors::HardwareError::OVERHEATING error, we still pass the temperature
+                   no matter what */
+                static_cast<float>(raw_servo.temperature));
         }
 
         // **************** Accelerometer and Gyroscope ****************

--- a/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
@@ -90,7 +90,7 @@ namespace module::input {
             sensors->accelerometer = raw_sensors.accelerometer.cast<double>();
         }
 
-        // If we have a previous Sensors message, our platform has errors, and the gyro is spinning too fast then
+        // If we have a previous Sensors message AND (our platform has errors OR the gyro is spinning too fast) then
         // reuse our last sensor value of the gyroscope. Note: One of the gyros would occasionally
         // throw massive numbers without an error flag and if our hardware is working as intended, it should never
         // read that we're spinning at 2 revs/s

--- a/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/RawSensors.cpp
@@ -42,7 +42,7 @@ namespace module::input {
 
         // **************** Servos ****************
         for (uint32_t id = 0; id < 20; ++id) {
-            const auto& raw_servo        = getRawServo(id, raw_sensors);
+            const auto& raw_servo       = getRawServo(id, raw_sensors);
             const auto& hardware_status = raw_servo.hardware_error;
 
             // Check for an error on the servo and report it

--- a/module/platform/HardwareSimulator/src/HardwareSimulator.cpp
+++ b/module/platform/HardwareSimulator/src/HardwareSimulator.cpp
@@ -53,10 +53,11 @@ namespace module::platform {
         : Reactor(std::move(environment)) {
 
         /*
-         CM740 Data
+         Subcontroller Data
          */
+
         // Read our Error code
-        sensors.platform_error_flags = 0;
+        sensors.subcontroller_error = 0;
 
         // LED Panel
         sensors.led_panel.led2 = false;
@@ -82,7 +83,7 @@ namespace module::platform {
 
         // Right Sensor
         // Error
-        sensors.fsr.right.error_flags = 0;
+        sensors.fsr.right.hardware_error = 0;
 
         // Sensors
         sensors.fsr.right.fsr1 = 1;
@@ -96,7 +97,7 @@ namespace module::platform {
 
         // Left Sensor
         // Error
-        sensors.fsr.left.error_flags = 0;
+        sensors.fsr.left.hardware_error = 0;
 
         // Sensors
         sensors.fsr.left.fsr1 = 1;
@@ -117,7 +118,7 @@ namespace module::platform {
             RawSensors::Servo& servo = utility::platform::getRawServo(i, sensors);
 
             // Error code
-            servo.error_flags = 0;
+            servo.hardware_error = 0;
 
             // Booleans
             servo.torque_enabled = true;

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -107,8 +107,14 @@ namespace module::platform::OpenCR {
                 servo_states[i].simulated = config["servos"][i]["simulated"].as<bool>();
             }
 
+            // populate alarm config levels
             cfg.alarms.temperature.level            = config["alarms"]["temperature"]["level"].as<float>();
             cfg.alarms.temperature.buzzer_frequency = config["alarms"]["temperature"]["buzzer_frequency"].as<float>();
+
+            // populate battery config levels
+            battery_state.charged_voltage = config["battery"]["charged_voltage"].as<float>();
+            battery_state.nominal_voltage = config["battery"]["nominal_voltage"].as<float>();
+            battery_state.flat_voltage    = config["battery"]["flat_voltage"].as<float>();
         });
 
         on<Startup>().then("HardwareIO Startup", [this] {

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
@@ -74,7 +74,7 @@ namespace module::platform::OpenCR {
             uint16_t buzzer = 0;
 
             /// @brief Most recent packet error from the OpenCR device
-            uint8_t error_flags = 0;
+            uint8_t packet_error = 0;
         };
 
         /// @see battery_state

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/construct_sensors.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/construct_sensors.cpp
@@ -91,8 +91,12 @@ namespace module::platform::OpenCR {
                 servo.voltage     = servo_states[i].voltage;
                 servo.temperature = servo_states[i].temperature;
 
-                /* Note: removed input voltage bit clear here as it wasn't clear how it fits into the refactor. If there
-                 * are problems with input voltage errors coming up too frequently then this is likely the culprit */
+                // Clear Overvoltage flag if the voltage error is only due to the high battery voltage, as this isn't
+                // dangerous, and will otherwise impede odometery (since RawSensors.cpp will discard sensor data from a
+                // servo reporting an error state)
+                if (servo.voltage <= battery_state.charged_voltage) {
+                    servo.error_flags &= ~RawSensors::Error::INPUT_VOLTAGE;
+                }
             }
         }
 

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/construct_sensors.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/construct_sensors.cpp
@@ -91,9 +91,7 @@ namespace module::platform::OpenCR {
                 servo.voltage     = servo_states[i].voltage;
                 servo.temperature = servo_states[i].temperature;
 
-                // Clear Overvoltage flag if the voltage error is only due to the high battery voltage, as this isn't
-                // dangerous, and will otherwise impede odometery (since RawSensors.cpp will discard sensor data from a
-                // servo reporting an error state)
+                // Clear Overvoltage flag if voltage is below the (normal) max battery voltage, as this isn't dangerous
                 if (servo.voltage <= battery_state.charged_voltage) {
                     servo.hardware_error &= ~RawSensors::HardwareError::INPUT_VOLTAGE;
                 }

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/construct_sensors.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/construct_sensors.cpp
@@ -13,7 +13,7 @@ namespace module::platform::OpenCR {
         sensors.timestamp = NUClear::clock::now();
 
         /* OpenCR data */
-        sensors.subcontroller_error = opencr_state.error_flags;
+        sensors.subcontroller_error = opencr_state.packet_error;
         sensors.led_panel           = opencr_state.led_panel;
         sensors.head_led            = opencr_state.head_led;
         sensors.eye_led             = opencr_state.eye_led;
@@ -78,7 +78,7 @@ namespace module::platform::OpenCR {
             // If we are using real data, get it from the packet
             else {
                 // Error code
-                servo.error_flags = servo_states[i].hardware_error;
+                servo.hardware_error = servo_states[i].hardware_error;
 
                 // Accumulate all packet error flags to read at once
                 sensors.subcontroller_error |= servo_states[i].packet_error;
@@ -95,15 +95,10 @@ namespace module::platform::OpenCR {
                 // dangerous, and will otherwise impede odometery (since RawSensors.cpp will discard sensor data from a
                 // servo reporting an error state)
                 if (servo.voltage <= battery_state.charged_voltage) {
-                    servo.error_flags &= ~RawSensors::Error::INPUT_VOLTAGE;
+                    servo.hardware_error &= ~RawSensors::HardwareError::INPUT_VOLTAGE;
                 }
             }
         }
-
-        // handle unused compatibility fields
-        sensors.platform_error_flags  = RawSensors::Error::OK_;
-        sensors.fsr.left.error_flags  = RawSensors::Error::OK_;
-        sensors.fsr.right.error_flags = RawSensors::Error::OK_;
 
         return sensors;
     }

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
@@ -58,7 +58,7 @@ namespace module::platform::OpenCR {
                                            -convert::acc(data.acc[1]),   // Y
                                            -convert::acc(data.acc[2]));  // Z
         // Command send/receive errors only
-        opencr_state.error_flags = packet.error;
+        opencr_state.packet_error = packet.error;
 
         // Work out a battery charged percentage
         battery_state.current_voltage = convert::voltage(data.voltage);

--- a/shared/message/input/Sensors.proto
+++ b/shared/message/input/Sensors.proto
@@ -35,7 +35,7 @@ message Sensors {
         /// Set of things which can or have gone wrong.
         /// https://emanual.robotis.com/docs/en/dxl/mx/mx-64-2/#hardware-error-status70
         uint32 hardware_error = 1;
-        uint32 id          = 2;
+        uint32 id             = 2;
         /// Whether the torque is on or off
         bool enabled = 3;
         /// Proportional gain. In proportion to the servo's position error. Gain

--- a/shared/message/input/Sensors.proto
+++ b/shared/message/input/Sensors.proto
@@ -29,12 +29,12 @@ import "Transform.proto";
 
 message Sensors {
     /// Full set of information to use a given servo.
-    /// Ref: https://emanual.robotis.com/docs/en/dxl/mx/mx-64/ ;
-    /// https://emanual.robotis.com/docs/en/dxl/mx/mx-106/
+    /// Ref: https://emanual.robotis.com/docs/en/dxl/mx/mx-64-2/ ;
+    /// https://emanual.robotis.com/docs/en/dxl/mx/mx-106-2/
     message Servo {
         /// Set of things which can or have gone wrong.
-        /// https://emanual.robotis.com/docs/en/dxl/mx/mx-106/#alarm-led17-shutdown18
-        uint32 error_flags = 1;
+        /// https://emanual.robotis.com/docs/en/dxl/mx/mx-64-2/#hardware-error-status70
+        uint32 hardware_error = 1;
         uint32 id          = 2;
         /// Whether the torque is on or off
         bool enabled = 3;
@@ -50,7 +50,7 @@ message Sensors {
         float d_gain = 6;
         /// It is a position value of destination. 0 to 4,095 (0xFFF) is available.
         /// The unit is 0.088 [°]. (FROM
-        /// https://emanual.robotis.com/docs/en/dxl/mx/mx-64/#specifications): If
+        /// https://emanual.robotis.com/docs/en/dxl/mx/mx-64-2/#specifications): If
         /// Goal Position is out of the range, Angle Limit Error Bit (Bit1) of
         /// Status Packet is returned as ‘1’ and Alarm is triggered as set in Alarm
         /// LED/Shutdown

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -32,7 +32,6 @@ message RawSensors {
     /// Set of error flags/statuses.
     /// bitmask values.
 
-    /// @note RawSensors::Error is kept for protocol v1 compatibility only.
     /// Values are suffixed with an underscore to resolve naming conflicts.
     enum Error {
         OK_            = 0;  // not really a flag but the lack of any other flag
@@ -116,7 +115,7 @@ message RawSensors {
         float  fsr4        = 4;
         float  centre_x    = 5;
         float  centre_y    = 6;
-        uint32 error_flags = 7;
+        uint32 hardware_error = 7;
     }
 
     message FSRs {
@@ -128,31 +127,28 @@ message RawSensors {
 
     // Full set of information to use for servos using Dynamixel v2 firmware
     message Servo {
-        // keep this for compatibility with cm740/v1 while we need it
-        uint32 error_flags = 1;  // components of type RawSensors::Error (but can have multiple bits set)
-        // this is for the protocol v2
-        uint32 hardware_error  = 2;  // components of type RawSensors::HardwareError (but can have multiple bits set)
-        bool   torque_enabled  = 3;
-        float  velocity_i_gain = 4;
-        float  velocity_p_gain = 5;
-        float  position_d_gain = 6;
-        float  position_i_gain = 7;
-        float  position_p_gain = 8;
-        float  feed_forward_1st_Gain = 9;
-        float  feed_forward_2nd_Gain = 10;
-        float  present_PWM           = 11;
-        float  present_current       = 12;
-        float  present_velocity      = 13;
-        float  present_position      = 14;
-        float  goal_PWM              = 15;
-        float  goal_current          = 16;
-        float  goal_velocity         = 17;
-        float  goal_position         = 18;
-        float  voltage               = 19;
-        float  temperature           = 20;
-        float  profile_acceleration  = 21;
+        uint32 hardware_error  = 1;  // components of type RawSensors::HardwareError (but can have multiple bits set)
+        bool   torque_enabled  = 2;
+        float  velocity_i_gain = 3;
+        float  velocity_p_gain = 4;
+        float  position_d_gain = 5;
+        float  position_i_gain = 6;
+        float  position_p_gain = 7;
+        float  feed_forward_1st_Gain = 8;
+        float  feed_forward_2nd_Gain = 9;
+        float  present_PWM           = 10;
+        float  present_current       = 11;
+        float  present_velocity      = 12;
+        float  present_position      = 13;
+        float  goal_PWM              = 14;
+        float  goal_current          = 15;
+        float  goal_velocity         = 16;
+        float  goal_position         = 17;
+        float  voltage               = 18;
+        float  temperature           = 19;
+        float  profile_acceleration  = 20;
         // Replaces "Moving speed" from v1 protocol, basically just the set speed.
-        float profile_velocity = 22;
+        float profile_velocity = 21;
     };
 
     /// Set of all the servos on the robot
@@ -181,23 +177,20 @@ message RawSensors {
 
     google.protobuf.Timestamp timestamp = 1;  // Timestamp when our data were taken
 
-    // again, keep this for compatibility with cm740/v1 while we need it
-    uint32 platform_error_flags = 2;
-    // this is for protocol v2
-    uint32 subcontroller_error = 3;  // components of type RawSensors::PacketError (but can have multiple bits set)
+    uint32 subcontroller_error = 2;  // components of type RawSensors::PacketError (but can have multiple bits set)
 
-    LEDPanel led_panel     = 4;
-    HeadLED  head_led      = 5;
-    EyeLED   eye_led       = 6;
-    Buttons  buttons       = 7;
-    fvec3    accelerometer = 8;
-    fvec3    gyroscope     = 9;
-    Servos   servo         = 10;
-    float    battery       = 11;
-    FSRs     fsr           = 12;
+    LEDPanel led_panel     = 3;
+    HeadLED  head_led      = 4;
+    EyeLED   eye_led       = 5;
+    Buttons  buttons       = 6;
+    fvec3    accelerometer = 7;
+    fvec3    gyroscope     = 8;
+    Servos   servo         = 9;
+    float    battery       = 10;
+    FSRs     fsr           = 11;
 
     /// Ground truth from a simulator
-    webots.OdometryGroundTruth odometry_ground_truth = 13;
+    webots.OdometryGroundTruth odometry_ground_truth = 12;
 }
 
 message ButtonLeftDown {}

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -95,12 +95,12 @@ message RawSensors {
     /// The robot has Force Sensitive Resistors on its feet to detect whether a foot is down.
     /// There are four FSRs per foot, so this message is for one foot
     message FSR {
-        float  fsr1        = 1;
-        float  fsr2        = 2;
-        float  fsr3        = 3;
-        float  fsr4        = 4;
-        float  centre_x    = 5;
-        float  centre_y    = 6;
+        float  fsr1           = 1;
+        float  fsr2           = 2;
+        float  fsr3           = 3;
+        float  fsr4           = 4;
+        float  centre_x       = 5;
+        float  centre_y       = 6;
         uint32 hardware_error = 7;
     }
 

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -32,20 +32,6 @@ message RawSensors {
     /// Set of error flags/statuses.
     /// bitmask values.
 
-    /// Values are suffixed with an underscore to resolve naming conflicts.
-    enum Error {
-        OK_            = 0;  // not really a flag but the lack of any other flag
-        INPUT_VOLTAGE_ = 1;
-        ANGLE_LIMIT_   = 2;
-        OVERHEATING_   = 4;
-        RANGE_         = 8;
-        CHECKSUM_      = 16;
-        OVERLOAD_      = 32;
-        INSTRUCTION_   = 64;
-        CORRUPT_DATA_  = 128;
-        TIMEOUT_       = 256;
-    }
-
     // See https://emanual.robotis.com/docs/en/dxl/protocol2/#error
     enum PacketError {
         PACKET_OK   = 0;

--- a/shared/utility/platform/RawSensors.hpp
+++ b/shared/utility/platform/RawSensors.hpp
@@ -30,7 +30,6 @@ namespace utility::platform {
 
     /**
      * @brief Functions to create log strings for packet errors and servo errors
-     * @note functions appended with `_v1` are compatibility functions for protocol v1
      */
 
     inline std::string make_packet_error_string(const std::string& src, const uint error_code) {
@@ -86,66 +85,6 @@ namespace utility::platform {
         }
         if ((servo.hardware_error & RawSensors::HardwareError::OVERLOAD) != 0u) {
             s << " Overloaded - " << servo.present_current;
-        }
-        return s.str();
-    }
-
-    inline std::string make_error_string_v1(const std::string& src, const uint error_code) {
-        std::stringstream s;
-
-        s << "Error on ";
-        s << src;
-        s << ":";
-
-        if ((error_code & RawSensors::Error::INPUT_VOLTAGE_) != 0u) {
-            s << " Input Voltage ";
-        }
-        if ((error_code & RawSensors::Error::ANGLE_LIMIT_) != 0u) {
-            s << " Angle Limit ";
-        }
-        if ((error_code & RawSensors::Error::OVERHEATING_) != 0u) {
-            s << " Overheating ";
-        }
-        if ((error_code & RawSensors::Error::OVERLOAD_) != 0u) {
-            s << " Overloaded ";
-        }
-        if ((error_code & RawSensors::Error::INSTRUCTION_) != 0u) {
-            s << " Bad Instruction ";
-        }
-        if ((error_code & RawSensors::Error::CORRUPT_DATA_) != 0u) {
-            s << " Corrupt Data ";
-        }
-        if ((error_code & RawSensors::Error::TIMEOUT_) != 0u) {
-            s << " Timeout ";
-        }
-
-        return s.str();
-    }
-
-    inline std::string make_servo_error_string_v1(const RawSensors::Servo& servo, const uint32_t servo_id) {
-        std::stringstream s;
-        s << "Error on Servo " << (servo_id + 1) << " (" << static_cast<ServoID>(servo_id) << "):";
-
-        if ((servo.error_flags & RawSensors::Error::INPUT_VOLTAGE_) != 0u) {
-            s << " Input Voltage - " << servo.voltage;
-        }
-        if ((servo.error_flags & RawSensors::Error::ANGLE_LIMIT_) != 0u) {
-            s << " Angle Limit - " << servo.present_position;
-        }
-        if ((servo.error_flags & RawSensors::Error::OVERHEATING_) != 0u) {
-            s << " Overheating - " << servo.temperature;
-        }
-        if ((servo.error_flags & RawSensors::Error::OVERLOAD_) != 0u) {
-            s << " Overloaded - " << servo.present_current;
-        }
-        if ((servo.error_flags & RawSensors::Error::INSTRUCTION_) != 0u) {
-            s << " Bad Instruction ";
-        }
-        if ((servo.error_flags & RawSensors::Error::CORRUPT_DATA_) != 0u) {
-            s << " Corrupt Data ";
-        }
-        if ((servo.error_flags & RawSensors::Error::TIMEOUT_) != 0u) {
-            s << " Timeout ";
         }
         return s.str();
     }


### PR DESCRIPTION
Change RawSensors error handling to, broadly, stop odometry from exploding when we get any error. Now:
- Odometry will update regardless of *hardware* errors, and will only be conditional on subcontroller packet errors (which are the only ones relevant to the IMU)
- Other sensors message values will be conditional only to the specific errors which might be relevant, not just any error.

It also re-implements a check which disables the servo input voltage error as long as it's below the battery voltage. This was in the code previously but I removed it a while ago because I didn't know what it was for. Turns out it was important.

This also removes all references to Dynamixel protocol v1 errors which I'd left in pre-robocup for just-in-case compatibility, but are no longer needed. Hopefully there isn't anything still hanging around, but there may be. It compiles at least.

### Reviewers, Note

~~I'm a bit uncertain about some of the error handling for overload, input voltage and overheating errors. I've kept the same logic as before for now, assuming that what was previously there was there because it works/was written by people much smarter than me. See lines 73-87 in RawSensors.cpp for the comments there (line numbers might change if I change stuff)~~

### Things left to do

- [x] Test it on a real robot (right now it just compiles)
