### PR TITLE
Improve odometry with anchor point method

### DIFF
--- a/module/input/SensorFilter/data/config/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/SensorFilter.yaml
@@ -77,6 +77,7 @@ mahony:
 
 # Tuning parameters to scale walk command to match actual achieved velocity for deckreckoning x, y, theta
 deadreckoning_scale: [1, 1, 0.6]
+initial_anchor_frame: "left_foot_base"
 
 # Kalman/Mahony filter initial pose
 initial_rTWw: [0, 0, 0.49]

--- a/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
@@ -72,6 +72,7 @@ mahony:
 
 # Tuning parameters to scale walk command to match actual achieved velocity for deckreckoning x, y, theta
 deadreckoning_scale: [1, 1, 0.6]
+initial_anchor_frame: "left_foot_base"
 
 # Kalman/Mahony filter initial pose
 initial_rTWw: [0, 0, 0.49]

--- a/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
@@ -64,7 +64,7 @@ kalman:
 
 mahony:
   # Mahony "Proportional" Gain on error
-  Kp: 1
+  Kp: 0.5
   # Mahony "Integral" Gain used to compute bias
   Ki: 0.3
   # Mahony Filter initial bias

--- a/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
@@ -75,7 +75,7 @@ deadreckoning_scale: [1, 1, 0.6]
 
 # Kalman/Mahony filter initial pose
 initial_rTWw: [0, 0, 0.49]
