### PR TITLE
Add function for finding `angle_between` two unit vectors in a numerically stable manner

### DIFF
--- a/shared/tests/utility/math/angle.cpp
+++ b/shared/tests/utility/math/angle.cpp
@@ -1,0 +1,169 @@
+#include "utility/math/angle.hpp"
+
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_adapters.hpp>
+#include <catch2/generators/catch_generators_random.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+namespace utility::math::test {
+    using Catch::Matchers::WithinAbs;
+    using utility::math::angle::angle_between;
+
+    SCENARIO("Find the angle between two vectors", "[utility][math][angle]") {
+        const auto& pi = std::numbers::pi;
+
+        // Define a precision to compare floating point values
+        const double precision = 1e-6;
+
+        GIVEN("The x-axis and y-axis") {
+            Eigen::Vector3d u{1.0, 0.0, 0.0};
+            Eigen::Vector3d v{0.0, 1.0, 0.0};
+
+            WHEN("Computing the angle between them") {
+                double angle = angle_between(u, v);
+
+                THEN("The angle should be approximately pi/2") {
+                    CHECK_THAT(angle, WithinAbs(pi / 2.0, precision));
+                }
+            }
+        }
+
+        GIVEN("The y-axis and z-axis") {
+            Eigen::Vector3d u{0.0, 1.0, 0.0};
+            Eigen::Vector3d v{0.0, 0.0, 1.0};
+
+            WHEN("Computing the angle between them") {
+                double angle = angle_between(u, v);
+
+                THEN("The angle should be approximately pi/2") {
+                    CHECK_THAT(angle, WithinAbs(pi / 2.0, precision));
+                }
+            }
+        }
+
+        GIVEN("Two parallel vectors") {
+            Eigen::Vector3d u{1.0, 2.0, 3.0};
+            Eigen::Vector3d v{2.0, 4.0, 6.0};
+
+            WHEN("Computing the angle between them") {
+                double angle = angle_between(u.normalized(), v.normalized());
+
+                THEN("The angle should be approximately 0") {
+                    CHECK_THAT(angle, WithinAbs(0.0, precision));
+                }
+            }
+        }
+
+        GIVEN("Two anti-parallel vectors") {
+            Eigen::Vector3d u{1.0, 1.0, 1.0};
+            Eigen::Vector3d v{-1.0, -1.0, -1.0};
+
+            WHEN("Computing the angle between them") {
+                double angle = angle_between(u.normalized(), v.normalized());
+
+                THEN("The angle should be approximately pi") {
+                    CHECK_THAT(angle, WithinAbs(pi, precision));
+                }
+            }
+        }
+
+        GIVEN("Two arbitrary vectors") {
+            Eigen::Vector2d u{3.0, 4.0};
+            Eigen::Vector2d v{-4.0, 3.0};
+
+            WHEN("Computing the angle between them") {
+                double angle = angle_between(u.normalized(), v.normalized());
+
+                THEN("The angle should be approximately pi/2") {
+                    CHECK_THAT(angle, WithinAbs(pi / 2.0, precision));
+                }
+            }
+        }
+
+        GIVEN("Two random 2d vectors") {
+            // Seed the random number generator
+            auto seed = GENERATE(take(10, random(uint64_t(0), std::numeric_limits<uint64_t>::max())));
+            // Setup a random number generator
+            std::mt19937 gen{seed};
+            // Draw samples with uniform probability
+            std::uniform_real_distribution<> dist_2pi(0.0, 2.0 * pi);
+            std::uniform_real_distribution<> dist_negpi_pi(-pi, pi);
+
+            // Generate a random vector using polar coordinates on the unit circle
+            double thetaU = dist_2pi(gen);
+            CAPTURE(thetaU);
+            Eigen::Vector2d u{std::cos(thetaU), std::sin(thetaU)};
+
+            // Generate a random angle
+            double thetaVU = dist_negpi_pi(gen);
+            CAPTURE(thetaVU);
+
+            // Construct a second vector using the combined angles to get the other test vector
+            Eigen::Vector2d v{std::cos(thetaU + thetaVU), std::sin(thetaU + thetaVU)};
+
+            WHEN("Computing the angle between them") {
+                double angle = angle_between(u.normalized(), v.normalized());
+
+                THEN("The angle should be approximately the random angle") {
+                    CHECK_THAT(angle, WithinAbs(std::abs(thetaVU), precision));
+                }
+            }
+        }
+
+        GIVEN("Two random 3d vectors") {
+            // Seed the random number generator
+            auto seed = GENERATE(take(10, random(uint64_t(0), std::numeric_limits<uint64_t>::max())));
+            // Setup a random number generator
+            std::mt19937 gen{seed};
+            // Draw samples with uniform probability
+            std::uniform_real_distribution<> dist_2pi(0.0, 2.0 * pi);
+            std::uniform_real_distribution<> dist_pi(0.0, pi);
+            std::uniform_real_distribution<> dist_negpi_pi(-pi, pi);
+
+            // Generate a random vector using spherical coordinates on the unit sphere
+            double phiU = dist_2pi(gen);
+            CAPTURE(phiU);
+            double thetaU = dist_pi(gen);
+            CAPTURE(thetaU);
+            Eigen::Vector3d u{
+                std::sin(thetaU) * std::cos(phiU),
+                std::sin(thetaU) * std::sin(phiU),
+                std::cos(thetaU),
+            };
+
+            // Generate a random vector to find a random orthogonal axis for rotation using spherical coordinates on the
+            // unit sphere
+            double phiR = dist_2pi(gen);
+            CAPTURE(phiR);
+            double thetaR = dist_pi(gen);
+            CAPTURE(thetaR);
+            Eigen::Vector3d r{
+                std::sin(thetaR) * std::cos(phiR),
+                std::sin(thetaR) * std::sin(phiR),
+                std::cos(thetaR),
+            };
+
+            // Generate a random angle for rotation
+            double thetaVU = dist_negpi_pi(gen);
+            CAPTURE(thetaVU);
+
+            // Construct the rotation matrix
+            Eigen::Matrix3d Rvu = Eigen::AngleAxisd(thetaVU, r.cross(u).normalized()).toRotationMatrix();
+
+            // Rotate u by the random rotation matrix to get the other test vector
+            Eigen::Vector3d v = Rvu * u;
+
+            WHEN("Computing the angle between them") {
+                double angle = angle_between(u.normalized(), v.normalized());
+
+                THEN("The angle should be approximately the random angle of rotation") {
+                    CHECK_THAT(angle, WithinAbs(std::abs(thetaVU), precision));
+                }
+            }
+        }
+    }
+
+}  // namespace utility::math::test

