### PR TITLE
Fix the script skipping issue by not emitting Done in the Servo Providers when already Done 

### DIFF
--- a/module/actuation/Servos/src/Servos.hpp
+++ b/module/actuation/Servos/src/Servos.hpp
@@ -105,7 +105,7 @@ namespace module::actuation {
             // Make an initial count message
             emit<Scope::DIRECT>(std::make_unique<Count<Sequence>>(0));
 
-            on<Provide<Sequence>, Needs<Group>, With<Count<Sequence>>>().then(
+            on<Provide<Sequence>, Needs<Group>, With<Count<Sequence>>, Single>().then(
                 [this](const Sequence& sequence, const RunInfo& info, const Count<Sequence>& count) {
                     // If the user gave us nothing then we are done
                     if (sequence.frames.empty()) {

--- a/module/actuation/Servos/src/Servos.hpp
+++ b/module/actuation/Servos/src/Servos.hpp
@@ -40,7 +40,7 @@ namespace module::actuation {
                                                        servo.command.state.torque));
                 }
                 // If the time to reach the position is over, then stop requesting the position
-                else if (NUClear::clock::now() >= servo.command.time) {
+                else if (NUClear::clock::now() >= servo.command.time && !info.done) {
                     emit<Task>(std::make_unique<Done>());
                 }
             });
@@ -105,7 +105,7 @@ namespace module::actuation {
             // Make an initial count message
             emit<Scope::DIRECT>(std::make_unique<Count<Sequence>>(0));
 
-            on<Provide<Sequence>, Needs<Group>, With<Count<Sequence>>, Single>().then(
+            on<Provide<Sequence>, Needs<Group>, With<Count<Sequence>>>().then(
                 [this](const Sequence& sequence, const RunInfo& info, const Count<Sequence>& count) {
                     // If the user gave us nothing then we are done
                     if (sequence.frames.empty()) {

--- a/module/actuation/Servos/src/Servos.hpp
+++ b/module/actuation/Servos/src/Servos.hpp
@@ -40,6 +40,7 @@ namespace module::actuation {
                                                        servo.command.state.torque));
                 }
                 // If the time to reach the position is over, then stop requesting the position
+                // Only emit Done once, so as not to spam the parent
                 else if (NUClear::clock::now() >= servo.command.time && !info.done) {
                     emit<Task>(std::make_unique<Done>());
                 }

--- a/module/extension/Director/src/information/get_run_info.cpp
+++ b/module/extension/Director/src/information/get_run_info.cpp
@@ -23,9 +23,15 @@ namespace module::extension {
 
     using ::extension::behaviour::RunInfo;
 
-    RunInfo Director::_get_run_info(const uint64_t& /*reaction_id*/) {
+    RunInfo Director::_get_run_info(const uint64_t& reaction_id) {
+        std::lock_guard<std::recursive_mutex> lock(director_mutex);
 
-        return RunInfo{current_run_reason};
+        if (providers.contains(reaction_id)) {
+            return RunInfo{current_run_reason, providers.at(reaction_id)->group.done};
+        }
+
+        log<NUClear::ERROR>("Getting run information for a reaction that isn't a Provider.");
+        return RunInfo{current_run_reason, false};
     }
 
 }  // namespace module::extension

--- a/shared/extension/behaviour/InformationSource.hpp
+++ b/shared/extension/behaviour/InformationSource.hpp
@@ -34,9 +34,9 @@ namespace extension::behaviour {
             OTHER_TRIGGER,
             /// A new task has been given to this provider
             NEW_TASK,
-            /// The provider has been started (will happen on on<Started<X>>)
+            /// The provider has been started (will happen on on<Start<X>>)
             STARTED,
-            /// The provider has been stopped (will happen on on<Stopped<X>>)
+            /// The provider has been stopped (will happen on on<Stop<X>>)
             STOPPED,
             /// A subtask has finished and emitted a Done message
             SUBTASK_DONE,

--- a/shared/extension/behaviour/InformationSource.hpp
+++ b/shared/extension/behaviour/InformationSource.hpp
@@ -46,6 +46,9 @@ namespace extension::behaviour {
 
         /// The reason we executed
         RunReason run_reason;
+
+        /// Whether we are currently in a Done state or not
+        bool done;
     };
 
     /**


### PR DESCRIPTION
Scripts were acting quite strange, such as skipping frames, not going at the right speed.

After having a look, it seems that the Sequence Provider is running the emit Task Group / update Count and emit multiple times for the same group/count. This will restart that script frame each time it does this - if it spams for the whole length of the frame, then the servo won't ever get a chance to move.

It does this because the Group is emitting Done multiple times.

The Group Provider emits Done multiple times because the Servos emit Done multiple times. This is because the Servos run on Sensors (90 times a second) and once the time is over for the servo it keeps emitting Done... 90 times a second. Causing too many triggers of the Group Provider on the Servo's Done.

The solution in this PR is to add information so that the Servo Providers know that they are already in a Done state and don't need to re-emit Done.

I've tested in Webots and it looks good. Real robot looks good too.

### Things left to do

- [x] Test real robot