### PR TITLE
Stop Hcw log spam from Visual Mesh when robot falls over

### DIFF
--- a/module/vision/VisualMesh/src/VisualMesh.cpp
+++ b/module/vision/VisualMesh/src/VisualMesh.cpp
@@ -79,7 +79,8 @@ namespace module::vision {
                         auto result = runner(image, Hcw.cast<float>());
 
                         if (result.indices.empty()) {
-                            log<NUClear::WARN>("Hcw resulted in no mesh points being on-screen.");
+                            // The ground is not visible, hence the mesh cannot be drawn
+                            log<NUClear::TRACE>("Hcw resulted in no mesh points being on-screen.");
                         }
                         else {
                             // Move stuff into the emit message


### PR DESCRIPTION
Every time the robot falls over and can't see the ground, we get a log from the Visual Mesh module spamming to the terminal. This PR lowers the log level to `TRACE` so that it won't spam normally with the current `INFO` log level on the config file.