--- a/shared/utility/math/angle.hpp
+++ b/shared/utility/math/angle.hpp
@@ -62,6 +62,27 @@ namespace utility::math::angle {
     }
 
     /**
+     *  Finds the angle between two vectors. This method is numerically stable when the vectors are close to parallel.
+     *
+     * @details Based on the implementation found here https://www.plunk.org/~hatch/rightway.html
+     *
+     * @param u A unit vector
+     * @param v A unit vector
+     *
+     * @tparam Derived Type derived from `Eigen::MatrixBase` (i.e. any dense matrix type)
+     * @tparam Scalar  Type of each element stored in the dense matrix (must be a floating point type)
+     *
+     * @return The acute angle in range [0,pi] between two vectors.
+     */
+    template <typename Derived, typename Scalar = typename Derived::Scalar>
+    typename std::enable_if_t<std::is_floating_point_v<Scalar>, Scalar> angle_between(
+        const Eigen::MatrixBase<Derived>& u,
+        const Eigen::MatrixBase<Derived>& v) {
+        return u.dot(v) < Scalar(0) ? std::numbers::pi_v<Scalar> - Scalar(2) * std::asin((-v - u).norm() * Scalar(0.5))
+                                    : Scalar(2) * std::asin((v - u).norm() * Scalar(0.5));
+    }
+
+    /**
      * Calculates the difference between two angles between -pi and pi
      * Method:
      * http://math.stackexchange.com/questions/1158223/solve-for-x-where-a-sin-x-b-cos-x-c-where-a-b-and-c-are-kno


### PR DESCRIPTION
Whenever you would use the acos of the dot product of two unit vectors (e.g.) `std::acos(uABb.dot(uCBb))` due to numerical instability it's possible for the dot product of (near) parallel or antiparalllel vectors to give values slightly above 1.0, when fed into `std::acos` this produces nan values which is bad.
The solution that is often done is to just clamp the output of the dot product between -1 and 1. However, this causes a loss of accuracy  (also you have to do clamping all the time).

A better way is described in https://www.plunk.org/~hatch/rightway.html

This PR adds a function to utility/angle and unit tests to ensure it works properly

### Pre-PR Checklist:

Have you

- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [X] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [ ] Added a descriptive title and relevant labels to the PR

### Optional Headings (delete this heading and the ones you don't use)

### Reviewers, Note

You should go replace every place you `acos` the dot product of two unit vectors with this function!