### PR TITLE
Fix some issues in the uart utility

### DIFF
--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -106,12 +106,7 @@ namespace module::platform::OpenCR {
         on<Configuration>("HardwareIO.yaml").then([this](const Configuration& config) {
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
 
-            // Make sure OpenCR is operating at the correct baud rate (based on config params)
-            if (opencr.connected()) {
-                opencr.close();
-            }
-
-            opencr.open(config["opencr"]["device"], config["opencr"]["baud"]);
+            opencr      = utility::io::uart(config["opencr"]["device"], config["opencr"]["baud"]);
             byte_wait   = config["opencr"]["byte_wait"];
             packet_wait = config["opencr"]["packet_wait"];
 

--- a/shared/utility/io/uart.cpp
+++ b/shared/utility/io/uart.cpp
@@ -2,36 +2,49 @@
 
 #include <cerrno>
 #include <cstring>
+#include <fmt/format.h>
+#include <system_error>
+#include <utility>
+
+extern "C" {
 #include <fcntl.h>
 #include <linux/serial.h>
-#include <stdexcept>
 #include <sys/ioctl.h>
 #include <termios.h>
 #include <unistd.h>
+}
 
 namespace utility::io {
-    uart::uart(const std::string& device, const unsigned int& baud) : device(device) {
-        open(device, baud);
-    }
 
-    void uart::open(const std::string& device, const unsigned int& baud) {
-
-        // Open our file descriptor for read/write with no controlling TTY and nonblock mode
-        fd = ::open(device.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+    uart::uart(const std::string& device, const unsigned int& baud)
+        : device(device), fd(::open(device.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK)) {
 
         if (fd >= 0) {
 
             // We want exclusive access to this uart
-            if (ioctl(fd, TIOCEXCL) == -1) {
-                throw std::runtime_error("Failed to set exclusive access for " + device);
+            if (::ioctl(fd, TIOCEXCL) == -1) {
+                throw std::system_error(errno,
+                                        std::system_category(),
+                                        fmt::format("Failed to set exclusive access for {}", device));
             }
 
             // Set our baud rate
             set_baud(baud);
         }
         else {
-            throw std::runtime_error("Failed to connect to " + device);
+            throw std::system_error(errno, std::system_category(), fmt::format("Failed to connect to {}", device));
         }
+    }
+
+    uart::uart(uart&& other) noexcept : device(std::move(other.device)), fd(std::exchange(other.fd, -1)) {}
+
+    uart& uart::operator=(uart&& rhs) noexcept {
+        if (this != &rhs) {
+            this->close();  // Close if we already have a device open
+            this->device = std::move(rhs.device);
+            this->fd     = std::exchange(rhs.fd, -1);
+        }
+        return *this;
     }
 
     void uart::close() {
@@ -42,7 +55,7 @@ namespace utility::io {
     }
 
     uart::~uart() {
-        close();
+        this->close();
     }
 
     int uart::native_handle() const {
@@ -53,8 +66,8 @@ namespace utility::io {
 
         // Do our setup for the tio settings, you must set BS38400 in order to set custom baud using "baud rate
         // aliasing" http://stackoverflow.com/questions/4968529/how-to-set-baud-rate-to-307200-on-linux
-        termios tio{};
-        memset(&tio, 0, sizeof(tio));
+        ::termios tio{};
+        std::memset(&tio, 0, sizeof(tio));
         // B38400 for aliasing, CS8 (8bit,no parity,1 stopbit), CLOCAL (local connection, no modem control), CREAD
         // (enable receiving characters)
 
@@ -78,38 +91,52 @@ namespace utility::io {
             case 38400: tio.c_cflag = B38400; break;
 #if defined(B57600)
             case 57600: tio.c_cflag = B57600; break;
-#elif defined(B115200)
+#endif
+#if defined(B115200)
             case 115200: tio.c_cflag = B115200; break;
-#elif defined(B230400)
+#endif
+#if defined(B230400)
             case 230400: tio.c_cflag = B230400; break;
-#elif defined(B460800)
+#endif
+#if defined(B460800)
             case 460800: tio.c_cflag = B460800; break;
-#elif defined(B500000)
+#endif
+#if defined(B500000)
             case 500000: tio.c_cflag = B500000; break;
-#elif defined(B576000)
+#endif
+#if defined(B576000)
             case 576000: tio.c_cflag = B576000; break;
-#elif defined(B921600)
+#endif
+#if defined(B921600)
             case 921600: tio.c_cflag = B921600; break;
-#elif defined(B1000000)
+#endif
+#if defined(B1000000)
             case 1000000: tio.c_cflag = B1000000; break;
-#elif defined(B1152000)
+#endif
+#if defined(B1152000)
             case 1152000: tio.c_cflag = B1152000; break;
-#elif defined(B1500000)
+#endif
+#if defined(B1500000)
             case 1500000: tio.c_cflag = B1500000; break;
-#elif defined(B2000000)
+#endif
+#if defined(B2000000)
             case 2000000: tio.c_cflag = B2000000; break;
-#elif defined(B2500000)
+#endif
+#if defined(B2500000)
             case 2500000: tio.c_cflag = B2500000; break;
-#elif defined(B3000000)
+#endif
+#if defined(B3000000)
             case 3000000: tio.c_cflag = B3000000; break;
-#elif defined(B3500000)
+#endif
+#if defined(B3500000)
             case 3500000: tio.c_cflag = B3500000; break;
-#elif defined(B4000000)
+#endif
+#if defined(B4000000)
             case 4000000: tio.c_cflag = B4000000; break;
 #endif
             default:
-                tio.c_cflag |= B38400;
-                known_baud = false;
+                tio.c_cflag = B38400;
+                known_baud  = false;
                 break;
         }
 
@@ -124,53 +151,61 @@ namespace utility::io {
         tio.c_cc[VTIME] = 0;
         tio.c_cc[VMIN]  = 0;
         // Set the settings
-        tcsetattr(fd, TCSANOW, &tio);
+        ::tcsetattr(fd, TCSANOW, &tio);
+
+        // Here we do the baud rate aliasing in order to set the custom baud rate
+        serial_struct serinfo{};
+
+        // Get our serial_info from the system
+        if (::ioctl(fd, TIOCGSERIAL, &serinfo) < 0) {
+            throw std::system_error(errno,
+                                    std::system_category(),
+                                    fmt::format("There was an error setting the baud rate for {}", device));
+        }
 
         if (!known_baud) {
-
-            // Here we do the baud rate aliasing in order to set the custom baud rate
-            serial_struct serinfo{};
-
-            // Get our serial_info from the system
-            if (ioctl(fd, TIOCGSERIAL, &serinfo) < 0) {
-                throw std::runtime_error("There was an error setting the baud rate for " + device);
-            }
-
             // Set the speed flags to "Custom Speed" (clear the existing speed, and set the custom speed flags)
             serinfo.flags &= int(~ASYNC_SPD_MASK);
             serinfo.flags |= ASYNC_SPD_CUST;
-
-            // Set our serial port to use low latency mode (otherwise the USB driver buffers for 16ms before sending
-            // data)
-            serinfo.flags |= ASYNC_LOW_LATENCY;
-
-            // Set our custom divsor for our speed
             serinfo.custom_divisor = int(serinfo.baud_base / baud);
+        }
 
-            // Set our custom speed in the system
-            if (ioctl(fd, TIOCSSERIAL, &serinfo) < 0) {
-                throw std::runtime_error("There was an error setting the baud rate for " + device);
-            }
+        // Set our serial port to use low latency mode
+        // otherwise the USB driver buffers for 16ms before sending data
+        serinfo.flags |= ASYNC_LOW_LATENCY;
+
+        // Set our custom speed in the system
+        if (::ioctl(fd, TIOCSSERIAL, &serinfo) < 0) {
+            throw std::system_error(errno,
+                                    std::system_category(),
+                                    fmt::format("There was an error setting serial info flags for {}", device));
         }
 
         // Flush our connection to remove all existing data
-        tcflush(fd, TCIFLUSH);
+        ::tcflush(fd, TCIFLUSH);
     }
 
     bool uart::connected() const {
-        return !(fcntl(fd, F_GETFL) < 0 && errno == EBADF);
+        return !(::fcntl(fd, F_GETFL) < 0 && errno == EBADF);
     }
 
-    // `read` and `write` can technically be `const`, but that's deceptive because they change the state of the buffer
-    // associated with the fd, so it can be thought of as "changing" the fd
+    // `read` `write` and `get` can technically be `const`, but that's deceptive because they change the state of the
+    // buffer associated with the fd, so it can be thought of as "changing" the fd
     // NOLINTNEXTLINE(readability-make-member-function-const)
     ssize_t uart::read(void* buf, size_t count) {
         return ::read(fd, buf, count);
     }
-
     // NOLINTNEXTLINE(readability-make-member-function-const)
     ssize_t uart::write(const void* buf, size_t count) {
         return ::write(fd, buf, count);
+    }
+
+    int uart::get() {
+        uint8_t c = 0;
+        if (read(&c, 1) == 1) {
+            return c;
+        }
+        return -1;
     }
 
 }  // namespace utility::io

--- a/shared/utility/io/uart.hpp
+++ b/shared/utility/io/uart.hpp
@@ -2,6 +2,7 @@
 #define UTILITY_IO_UART_HPP
 
 #include <string>
+#include <type_traits>
 
 namespace utility::io {
 
@@ -82,6 +83,20 @@ namespace utility::io {
         ssize_t read(void* buf, size_t count);
 
         /**
+         * @brief Read from the device into a structure
+         *
+         * @param data the structure to read in to
+         *
+         * @return the number of bytes that were actually read, or -1 if fail. See ::read
+         *
+         * @note Implementation in header file to stop the compiler from optimising it away
+         */
+        template <typename T>
+        ssize_t read(T& data) requires std::is_trivially_copyable_v<T> {
+            return read(static_cast<void*>(&data), sizeof(T));
+        }
+
+        /**
          * Write bytes to the uart
          *
          * @param buf the buffer to write bytes from
@@ -90,6 +105,20 @@ namespace utility::io {
          * @return the number of bytes that were written
          */
         ssize_t write(const void* buf, size_t count);
+
+        /**
+         * @brief Write bytes to the uart
+         *
+         * @param data the data to write
+         *
+         * @return the number of bytes that were written
+         *
+         * @note Implementation in header file to stop the compiler from optimising it away
+         */
+        template <typename T>
+        ssize_t write(const T& data) requires std::is_trivially_copyable_v<T> {
+            return write(static_cast<const void*>(&data), sizeof(T));
+        }
 
         /**
          * Read a single character from the uart device, returning -1 if there is no data

--- a/shared/utility/io/uart.hpp
+++ b/shared/utility/io/uart.hpp
@@ -2,20 +2,19 @@
 #define UTILITY_IO_UART_HPP
 
 #include <string>
-#include <unistd.h>
 
 namespace utility::io {
 
     /**
-     * @brief Class for managing a connection to a serial device
+     * Class for managing a connection to a serial device
      */
     class uart {
     private:
-        std::string device;
+        std::string device{};
         int fd = -1;
 
         /**
-         * @brief Set the baud rate of the device
+         * Set the baud rate of the device
          *
          * @param baud the baud rate to set
          */
@@ -23,17 +22,12 @@ namespace utility::io {
 
     public:
         /**
-         * @brief The type that is read by this device
-         */
-        using char_type = char;
-
-        /**
-         * @brief Construct a new unconnected uart class
+         * Construct a new unconnected uart class
          */
         uart() = default;
 
         /**
-         * @brief Create a new uart class that is connected to the device `device`
+         * Create a new uart class that is connected to the device `device`
          *
          * @param device the file path of the device to connect to
          * @param int the baud rate to connect to
@@ -41,40 +35,44 @@ namespace utility::io {
         uart(const std::string& device, const unsigned int& baud_rate = 57600);
 
         /**
-         * @brief We can't copy these because otherwise we might close the device twice
+         * Move construct a new uart class
+         *
+         * @param other the uart class to move from
          */
+        uart(uart&& other) noexcept;
+
+        /**
+         * Move assign a new uart class
+         *
+         * @param rhs the uart class to move from
+         */
+        uart& operator=(uart&& rhs) noexcept;
+
+        // We can't copy these because otherwise we might close the device twice
         uart(const uart& uart)            = delete;
         uart& operator=(const uart& uart) = delete;
 
         /**
-         * @brief Moving these will call the destructors, closing the fd before trying to use it again
-         * TODO(KipHamiltons) implement an RAII fd utility, which would allow the uarts to be moved without that issue
-         */
-        uart(uart&&)                 = delete;
-        uart& operator=(uart&& uart) = delete;
-
-
-        /**
-         * @brief Destructor, close the device on destruction
+         * Destructor, close the device on destruction
          */
         ~uart();
 
         /**
-         * @brief Get the native file descriptor used by this class. Useful for using in poll or select.
+         * Get the native file descriptor used by this class. Useful for using in poll or select.
          *
          * @return the native file descriptor
          */
         [[nodiscard]] int native_handle() const;
 
         /**
-         * @brief Return true if the connection is valid
+         * Return true if the connection is valid
          *
          * @return true if the uart is connected and working, false otherwise
          */
         [[nodiscard]] bool connected() const;
 
         /**
-         * @brief Read from the device into a buffer
+         * Read from the device into a buffer
          *
          * @param buf buffer to read into
          * @param count the number of bytes to read
@@ -84,21 +82,7 @@ namespace utility::io {
         ssize_t read(void* buf, size_t count);
 
         /**
-         * @brief Read from the device into a structure
-         *
-         * @param data the structure to read in to
-         *
-         * @return the number of bytes that were actually read, or -1 if fail. See ::read
-         *
-         * @note Implementation in header file to stop the compiler from optimising it away
-         */
-        template <typename T>
-        ssize_t read(T& data) {
-            return ::read(fd, static_cast<void*>(&data), sizeof(T));
-        }
-
-        /**
-         * @brief Write bytes to the uart
+         * Write bytes to the uart
          *
          * @param buf the buffer to write bytes from
          * @param count the number of bytes to write
@@ -108,29 +92,14 @@ namespace utility::io {
         ssize_t write(const void* buf, size_t count);
 
         /**
-         * @brief Write bytes to the uart
+         * Read a single character from the uart device, returning -1 if there is no data
          *
-         * @param data the data to write
-         *
-         * @return the number of bytes that were written
-         *
-         * @note Implementation in header file to stop the compiler from optimising it away
+         * @return the character read from the device, or -1 if there is no data
          */
-        template <typename T>
-        ssize_t write(const T& data) {
-            return ::write(fd, static_cast<const void*>(&data), sizeof(T));
-        }
+        [[nodiscard]] int get();
 
         /**
-         * @brief Open the uart for the given file descriptor. Closes any currently open file.
-         *
-         * @param device the path to the device to open
-         * @param int the baud rate to open with
-         */
-        void open(const std::string& device, const unsigned int& baud_rate = 57600);
-
-        /**
-         * @brief Close the open file descriptor then reset fd = -1
+         * Close the open file descriptor then reset fd = -1
          */
         void close();
     };


### PR DESCRIPTION
The UART utility had a few problems that needed fixing. This combines them all into one PR

Fixes include:

- Making the code clang-tidy conformant
- The extra static baud rate flags actually work since they don't have `elif`
- the low latency flag is always applied regardless of if it's using a custom baud or not
- make uart classes movable