### PR TITLE
Fix urdf webots model path, specifically for webots docker

### DIFF
--- a/module/actuation/Kinematics/data/config/webots/Kinematics.yaml
+++ b/module/actuation/Kinematics/data/config/webots/Kinematics.yaml
@@ -1,7 +1,7 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-urdf_path: "/home/nubots/NUbots/shared/utility/platform/models/nugus.urdf"
+urdf_path: "models/nugus.urdf"
 
 # Stopping tolerance for IK
 ik_tolerance: 1e-5

--- a/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
@@ -80,4 +80,4 @@ initial_rpy: [0, 0.3839, 0]
 # Specify which filtering method to use, either UKF, KF, MAHONY or GROUND_TRUTH
 filtering_method: MAHONY
 
-urdf_path: "/home/nubots/NUbots/shared/utility/platform/models/nugus.urdf"
+urdf_path: "models/nugus.urdf"

--- a/module/platform/Webots/data/config/WebotsCameras/left_camera.yaml
+++ b/module/platform/Webots/data/config/WebotsCameras/left_camera.yaml
@@ -33,7 +33,7 @@ settings:
   # BalanceWhiteAuto: Contsinuous
 
 # Camera kinematics
-urdf_path: "/home/nubots/NUbots/shared/utility/platform/models/nugus.urdf"
+urdf_path: "models/nugus.urdf"
 
 roll_offset: 0.0 * pi / 180
 


### PR DESCRIPTION
Reason this wasn't working in Webots is because the folder isn't mounted in the webots docker container, so normally it would work but not if you're using the docker container for the purpose of virtual season or running multiple robots.