-initial_rpy: [0, 0.3839, 0]
+initial_rpy: [0, 0.21, 0]
 
 # Specify which filtering method to use, either UKF, KF, MAHONY or GROUND_TRUTH
 filtering_method: MAHONY

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -179,7 +179,7 @@ namespace module::input {
     void SensorFilter::anchor_update(std::unique_ptr<Sensors>& sensors,
                                      const Stability& stability,
                                      const WalkState& walk_state) {
-        // Compute torso pose in world space using anchor frame
+        // Compute torso pose in world space using kinematics from anchor frame
         if (current_support_phase.value == WalkState::SupportPhase::LEFT) {
             Hwt = Hwa * sensors->Htx[FrameID::L_FOOT_BASE].inverse();
         }
@@ -187,7 +187,7 @@ namespace module::input {
             Hwt = Hwa * sensors->Htx[FrameID::R_FOOT_BASE].inverse();
         }
 
-        // Update the anchor {a} frame if a support phase switch just occurred (could be done with touch sensors)
+        // Update the anchor {a} frame if a support phase switch just occurred (could be done with foot down sensors)
         if (walk_state.support_phase != current_support_phase) {
             current_support_phase = walk_state.support_phase;
             if (current_support_phase.value == WalkState::SupportPhase::LEFT) {

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -138,7 +138,7 @@ namespace module::input {
                                   update_odometry_kf(sensors, previous_sensors, raw_sensors, stability, walk_state);
                                   break;
                               case FilteringMethod::MAHONY:
-                                  update_odometry_mahony(sensors, previous_sensors, raw_sensors, stability, walk_state);
+                                  update_odometry_mahony(sensors, previous_sensors, raw_sensors, walk_state);
                                   break;
                               case FilteringMethod::GROUND_TRUTH:
                                   update_odometry_ground_truth(sensors, raw_sensors);
@@ -176,9 +176,7 @@ namespace module::input {
         }
     }
 
-    void SensorFilter::anchor_update(std::unique_ptr<Sensors>& sensors,
-                                     const Stability& stability,
-                                     const WalkState& walk_state) {
+    void SensorFilter::anchor_update(std::unique_ptr<Sensors>& sensors, const WalkState& walk_state) {
         // Compute torso pose in world space using kinematics from anchor frame
         if (current_support_phase.value == WalkState::SupportPhase::LEFT) {
             Hwt = Hwa * sensors->Htx[FrameID::L_FOOT_BASE].inverse();

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -198,12 +198,11 @@ namespace module::input {
                 // Update the anchor frame to the base of right foot
                 Hwa = Hwt * sensors->Htx[FrameID::R_FOOT_BASE];
             }
-
-            // Set the z translation, roll and pitch of the anchor frame to 0 as assumed to be on flat ground
-            Hwa.translation().z() = 0;
-            Hwa.linear() = Eigen::AngleAxisd(MatrixToEulerIntrinsic(Hwa.linear()).z(), Eigen::Vector3d::UnitZ())
-                               .toRotationMatrix();
         }
+        // Set the z translation, roll and pitch of the anchor frame to 0 as assumed to be on flat ground
+        Hwa.translation().z() = 0;
+        Hwa.linear() =
+            Eigen::AngleAxisd(MatrixToEulerIntrinsic(Hwa.linear()).z(), Eigen::Vector3d::UnitZ()).toRotationMatrix();
     }
 
     void SensorFilter::debug_sensor_filter(std::unique_ptr<Sensors>& sensors, const RawSensors& raw_sensors) {

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -173,44 +173,30 @@ namespace module::input {
     void SensorFilter::anchor_update(std::unique_ptr<Sensors>& sensors,
                                      const Stability& stability,
                                      const WalkState& walk_state) {
-        // Check if we are not currently falling
-        // Update torso frame estimate using kinematics relative to the anchor frame
-        switch (current_support_phase.value) {
-            case WalkState::SupportPhase::LEFT:
-                // Update the anchor frame to the left foot
-                Hwt = Hwa * sensors->Htx[FrameID::L_FOOT_BASE].inverse();
-
-                log<NUClear::DEBUG>("Hwt.translation().z() = {}", Hwt.translation().z());
-                log<NUClear::DEBUG>("sensors->Htx[FrameID::L_FOOT_BASE].translation().z() = {}",
-                                    Eigen::Isometry3d(sensors->Htx[FrameID::L_FOOT_BASE]).translation().z());
-                break;
-            case WalkState::SupportPhase::RIGHT:
-                // Update the anchor frame to the right foot
-                Hwt = Hwa * sensors->Htx[FrameID::R_FOOT_BASE].inverse();
-                break;
-            default: break;
+        // Compute torso pose in world space using anchor frame
+        if (current_support_phase.value == WalkState::SupportPhase::LEFT) {
+            Hwt = Hwa * sensors->Htx[FrameID::L_FOOT_BASE].inverse();
+        }
+        else if (current_support_phase.value == WalkState::SupportPhase::RIGHT) {
+            Hwt = Hwa * sensors->Htx[FrameID::R_FOOT_BASE].inverse();
         }
 
         // Update the anchor {a} frame if a support phase switch just occurred (could be done with touch sensors)
         if (walk_state.support_phase != current_support_phase) {
-            log<NUClear::DEBUG>("Support Phase Switch");
             current_support_phase = walk_state.support_phase;
-            switch (current_support_phase.value) {
-                case WalkState::SupportPhase::LEFT:
-                    // Update the anchor frame to the left foot
-                    Hwa = Hwt * sensors->Htx[FrameID::L_FOOT_BASE];
-                    break;
-                case WalkState::SupportPhase::RIGHT:
-                    // Update the anchor frame to the right foot
-                    Hwa = Hwt * sensors->Htx[FrameID::R_FOOT_BASE];
-                    break;
-                default: break;
+            if (current_support_phase.value == WalkState::SupportPhase::LEFT) {
+                // Update the anchor frame to the base of left foot
+                Hwa = Hwt * sensors->Htx[FrameID::L_FOOT_BASE];
             }
-            // Set the z translation of the anchor frame to 0
+            else if (current_support_phase.value == WalkState::SupportPhase::RIGHT) {
+                // Update the anchor frame to the base of right foot
+                Hwa = Hwt * sensors->Htx[FrameID::R_FOOT_BASE];
+            }
+
+            // Set the z translation, roll and pitch of the anchor frame to 0 as assumed to be on flat ground
             Hwa.translation().z() = 0;
-            // Set the roll and pitch of the anchor frame to 0
-            Hwa.linear() =
-                Eigen::AngleAxisd(std::atan2(Hwa(1, 0), Hwa(0, 0)), Eigen::Vector3d::UnitZ()).toRotationMatrix();
+            Hwa.linear() = Eigen::AngleAxisd(MatrixToEulerIntrinsic(Hwa.linear()).z(), Eigen::Vector3d::UnitZ())
+                               .toRotationMatrix();
         }
     }
 

--- a/module/input/SensorFilter/src/SensorFilter.hpp
+++ b/module/input/SensorFilter/src/SensorFilter.hpp
@@ -289,6 +289,10 @@ namespace module::input {
         /// @param walk_state Current state of walk engine
         void integrate_walkcommand(const double dt, const Stability& stability, const WalkState& walk_state);
 
+        /// @brief Updates translational and yaw components of odometry using the anchor method
+        /// @param walk_state Current state of walk engine
+        void anchor_update(std::unique_ptr<Sensors>& sensors, const Stability& stability, const WalkState& walk_state);
+
         /// @brief Configure UKF filter
         void configure_ukf(const Configuration& config);
 
@@ -343,11 +347,19 @@ namespace module::input {
         void debug_sensor_filter(std::unique_ptr<Sensors>& sensors, const RawSensors& raw_sensors);
 
     private:
+        /// @brief Anchor position of the robot in world space
+        Eigen::Isometry3d Hwa = Eigen::Isometry3d::Identity();
+
+        /// @brief Current support phase of the robot
+        WalkState::SupportPhase current_support_phase = WalkState::SupportPhase::LEFT;
+
         /// @brief Dead reckoning yaw orientation of the robot in world space
         double yaw = 0;
 
+
         /// @brief Transform of torso from world space
-        Eigen::Isometry3d Hwt = Eigen::Isometry3d::Identity();
+        Eigen::Isometry3d Hwt        = Eigen::Isometry3d::Identity();
+        Eigen::Isometry3d Hwt_mahony = Eigen::Isometry3d::Identity();
 
         /// @brief Current walk command
         Eigen::Vector3d walk_command = Eigen::Vector3d::Zero();

--- a/module/input/SensorFilter/src/SensorFilter.hpp
+++ b/module/input/SensorFilter/src/SensorFilter.hpp
@@ -291,7 +291,7 @@ namespace module::input {
 
         /// @brief Updates translational and yaw components of odometry using the anchor method
         /// @param walk_state Current state of walk engine
-        void anchor_update(std::unique_ptr<Sensors>& sensors, const Stability& stability, const WalkState& walk_state);
+        void anchor_update(std::unique_ptr<Sensors>& sensors, const WalkState& walk_state);
 
         /// @brief Configure UKF filter
         void configure_ukf(const Configuration& config);
@@ -331,7 +331,6 @@ namespace module::input {
         void update_odometry_mahony(std::unique_ptr<Sensors>& sensors,
                                     const std::shared_ptr<const Sensors>& previous_sensors,
                                     const RawSensors& raw_sensors,
-                                    const std::shared_ptr<const Stability>& stability,
                                     const std::shared_ptr<const WalkState>& walk_state);
 
         /// @brief Updates the sensors message with odometry data filtered using ground truth from WeBots. This includes
@@ -347,7 +346,7 @@ namespace module::input {
         void debug_sensor_filter(std::unique_ptr<Sensors>& sensors, const RawSensors& raw_sensors);
 
     private:
-        /// @brief Anchor position of the robot in world space
+        /// @brief Transform from anchor {a} to world {w} space
         Eigen::Isometry3d Hwa = Eigen::Isometry3d::Identity();
 
         /// @brief Current support phase of the robot
@@ -356,19 +355,14 @@ namespace module::input {
         /// @brief Dead reckoning yaw orientation of the robot in world space
         double yaw = 0;
 
+        /// @brief Transform from torso {t} to world {w} space
+        Eigen::Isometry3d Hwt = Eigen::Isometry3d::Identity();
 
-        /// @brief Transform of torso from world space
-        Eigen::Isometry3d Hwt        = Eigen::Isometry3d::Identity();
+        // @brief Transform from torso {t} to world {w} space using mahony filter (only roll and pitch estimation)
         Eigen::Isometry3d Hwt_mahony = Eigen::Isometry3d::Identity();
 
         /// @brief Current walk command
         Eigen::Vector3d walk_command = Eigen::Vector3d::Zero();
-
-        /// @brief Bool to indicate if the robot is falling
-        bool falling = false;
-
-        /// @brief Bool to indicate if the robot is walking
-        bool walk_engine_enabled = false;
 
         /// @brief Current state of the left button
         bool left_down = false;

--- a/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
@@ -51,6 +51,7 @@ namespace module::input {
         cfg.bias          = Eigen::Vector3d(config["mahony"]["bias"].as<Expression>());
         Hwt.translation() = Eigen::VectorXd(config["initial_rTWw"].as<Expression>());
         Hwt.linear()      = EulerIntrinsicToMatrix(Eigen::Vector3d(config["initial_rpy"].as<Expression>()));
+        Hwt_mahony        = Hwt;
     }
 
     void SensorFilter::update_odometry_mahony(std::unique_ptr<Sensors>& sensors,

--- a/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
+++ b/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
@@ -29,4 +29,4 @@ targets:
 
     # Localisation Messages
     message.localisation.Ball: true
-    message.localisation.Field: true
+    message.localisation.Field: false

--- a/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
+++ b/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
@@ -29,4 +29,4 @@ targets:
 
     # Localisation Messages
     message.localisation.Ball: true
-    message.localisation.Field: false
+    message.localisation.Field: true

--- a/module/skill/Walk/src/Walk.cpp
+++ b/module/skill/Walk/src/Walk.cpp
@@ -141,7 +141,9 @@ namespace module::skill {
                 emit<Task>(right_arm, 0, true, "Walk right arm");
 
                 // Emit walk engine state
-                emit(std::make_unique<WalkState>(walk_generator.get_state(), walk_task.velocity_target));
+                WalkState::SupportPhase phase = walk_generator.is_left_foot_planted() ? WalkState::SupportPhase::LEFT
+                                                                                      : WalkState::SupportPhase::RIGHT;
+                emit(std::make_unique<WalkState>(walk_generator.get_state(), walk_task.velocity_target, phase));
 
                 // Debugging
                 if (log_level <= NUClear::DEBUG) {

--- a/shared/message/behaviour/state/WalkState.proto
+++ b/shared/message/behaviour/state/WalkState.proto
@@ -31,9 +31,20 @@ message WalkState {
         STOPPED  = 3;
     }
 
+    enum SupportPhase {
+        DOUBLE  = 0;
+        LEFT  = 1;
+        RIGHT = 2;
+    }
+
     /// Walking state
     State state = 1;
 
     /// Current requested velocity target (dx, dy, dtheta)
     vec3 velocity_target = 2;
+
+    /// Support phase
+    SupportPhase support_phase = 3;
+
+
 }

--- a/shared/message/behaviour/state/WalkState.proto
+++ b/shared/message/behaviour/state/WalkState.proto
@@ -32,9 +32,9 @@ message WalkState {
     }
 
     enum SupportPhase {
-        DOUBLE  = 0;
-        LEFT  = 1;
-        RIGHT = 2;
+        DOUBLE = 0;
+        LEFT   = 1;
+        RIGHT  = 2;
     }
 
     /// Walking state
@@ -45,6 +45,4 @@ message WalkState {
 
     /// Support phase
     SupportPhase support_phase = 3;
-
-
 }


### PR DESCRIPTION
The current method for estimating the x-y translation and yaw of odometry involves integrating the walk command. This PR replaces this with an "anchor point" method. We select an anchor point A which is a left/right foot base frame and assume that this point is in contact, fixed to the ground in world space, giving us Hwa. We then simply compute the pose of the torso from this frame (Hat) using kinematics. This allows us to compute Hwt = Hwa * Hat. Finally, we replace the roll and pitch components of the rotation using the Mahony filter estimation. After a step has been taken the anchor point is switched to the next planted foot, illustrated below.

![image](https://github.com/NUbots/NUbots/assets/41043317/191515ea-fbb1-4474-8399-08bcdab6675d)

A nice blog post can be found here discussing the idea: https://scaron.info/robotics/floating-base-estimation.html
This method can be improved with a more advanced filtering technique, however, this simple idea provides quite good results.
