### PR TITLE
Install node-gyp dependency manually

### DIFF
--- a/.github/workflows/nusight.yaml
+++ b/.github/workflows/nusight.yaml
@@ -93,7 +93,7 @@ jobs:
       # Check dependencies from cache and install any which weren't cached or were corrupted
       - name: Install Dependencies
         working-directory: nusight2
-        run: yarn --prefer-offline
+        run: yarn global add node-gyp && yarn --prefer-offline
 
       - name: Type Check NUsight
         working-directory: nusight2

--- a/.github/workflows/nusight.yaml
+++ b/.github/workflows/nusight.yaml
@@ -144,7 +144,7 @@ jobs:
       # Check dependencies from cache and install any which weren't cached or were corrupted
       - name: Install Dependencies
         working-directory: nusight2
-        run: yarn --prefer-offline
+        run: yarn global add node-gyp && yarn --prefer-offline
 
       - name: Build NUsight
         working-directory: nusight2
@@ -191,7 +191,7 @@ jobs:
       # Check dependencies from cache and install any which weren't cached or were corrupted
       - name: Install Dependencies
         working-directory: nusight2
-        run: yarn --prefer-offline
+        run: yarn global add node-gyp && yarn --prefer-offline
 
       - name: Build NUsight
         working-directory: nusight2


### PR DESCRIPTION
It seems like something in the Node 18 image we use in CI has changed such that [yarn can no longer find a globally installed node-gyp](https://github.com/NUbots/NUbots/actions/runs/6347202110/job/17241866951?pr=1245#step:6:19) to build native dependencies.

It [tries to install it on the fly but fails](https://github.com/NUbots/NUbots/actions/runs/6347202110/job/17241866951?pr=1245#step:6:21) since we have --prefer-offline (to use the cache) and it doesn't find node-gyp in the cache.

This PR adds the manual installation of `node-gyp` to the "Install dependencies" step to temporarily solve the issue. 

Thanks @JosephusPaye for fix.