### PR TITLE
Add ability to chat with ChatGPT using mic (speech-to-text)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -313,6 +313,8 @@ RUN install-from-source https://github.com/stevengj/nlopt/archive/refs/tags/v2.7
 RUN install-from-source https://github.com/Tom0Brien/tinyrobotics/archive/refs/tags/0.0.1.tar.gz \
     -DBUILD_TESTS=OFF
 
+RUN install-package lame
+
 #######################################
 ### ADD NEW PROGRAMS/LIBRARIES HERE ###
 #######################################

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -276,6 +276,7 @@ RUN install-from-source https://github.com/ianlancetaylor/libbacktrace/archive/8
 # Alsa and espeak
 RUN install-from-source https://github.com/alsa-project/alsa-lib/archive/refs/tags/v1.2.7.2.tar.gz \
     --without-debug
+RUN install-package alsa-utils
 RUN install-from-source https://github.com/espeak-ng/pcaudiolib/releases/download/1.2/pcaudiolib-1.2.tar.gz
 # Need to run ldconfig before building eSpeak because ...... ¯\_(ツ)_/¯
 RUN ldconfig && \
@@ -324,6 +325,7 @@ RUN pip install \
     stringcase \
     Pillow \
     protobuf==4.21.2 \
+    mycroft-mimic3-tts \
     tqdm
 
 # Install tools needed for building individual modules as well as development tools

--- a/module/purpose/Tester/data/config/Tester.yaml
+++ b/module/purpose/Tester/data/config/Tester.yaml
@@ -18,7 +18,9 @@ tasks:
 
   # Skills
   say_priority: 0
-  gpt_priority: 0
+  chatgpt_priority: 0
+  audiogpt_priority: 0
+
 
 # Position to walk to when emitting WalkToFieldPosition [x, y, theta]
 walk_to_field_position_position: [0, 0, 0]
@@ -26,5 +28,6 @@ walk_to_field_position_position: [0, 0, 0]
 # What to have the robot say when speaking
 say_text: "Hello!"
 
-# What to prompt openai gpt with
-gpt_prompt: "Hello!"
+# What to prompt openai chatgpt with
+chatgpt_prompt: "Hello!"
+audiogpt_listen_duration: 10

--- a/module/purpose/Tester/data/config/Tester.yaml
+++ b/module/purpose/Tester/data/config/Tester.yaml
@@ -16,5 +16,11 @@ tasks:
   kick_to_priority: 0
   look_around_priority: 0
 
+  # Skills
+  say_priority: 1
+
 # Position to walk to when emitting WalkToFieldPosition [x, y, theta]
 walk_to_field_position_position: [0, 0, 0]
+
+# What to have the robot say when speaking
+say_text: "Hello!"

--- a/module/purpose/Tester/data/config/Tester.yaml
+++ b/module/purpose/Tester/data/config/Tester.yaml
@@ -17,10 +17,14 @@ tasks:
   look_around_priority: 0
 
   # Skills
-  say_priority: 1
+  say_priority: 0
+  gpt_priority: 0
 
 # Position to walk to when emitting WalkToFieldPosition [x, y, theta]
 walk_to_field_position_position: [0, 0, 0]
 
 # What to have the robot say when speaking
 say_text: "Hello!"
+
+# What to prompt openai gpt with
+gpt_prompt: "Hello!"

--- a/module/purpose/Tester/src/Tester.cpp
+++ b/module/purpose/Tester/src/Tester.cpp
@@ -5,6 +5,7 @@
 
 #include "message/planning/KickTo.hpp"
 #include "message/planning/LookAround.hpp"
+#include "message/skill/GPT.hpp"
 #include "message/skill/Say.hpp"
 #include "message/strategy/AlignBallToGoal.hpp"
 #include "message/strategy/FindFeature.hpp"
@@ -23,6 +24,7 @@ namespace module::purpose {
 
     using message::planning::KickTo;
     using message::planning::LookAround;
+    using message::skill::GPTRequest;
     using message::skill::Say;
     using message::strategy::AlignBallToGoal;
     using message::strategy::FindBall;
@@ -50,8 +52,10 @@ namespace module::purpose {
             cfg.look_around_priority            = config["tasks"]["look_around_priority"].as<int>();
             cfg.stand_still_priority            = config["tasks"]["stand_still_priority"].as<int>();
             cfg.say_priority                    = config["tasks"]["say_priority"].as<int>();
+            cfg.gpt_priority                    = config["tasks"]["gpt_priority"].as<int>();
             cfg.walk_to_field_position_position = config["walk_to_field_position_position"].as<Expression>();
             cfg.say_text                        = config["say_text"].as<std::string>();
+            cfg.gpt_prompt                      = config["gpt_prompt"].as<std::string>();
         });
 
         on<Startup>().then([this] {
@@ -90,6 +94,9 @@ namespace module::purpose {
             }
             if (cfg.say_priority > 0) {
                 emit<Task>(std::make_unique<Say>(cfg.say_text), cfg.say_priority);
+            }
+            if (cfg.gpt_priority > 0) {
+                emit<Task>(std::make_unique<GPTRequest>(cfg.gpt_prompt), cfg.gpt_priority);
             }
         });
     }

--- a/module/purpose/Tester/src/Tester.cpp
+++ b/module/purpose/Tester/src/Tester.cpp
@@ -96,7 +96,7 @@ namespace module::purpose {
                 emit<Task>(std::make_unique<Say>(cfg.say_text), cfg.say_priority);
             }
             if (cfg.gpt_priority > 0) {
-                emit<Task>(std::make_unique<GPTRequest>(cfg.gpt_prompt), cfg.gpt_priority);
+                emit<Task>(std::make_unique<GPTRequest>(cfg.gpt_prompt, true), cfg.gpt_priority);
             }
         });
     }

--- a/module/purpose/Tester/src/Tester.cpp
+++ b/module/purpose/Tester/src/Tester.cpp
@@ -24,7 +24,8 @@ namespace module::purpose {
 
     using message::planning::KickTo;
     using message::planning::LookAround;
-    using message::skill::GPTRequest;
+    using message::skill::GPTAudioRequest;
+    using message::skill::GPTChatRequest;
     using message::skill::Say;
     using message::strategy::AlignBallToGoal;
     using message::strategy::FindBall;
@@ -52,10 +53,12 @@ namespace module::purpose {
             cfg.look_around_priority            = config["tasks"]["look_around_priority"].as<int>();
             cfg.stand_still_priority            = config["tasks"]["stand_still_priority"].as<int>();
             cfg.say_priority                    = config["tasks"]["say_priority"].as<int>();
-            cfg.gpt_priority                    = config["tasks"]["gpt_priority"].as<int>();
+            cfg.chatgpt_priority                = config["tasks"]["chatgpt_priority"].as<int>();
+            cfg.audiogpt_priority               = config["tasks"]["audiogpt_priority"].as<int>();
+            cfg.audiogpt_listen_duration        = config["audiogpt_listen_duration"].as<int>();
             cfg.walk_to_field_position_position = config["walk_to_field_position_position"].as<Expression>();
             cfg.say_text                        = config["say_text"].as<std::string>();
-            cfg.gpt_prompt                      = config["gpt_prompt"].as<std::string>();
+            cfg.chatgpt_prompt                  = config["chatgpt_prompt"].as<std::string>();
         });
 
         on<Startup>().then([this] {
@@ -95,8 +98,12 @@ namespace module::purpose {
             if (cfg.say_priority > 0) {
                 emit<Task>(std::make_unique<Say>(cfg.say_text), cfg.say_priority);
             }
-            if (cfg.gpt_priority > 0) {
-                emit<Task>(std::make_unique<GPTRequest>(cfg.gpt_prompt, true), cfg.gpt_priority);
+            if (cfg.chatgpt_priority > 0) {
+                emit<Task>(std::make_unique<GPTChatRequest>(cfg.chatgpt_prompt, true), cfg.chatgpt_priority);
+            }
+            if (cfg.audiogpt_priority > 0) {
+                emit<Task>(std::make_unique<GPTAudioRequest>(true, true, cfg.audiogpt_listen_duration),
+                           cfg.audiogpt_priority);
             }
         });
     }

--- a/module/purpose/Tester/src/Tester.cpp
+++ b/module/purpose/Tester/src/Tester.cpp
@@ -5,6 +5,7 @@
 
 #include "message/planning/KickTo.hpp"
 #include "message/planning/LookAround.hpp"
+#include "message/skill/Say.hpp"
 #include "message/strategy/AlignBallToGoal.hpp"
 #include "message/strategy/FindFeature.hpp"
 #include "message/strategy/KickToGoal.hpp"
@@ -22,6 +23,7 @@ namespace module::purpose {
 
     using message::planning::KickTo;
     using message::planning::LookAround;
+    using message::skill::Say;
     using message::strategy::AlignBallToGoal;
     using message::strategy::FindBall;
     using message::strategy::KickToGoal;
@@ -47,7 +49,9 @@ namespace module::purpose {
             cfg.kick_to_priority                = config["tasks"]["kick_to_priority"].as<int>();
             cfg.look_around_priority            = config["tasks"]["look_around_priority"].as<int>();
             cfg.stand_still_priority            = config["tasks"]["stand_still_priority"].as<int>();
+            cfg.say_priority                    = config["tasks"]["say_priority"].as<int>();
             cfg.walk_to_field_position_position = config["walk_to_field_position_position"].as<Expression>();
+            cfg.say_text                        = config["say_text"].as<std::string>();
         });
 
         on<Startup>().then([this] {
@@ -83,6 +87,9 @@ namespace module::purpose {
             }
             if (cfg.stand_still_priority > 0) {
                 emit<Task>(std::make_unique<StandStill>(), cfg.stand_still_priority);
+            }
+            if (cfg.say_priority > 0) {
+                emit<Task>(std::make_unique<Say>(cfg.say_text), cfg.say_priority);
             }
         });
     }

--- a/module/purpose/Tester/src/Tester.hpp
+++ b/module/purpose/Tester/src/Tester.hpp
@@ -32,12 +32,14 @@ namespace module::purpose {
             int stand_still_priority = 0;
             /// @brief Priority of Say task
             int say_priority = 0;
-
+            /// @brief Priority of ChatGPT task
+            int gpt_priority = 0;
             /// @brief Position to walk to when emitting WalkToFieldPosition task
             Eigen::Vector3f walk_to_field_position_position = Eigen::Vector3f::Zero();
-
             /// @brief Text to say when emitting Say task
             std::string say_text = "";
+            /// @brief Text to prompt ChatGPT with
+            std::string gpt_prompt = "";
         } cfg;
 
     public:

--- a/module/purpose/Tester/src/Tester.hpp
+++ b/module/purpose/Tester/src/Tester.hpp
@@ -33,13 +33,17 @@ namespace module::purpose {
             /// @brief Priority of Say task
             int say_priority = 0;
             /// @brief Priority of ChatGPT task
-            int gpt_priority = 0;
+            int chatgpt_priority = 0;
+            /// @brief Priority of AudioGPT task
+            int audiogpt_priority = 0;
             /// @brief Position to walk to when emitting WalkToFieldPosition task
             Eigen::Vector3f walk_to_field_position_position = Eigen::Vector3f::Zero();
             /// @brief Text to say when emitting Say task
             std::string say_text = "";
             /// @brief Text to prompt ChatGPT with
-            std::string gpt_prompt = "";
+            std::string chatgpt_prompt = "";
+            /// @brief Duration to listen for audio when emitting AudioGPT task
+            int audiogpt_listen_duration = 0;
         } cfg;
 
     public:

--- a/module/purpose/Tester/src/Tester.hpp
+++ b/module/purpose/Tester/src/Tester.hpp
@@ -30,9 +30,14 @@ namespace module::purpose {
             int look_around_priority = 0;
             /// @brief Priority of StandStill task
             int stand_still_priority = 0;
+            /// @brief Priority of Say task
+            int say_priority = 0;
 
             /// @brief Position to walk to when emitting WalkToFieldPosition task
             Eigen::Vector3f walk_to_field_position_position = Eigen::Vector3f::Zero();
+
+            /// @brief Text to say when emitting Say task
+            std::string say_text = "";
         } cfg;
 
     public:

--- a/module/skill/GPT/CMakeLists.txt
+++ b/module/skill/GPT/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Build our NUClear module
+nuclear_module()

--- a/module/skill/GPT/README.md
+++ b/module/skill/GPT/README.md
@@ -1,0 +1,22 @@
+# GPT
+
+## Description
+
+A module that integrates with OpenAI's GPT-3.5 model to send text prompts and receive generated responses.
+
+## Usage
+
+Include this module to allow your system to interact with OpenAI's GPT for natural language processing tasks.
+
+## Consumes
+
+- `message::skill::GPTRequest`: A request containing text that needs to be processed by GPT.
+
+## Emits
+
+- `message::skill::GPTResponse`: A response from GPT containing the generated text based on the input request.
+
+## Dependencies
+
+- **nlohmann::json**: For JSON data serialization and deserialization.
+- **utility::openai::openai**: A utility to interface with the OpenAI API.

--- a/module/skill/GPT/README.md
+++ b/module/skill/GPT/README.md
@@ -10,7 +10,7 @@ Include this module to allow your system to interact with OpenAI's GPT for natur
 
 ## Consumes
 
-- `message::skill::GPTRequest`: A request containing text that needs to be processed by GPT.
+- `message::skill::GPTChatRequest`: A request containing text that needs to be processed by GPT.
 
 ## Emits
 

--- a/module/skill/GPT/data/config/GPT.yaml
+++ b/module/skill/GPT/data/config/GPT.yaml
@@ -1,0 +1,5 @@
+# Controls the minimum log level that NUClear log will display
+log_level: INFO
+
+# The OpenAI API costs $$$ to use, so we need to use a key to access it. DO NOT COMMIT THIS
+openai_api_key: ""

--- a/module/skill/GPT/src/GPT.cpp
+++ b/module/skill/GPT/src/GPT.cpp
@@ -1,0 +1,46 @@
+#include "GPT.hpp"
+
+#include "extension/Configuration.hpp"
+
+#include "message/skill/GPT.hpp"
+
+#include "utility/openai/openai.hpp"
+
+namespace module::skill {
+
+    using extension::Configuration;
+    using message::skill::GPTRequest;
+    using message::skill::GPTResponse;
+
+    GPT::GPT(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
+
+        on<Configuration>("GPT.yaml").then([this](const Configuration& config) {
+            // Use configuration here from file GPT.yaml
+            this->log_level    = config["log_level"].as<NUClear::LogLevel>();
+            cfg.openai_api_key = config["openai_api_key"].as<std::string>();
+        });
+
+        on<Startup>().then([this] {
+            // Configure the OpenAI API key
+            utility::openai::start(cfg.openai_api_key);
+        });
+
+        on<Provide<GPTRequest>>().then([this](const GPTRequest& chatgpt_request, const RunInfo& info) {
+            if (info.run_reason == RunInfo::NEW_TASK) {
+                // Send request to OpenAI API
+                nlohmann::json request = {
+                    {"model", "gpt-3.5-turbo"},
+                    {"messages", nlohmann::json::array({{{"role", "user"}, {"content", chatgpt_request.text}}})},
+                    {"max_tokens", 100},
+                    {"temperature", 0}};
+                auto chat = utility::openai::chat().create(request);
+
+                std::string response = chat["choices"][0]["message"]["content"].get<std::string>();
+                log<NUClear::DEBUG>("Response: {}", response);
+
+                emit(std::make_unique<GPTResponse>(response));
+            }
+        });
+    }
+
+}  // namespace module::skill

--- a/module/skill/GPT/src/GPT.cpp
+++ b/module/skill/GPT/src/GPT.cpp
@@ -10,7 +10,8 @@
 namespace module::skill {
 
     using extension::Configuration;
-    using message::skill::GPTRequest;
+    using message::skill::GPTAudioRequest;
+    using message::skill::GPTChatRequest;
     using message::skill::Say;
 
     GPT::GPT(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
@@ -26,7 +27,7 @@ namespace module::skill {
             utility::openai::start(cfg.openai_api_key);
         });
 
-        on<Provide<GPTRequest>>().then([this](const GPTRequest& gpt_request, const RunInfo& info) {
+        on<Provide<GPTChatRequest>>().then([this](const GPTChatRequest& gpt_request, const RunInfo& info) {
             if (info.run_reason == RunInfo::NEW_TASK) {
                 // Send request to OpenAI API
                 nlohmann::json request = {
@@ -37,10 +38,40 @@ namespace module::skill {
                 auto chat = utility::openai::chat().create(request);
 
                 std::string response = chat["choices"][0]["message"]["content"].get<std::string>();
-                log<NUClear::DEBUG>("Response: {}", response);
+                log<NUClear::DEBUG>("Response: ", response);
 
                 if (gpt_request.speak_response) {
                     emit<Task>(std::make_unique<Say>(response));
+                }
+            }
+        });
+
+        on<Provide<GPTAudioRequest>>().then([this](const GPTAudioRequest& gpt_request, const RunInfo& info) {
+            if (info.run_reason == RunInfo::NEW_TASK) {
+                // Record audio for requested time
+                std::string cmd = "arecord -d " + std::to_string(gpt_request.record_time) + " -f cd -t wav audio.wav";
+
+                // Execute the command to record audio and convert it to MP3
+                log<NUClear::INFO>("Recording audio...");
+                system(cmd.c_str());
+                log<NUClear::INFO>("Finished recording audio.");
+                // Convert audio to mp3
+                system("lame audio.wav audio.mp3");
+                log<NUClear::INFO>("Converted audio to mp3.");
+
+                // Send request to OpenAI API
+                auto audio = utility::openai::audio().transcribe(R"(
+                    {
+                    "file": "audio.mp3",
+                    "model": "whisper-1"
+                    }
+                )"_json);
+
+                std::string transcription = audio["text"].get<std::string>();
+                log<NUClear::DEBUG>("Transcription: ", transcription);
+
+                if (gpt_request.send_to_chat) {
+                    emit<Task>(std::make_unique<GPTChatRequest>(transcription, gpt_request.speak_response));
                 }
             }
         });

--- a/module/skill/GPT/src/GPT.hpp
+++ b/module/skill/GPT/src/GPT.hpp
@@ -1,0 +1,25 @@
+#ifndef MODULE_SKILL_GPT_HPP
+#define MODULE_SKILL_GPT_HPP
+
+#include <nuclear>
+
+#include "extension/Behaviour.hpp"
+
+namespace module::skill {
+
+    class GPT : public ::extension::behaviour::BehaviourReactor {
+    private:
+        /// @brief Stores configuration values
+        struct Config {
+            /// @brief OpenAI API key
+            std::string openai_api_key = "";
+        } cfg;
+
+    public:
+        /// @brief Called by the powerplant to build and setup the GPT reactor.
+        explicit GPT(std::unique_ptr<NUClear::Environment> environment);
+    };
+
+}  // namespace module::skill
+
+#endif  // MODULE_SKILL_GPT_HPP

--- a/module/skill/Say/CMakeLists.txt
+++ b/module/skill/Say/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Build our NUClear module
+nuclear_module()

--- a/module/skill/Say/README.md
+++ b/module/skill/Say/README.md
@@ -1,0 +1,22 @@
+# Say
+
+## Description
+
+Module that enables the robot to vocalize specified text using a text-to-speech tool and optionally perform a nodding gesture to indicate speaking.
+
+## Usage
+
+Include this module whenever the robot needs to vocalize or acknowledge messages via speech-like actions.
+
+## Consumes
+
+- `message::skill::Say`: A Task requesting to vocalize a text string. Contains the text to be spoken and an optional nod gesture request.
+
+## Emits
+
+- `message::actuation::LimbsSequence`: A Task to instruct the robot's limbs to perform specific sequences, such as a nodding gesture.
+
+## Dependencies
+
+- **mimic3**: External python based command-line text-to-speech tool.
+- **aplay**: Command-line sound player for Linux.

--- a/module/skill/Say/data/config/Say.yaml
+++ b/module/skill/Say/data/config/Say.yaml
@@ -1,0 +1,2 @@
+# Controls the minimum log level that NUClear log will display
+log_level: INFO

--- a/module/skill/Say/src/Say.cpp
+++ b/module/skill/Say/src/Say.cpp
@@ -29,8 +29,17 @@ namespace module::skill {
             // Only say text if it is a new task
             if (info.run_reason == RunInfo::NEW_TASK) {
                 // Play the requested audio using python command-line tool mimic3 and aplay
-                log<NUClear::DEBUG>("Saying: {}", say.text);
-                system(std::string("mimic3 '" + say.text + "' | aplay").c_str());
+                // Sanitize the text to remove special characters which could break the command
+                std::string sanitized_text         = say.text;
+                const std::string chars_to_replace = "'\"`|;&$\\";
+                for (char c : chars_to_replace) {
+                    std::replace(sanitized_text.begin(),
+                                 sanitized_text.end(),
+                                 c,
+                                 ' ');  // Replacing each dangerous char with space
+                }
+                log<NUClear::DEBUG>("Saying: ", sanitized_text);
+                system(std::string("mimic3 '" + sanitized_text + "' | aplay").c_str());
             }
 
             // Nod head to indicate that the robot is "talking"

--- a/module/skill/Say/src/Say.cpp
+++ b/module/skill/Say/src/Say.cpp
@@ -29,6 +29,7 @@ namespace module::skill {
             // Only say text if it is a new task
             if (info.run_reason == RunInfo::NEW_TASK) {
                 // Play the requested audio using python command-line tool mimic3 and aplay
+                log<NUClear::DEBUG>("Saying: {}", say.text);
                 system(std::string("mimic3 '" + say.text + "' | aplay").c_str());
             }
 

--- a/module/skill/Say/src/Say.cpp
+++ b/module/skill/Say/src/Say.cpp
@@ -1,0 +1,42 @@
+#include "Say.hpp"
+
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+#include "extension/Configuration.hpp"
+
+#include "message/actuation/Limbs.hpp"
+#include "message/skill/Say.hpp"
+
+#include "utility/skill/Script.hpp"
+
+namespace module::skill {
+
+    using extension::Configuration;
+    using message::actuation::LimbsSequence;
+    using utility::skill::load_script;
+    using SayTask = message::skill::Say;
+
+    Say::Say(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
+
+        on<Configuration>("Say.yaml").then([this](const Configuration& config) {
+            // Use configuration here from file Say.yaml
+            this->log_level = config["log_level"].as<NUClear::LogLevel>();
+        });
+
+        on<Provide<SayTask>>().then([this](const SayTask& say, const RunInfo& info) {
+            // Only say text if it is a new task
+            if (info.run_reason == RunInfo::NEW_TASK) {
+                // Play the requested audio using python command-line tool mimic3 and aplay
+                system(std::string("mimic3 '" + say.text + "' | aplay").c_str());
+            }
+
+            // Nod head to indicate that the robot is "talking"
+            if (say.nod) {
+                emit<Task>(load_script<LimbsSequence>("NodYes.yaml"));
+            }
+        });
+    }
+
+}  // namespace module::skill

--- a/module/skill/Say/src/Say.hpp
+++ b/module/skill/Say/src/Say.hpp
@@ -1,0 +1,24 @@
+#ifndef MODULE_SKILL_SAY_HPP
+#define MODULE_SKILL_SAY_HPP
+
+#include <nuclear>
+
+#include "extension/Behaviour.hpp"
+#include "extension/Configuration.hpp"
+
+namespace module::skill {
+
+    class Say : public ::extension::behaviour::BehaviourReactor {
+    private:
+        /// @brief Stores configuration values
+        struct Config {
+        } cfg;
+
+    public:
+        /// @brief Called by the powerplant to build and setup the Say reactor.
+        explicit Say(std::unique_ptr<NUClear::Environment> environment);
+    };
+
+}  // namespace module::skill
+
+#endif  // MODULE_SKILL_SAY_HPP

--- a/roles/webots/behaviour.role
+++ b/roles/webots/behaviour.role
@@ -35,6 +35,7 @@ nuclear_role(
   skill::GetUp
   skill::Look
   skill::Dive
+  skill::Say
   # Planners
   planning::PlanWalkPath
   planning::PlanLook

--- a/roles/webots/behaviour.role
+++ b/roles/webots/behaviour.role
@@ -36,6 +36,7 @@ nuclear_role(
   skill::Look
   skill::Dive
   skill::Say
+  skill::GPT
   # Planners
   planning::PlanWalkPath
   planning::PlanLook

--- a/shared/message/skill/GPT.proto
+++ b/shared/message/skill/GPT.proto
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2023 NUbots <nubots@nubots.net>
+ */
+syntax = "proto3";
+
+package message.skill;
+
+message GPTRequest {
+    /// Prompt for GPT
+    string text = 1;
+}
+
+message GPTResponse {
+    /// Response from GPT
+    string text = 1;
+}

--- a/shared/message/skill/GPT.proto
+++ b/shared/message/skill/GPT.proto
@@ -23,9 +23,6 @@ package message.skill;
 message GPTRequest {
     /// Prompt for GPT
     string text = 1;
-}
-
-message GPTResponse {
-    /// Response from GPT
-    string text = 1;
+    /// Whether or not to speak the response
+    bool speak_response = 2;
 }

--- a/shared/message/skill/GPT.proto
+++ b/shared/message/skill/GPT.proto
@@ -20,9 +20,18 @@ syntax = "proto3";
 
 package message.skill;
 
-message GPTRequest {
+message GPTChatRequest {
     /// Prompt for GPT
     string text = 1;
     /// Whether or not to speak the response
     bool speak_response = 2;
+}
+
+message GPTAudioRequest {
+    /// Whether or not to send the transcription to chat after
+    bool send_to_chat = 1;
+    /// Whether or not to speak the chat response
+    bool speak_response = 2;
+    /// Time to record audio for
+    int32 record_time = 4;
 }

--- a/shared/message/skill/Say.proto
+++ b/shared/message/skill/Say.proto
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the NUbots Codebase.
+ *
+ * The NUbots Codebase is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The NUbots Codebase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the NUbots Codebase.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2023 NUbots <nubots@nubots.net>
+ */
+syntax = "proto3";
+
+package message.skill;
+
+message Say {
+    /// Text for robot to say
+    string text = 1;
+    /// Whether or not to nod while saying text
+    bool nod = 2;
+}

--- a/shared/utility/libraries.cmake
+++ b/shared/utility/libraries.cmake
@@ -28,6 +28,9 @@ target_link_libraries(nuclear_utility PUBLIC tinyrobotics::tinyrobotics)
 find_package(NLopt REQUIRED)
 target_link_libraries(nuclear_utility PUBLIC NLopt::nlopt)
 
+find_package(CURL REQUIRED)
+target_link_libraries(nuclear_utility PUBLIC CURL::libcurl)
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   find_package(libbacktrace REQUIRED)
   target_link_libraries(nuclear_utility PUBLIC libbacktrace::libbacktrace ${CMAKE_DL_LIBS})

--- a/shared/utility/openai/openai.hpp
+++ b/shared/utility/openai/openai.hpp
@@ -1,0 +1,858 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2023 Olrea, Florian Dang
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef UTILITY_OPENAI_OPENAI_HPP
+#define UTILITY_OPENAI_OPENAI_HPP
+
+
+#if OPENAI_VERBOSE_OUTPUT
+    #pragma message("OPENAI_VERBOSE_OUTPUT is ON")
+#endif
+
+#include <cstdlib>
+#include <curl/curl.h>
+#include <iostream>
+#include <json.hpp>  // nlohmann/json
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace utility::openai {
+
+    namespace _detail {
+
+        // Json alias
+        using Json = nlohmann::json;
+
+        struct Response {
+            std::string text;
+            bool is_error;
+            std::string error_message;
+        };
+
+        // Simple curl Session inspired by CPR
+        class Session {
+        public:
+            Session(bool throw_exception) : throw_exception_{throw_exception} {
+                initCurl();
+                ignoreSSL();
+            }
+
+            Session(bool throw_exception, std::string proxy_url) : throw_exception_{throw_exception} {
+                initCurl();
+                ignoreSSL();
+                setProxyUrl(proxy_url);
+            }
+
+            ~Session() {
+                curl_easy_cleanup(curl_);
+                curl_global_cleanup();
+                if (mime_form_ != nullptr) {
+                    curl_mime_free(mime_form_);
+                }
+            }
+
+            void initCurl() {
+                curl_global_init(CURL_GLOBAL_ALL);
+                curl_ = curl_easy_init();
+                if (curl_ == nullptr) {
+                    throw std::runtime_error("curl cannot initialize");  // here we throw it shouldn't happen
+                }
+            }
+
+            void ignoreSSL() {
+                curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYPEER, 0L);
+            }
+
+            void setUrl(const std::string& url) {
+                url_ = url;
+            }
+
+            void setToken(const std::string& token, const std::string& organization) {
+                token_        = token;
+                organization_ = organization;
+            }
+            void setProxyUrl(const std::string& url) {
+                proxy_url_ = url;
+                curl_easy_setopt(curl_, CURLOPT_PROXY, proxy_url_.c_str());
+            }
+
+            void setBody(const std::string& data);
+            void setMultiformPart(const std::pair<std::string, std::string>& filefield_and_filepath,
+                                  const std::map<std::string, std::string>& fields);
+
+            Response getPrepare();
+            Response postPrepare(const std::string& contentType = "");
+            Response deletePrepare();
+            Response makeRequest(const std::string& contentType = "");
+            std::string easyEscape(const std::string& text);
+
+        private:
+            static size_t writeFunction(void* ptr, size_t size, size_t nmemb, std::string* data) {
+                data->append((char*) ptr, size * nmemb);
+                return size * nmemb;
+            }
+
+        private:
+            CURL* curl_;
+            CURLcode res_;
+            curl_mime* mime_form_ = nullptr;
+            std::string url_;
+            std::string proxy_url_;
+            std::string token_;
+            std::string organization_;
+
+            bool throw_exception_;
+            std::mutex mutex_request_;
+        };
+
+        inline void Session::setBody(const std::string& data) {
+            if (curl_) {
+                curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, data.length());
+                curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, data.data());
+            }
+        }
+
+        inline void Session::setMultiformPart(const std::pair<std::string, std::string>& fieldfield_and_filepath,
+                                              const std::map<std::string, std::string>& fields) {
+            // https://curl.se/libcurl/c/curl_mime_init.html
+            if (curl_) {
+                if (mime_form_ != nullptr) {
+                    curl_mime_free(mime_form_);
+                    mime_form_ = nullptr;
+                }
+                curl_mimepart* field = nullptr;
+
+                mime_form_ = curl_mime_init(curl_);
+
+                field = curl_mime_addpart(mime_form_);
+                curl_mime_name(field, fieldfield_and_filepath.first.c_str());
+                curl_mime_filedata(field, fieldfield_and_filepath.second.c_str());
+
+                for (const auto& field_pair : fields) {
+                    field = curl_mime_addpart(mime_form_);
+                    curl_mime_name(field, field_pair.first.c_str());
+                    curl_mime_data(field, field_pair.second.c_str(), CURL_ZERO_TERMINATED);
+                }
+
+                curl_easy_setopt(curl_, CURLOPT_MIMEPOST, mime_form_);
+            }
+        }
+
+        inline Response Session::getPrepare() {
+            if (curl_) {
+                curl_easy_setopt(curl_, CURLOPT_HTTPGET, 1L);
+                curl_easy_setopt(curl_, CURLOPT_POST, 0L);
+                curl_easy_setopt(curl_, CURLOPT_NOBODY, 0L);
+            }
+            return makeRequest();
+        }
+
+        inline Response Session::postPrepare(const std::string& contentType) {
+            return makeRequest(contentType);
+        }
+
+        inline Response Session::deletePrepare() {
+            if (curl_) {
+                curl_easy_setopt(curl_, CURLOPT_HTTPGET, 0L);
+                curl_easy_setopt(curl_, CURLOPT_NOBODY, 0L);
+                curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, "DELETE");
+            }
+            return makeRequest();
+        }
+
+        inline Response Session::makeRequest(const std::string& contentType) {
+            std::lock_guard<std::mutex> lock(mutex_request_);
+
+            struct curl_slist* headers = NULL;
+            if (!contentType.empty()) {
+                headers = curl_slist_append(headers, std::string{"Content-Type: " + contentType}.c_str());
+                if (contentType == "multipart/form-data") {
+                    headers = curl_slist_append(headers, "Expect:");
+                }
+            }
+            headers = curl_slist_append(headers, std::string{"Authorization: Bearer " + token_}.c_str());
+            if (!organization_.empty()) {
+                headers = curl_slist_append(headers, std::string{"OpenAI-Organization: " + organization_}.c_str());
+            }
+            curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, headers);
+            curl_easy_setopt(curl_, CURLOPT_URL, url_.c_str());
+
+            std::string response_string;
+            std::string header_string;
+            curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION, writeFunction);
+            curl_easy_setopt(curl_, CURLOPT_WRITEDATA, &response_string);
+            curl_easy_setopt(curl_, CURLOPT_HEADERDATA, &header_string);
+
+            res_ = curl_easy_perform(curl_);
+
+            bool is_error = false;
+            std::string error_msg{};
+            if (res_ != CURLE_OK) {
+                is_error  = true;
+                error_msg = "OpenAI curl_easy_perform() failed: " + std::string{curl_easy_strerror(res_)};
+                if (throw_exception_) {
+                    throw std::runtime_error(error_msg);
+                }
+                else {
+                    std::cerr << error_msg << '\n';
+                }
+            }
+
+            return {response_string, is_error, error_msg};
+        }
+
+        inline std::string Session::easyEscape(const std::string& text) {
+            char* encoded_output = curl_easy_escape(curl_, text.c_str(), static_cast<int>(text.length()));
+            const auto str       = std::string{encoded_output};
+            curl_free(encoded_output);
+            return str;
+        }
+
+        // forward declaration for category structures
+        class OpenAI;
+
+        // https://platform.openai.com/docs/api-reference/models
+        // List and describe the various models available in the API. You can refer to the Models documentation to
+        // understand what models are available and the differences between them.
+        struct CategoryModel {
+            Json list();
+            Json retrieve(const std::string& model);
+
+            CategoryModel(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+        // https://platform.openai.com/docs/api-reference/completions
+        // Given a prompt, the model will return one or more predicted completions, and can also return the
+        // probabilities of alternative tokens at each position.
+        struct CategoryCompletion {
+            Json create(Json input);
+
+            CategoryCompletion(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+        // https://platform.openai.com/docs/api-reference/chat
+        // Given a prompt, the model will return one or more predicted chat completions.
+        struct CategoryChat {
+            Json create(Json input);
+
+            CategoryChat(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+        // https://platform.openai.com/docs/api-reference/audio
+        // Learn how to turn audio into text.
+        struct CategoryAudio {
+            Json transcribe(Json input);
+            Json translate(Json input);
+
+            CategoryAudio(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+        // https://platform.openai.com/docs/api-reference/edits
+        // Given a prompt and an instruction, the model will return an edited version of the prompt.
+        struct CategoryEdit {
+            Json create(Json input);
+
+            CategoryEdit(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+
+        // https://platform.openai.com/docs/api-reference/images
+        // Given a prompt and/or an input image, the model will generate a new image.
+        struct CategoryImage {
+            Json create(Json input);
+            Json edit(Json input);
+            Json variation(Json input);
+
+            CategoryImage(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+        // https://platform.openai.com/docs/api-reference/embeddings
+        // Get a vector representation of a given input that can be easily consumed by machine learning models and
+        // algorithms.
+        struct CategoryEmbedding {
+            Json create(Json input);
+            CategoryEmbedding(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+        struct FileRequest {
+            std::string file;
+            std::string purpose;
+        };
+
+        // https://platform.openai.com/docs/api-reference/files
+        // Files are used to upload documents that can be used with features like Fine-tuning.
+        struct CategoryFile {
+            Json list();
+            Json upload(Json input);
+            Json del(const std::string& file);  // TODO
+            Json retrieve(const std::string& file_id);
+            Json content(const std::string& file_id);
+
+            CategoryFile(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+        // https://platform.openai.com/docs/api-reference/fine-tunes
+        // Manage fine-tuning jobs to tailor a model to your specific training data.
+        struct CategoryFineTune {
+            Json create(Json input);
+            Json list();
+            Json retrieve(const std::string& fine_tune_id);
+            Json content(const std::string& fine_tune_id);
+            Json cancel(const std::string& fine_tune_id);
+            Json events(const std::string& fine_tune_id);
+            Json del(const std::string& model);
+
+            CategoryFineTune(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+        // https://platform.openai.com/docs/api-reference/moderations
+        // Given a input text, outputs if the model classifies it as violating OpenAI's content policy.
+        struct CategoryModeration {
+            Json create(Json input);
+
+            CategoryModeration(OpenAI& openai) : openai_{openai} {}
+
+        private:
+            OpenAI& openai_;
+        };
+
+
+        // OpenAI
+        class OpenAI {
+        public:
+            OpenAI(const std::string& token        = "",
+                   const std::string& organization = "",
+                   bool throw_exception            = true,
+                   const std::string& api_base_url = "")
+                : session_{throw_exception}
+                , token_{token}
+                , organization_{organization}
+                , throw_exception_{throw_exception} {
+                if (token.empty()) {
+                    if (const char* env_p = std::getenv("OPENAI_API_KEY")) {
+                        token_ = std::string{env_p};
+                    }
+                }
+                if (api_base_url.empty()) {
+                    if (const char* env_p = std::getenv("OPENAI_API_BASE")) {
+                        base_url = std::string{env_p} + "/";
+                    }
+                    else {
+                        base_url = "https://api.openai.com/v1/";
+                    }
+                }
+                else {
+                    base_url = api_base_url;
+                }
+                session_.setUrl(base_url);
+                session_.setToken(token_, organization_);
+            }
+
+            OpenAI(const OpenAI&)            = delete;
+            OpenAI& operator=(const OpenAI&) = delete;
+            OpenAI(OpenAI&&)                 = delete;
+            OpenAI& operator=(OpenAI&&)      = delete;
+
+            void setProxy(const std::string& url) {
+                session_.setProxyUrl(url);
+            }
+
+            // void change_token(const std::string& token) { token_ = token; };
+            void setThrowException(bool throw_exception) {
+                throw_exception_ = throw_exception;
+            }
+
+            void setMultiformPart(const std::pair<std::string, std::string>& filefield_and_filepath,
+                                  const std::map<std::string, std::string>& fields) {
+                session_.setMultiformPart(filefield_and_filepath, fields);
+            }
+
+            Json post(const std::string& suffix, const std::string& data, const std::string& contentType) {
+                setParameters(suffix, data, contentType);
+                auto response = session_.postPrepare(contentType);
+                if (response.is_error) {
+                    trigger_error(response.error_message);
+                }
+
+                Json json{};
+                if (isJson(response.text)) {
+
+                    json = Json::parse(response.text);
+                    checkResponse(json);
+                }
+                else {
+#if OPENAI_VERBOSE_OUTPUT
+                    std::cerr << "Response is not a valid JSON";
+                    std::cout << "<< " << response.text << "\n";
+#endif
+                }
+
+                return json;
+            }
+
+            Json get(const std::string& suffix, const std::string& data = "") {
+                setParameters(suffix, data);
+                auto response = session_.getPrepare();
+                if (response.is_error) {
+                    trigger_error(response.error_message);
+                }
+
+                Json json{};
+                if (isJson(response.text)) {
+                    json = Json::parse(response.text);
+                    checkResponse(json);
+                }
+                else {
+#if OPENAI_VERBOSE_OUTPUT
+                    std::cerr << "Response is not a valid JSON\n";
+                    std::cout << "<< " << response.text << "\n";
+#endif
+                }
+                return json;
+            }
+
+            Json post(const std::string& suffix,
+                      const Json& json,
+                      const std::string& contentType = "application/json") {
+                return post(suffix, json.dump(), contentType);
+            }
+
+            Json del(const std::string& suffix) {
+                setParameters(suffix, "");
+                auto response = session_.deletePrepare();
+                if (response.is_error) {
+                    trigger_error(response.error_message);
+                }
+
+                Json json{};
+                if (isJson(response.text)) {
+                    json = Json::parse(response.text);
+                    checkResponse(json);
+                }
+                else {
+#if OPENAI_VERBOSE_OUTPUT
+                    std::cerr << "Response is not a valid JSON\n";
+                    std::cout << "<< " << response.text << "\n";
+#endif
+                }
+                return json;
+            }
+
+            std::string easyEscape(const std::string& text) {
+                return session_.easyEscape(text);
+            }
+
+            void debug() const {
+                std::cout << token_ << '\n';
+            }
+
+            void setBaseUrl(const std::string& url) {
+                base_url = url;
+            }
+
+            std::string getBaseUrl() const {
+                return base_url;
+            }
+
+        private:
+            std::string base_url;
+
+            void setParameters(const std::string& suffix,
+                               const std::string& data,
+                               const std::string& contentType = "") {
+                auto complete_url = base_url + suffix;
+                session_.setUrl(complete_url);
+
+                if (contentType != "multipart/form-data") {
+                    session_.setBody(data);
+                }
+
+#if OPENAI_VERBOSE_OUTPUT
+                std::cout << "<< request: " << complete_url << "  " << data << '\n';
+#endif
+            }
+
+            void checkResponse(const Json& json) {
+                if (json.count("error")) {
+                    auto reason = json["error"].dump();
+                    trigger_error(reason);
+
+#if OPENAI_VERBOSE_OUTPUT
+                    std::cerr << ">> response error :\n" << json.dump(2) << "\n";
+#endif
+                }
+            }
+
+            // as of now the only way
+            bool isJson(const std::string& data) {
+                bool rc = true;
+                try {
+                    auto json = Json::parse(data);  // throws if no json
+                }
+                catch (std::exception&) {
+                    rc = false;
+                }
+                return (rc);
+            }
+
+            void trigger_error(const std::string& msg) {
+                if (throw_exception_) {
+                    throw std::runtime_error(msg);
+                }
+                else {
+                    std::cerr << "[OpenAI] error. Reason: " << msg << '\n';
+                }
+            }
+
+        public:
+            CategoryModel model{*this};
+            CategoryCompletion completion{*this};
+            CategoryEdit edit{*this};
+            CategoryImage image{*this};
+            CategoryEmbedding embedding{*this};
+            CategoryFile file{*this};
+            CategoryFineTune fine_tune{*this};
+            CategoryModeration moderation{*this};
+            CategoryChat chat{*this};
+            CategoryAudio audio{*this};
+            // CategoryEngine          engine{*this}; // Not handled since deprecated (use Model instead)
+
+        private:
+            Session session_;
+            std::string token_;
+            std::string organization_;
+            bool throw_exception_;
+        };
+
+        inline std::string bool_to_string(const bool b) {
+            std::ostringstream ss;
+            ss << std::boolalpha << b;
+            return ss.str();
+        }
+
+        inline OpenAI& start(const std::string& token        = "",
+                             const std::string& organization = "",
+                             bool throw_exception            = true) {
+            static OpenAI instance{token, organization, throw_exception};
+            return instance;
+        }
+
+        inline OpenAI& instance() {
+            return start();
+        }
+
+        inline Json post(const std::string& suffix, const Json& json) {
+            return instance().post(suffix, json);
+        }
+
+        inline Json get(const std::string& suffix /*, const Json& json*/) {
+            return instance().get(suffix);
+        }
+
+        // Helper functions to get category structures instance()
+
+        inline CategoryModel& model() {
+            return instance().model;
+        }
+
+        inline CategoryCompletion& completion() {
+            return instance().completion;
+        }
+
+        inline CategoryChat& chat() {
+            return instance().chat;
+        }
+
+        inline CategoryAudio& audio() {
+            return instance().audio;
+        }
+
+        inline CategoryEdit& edit() {
+            return instance().edit;
+        }
+
+        inline CategoryImage& image() {
+            return instance().image;
+        }
+
+        inline CategoryEmbedding& embedding() {
+            return instance().embedding;
+        }
+
+        inline CategoryFile& file() {
+            return instance().file;
+        }
+
+        inline CategoryFineTune& fineTune() {
+            return instance().fine_tune;
+        }
+
+        inline CategoryModeration& moderation() {
+            return instance().moderation;
+        }
+
+        // Definitions of category methods
+
+        // GET https://api.openai.com/v1/models
+        // Lists the currently available models, and provides basic information about each one such as the owner and
+        // availability.
+        inline Json CategoryModel::list() {
+            return openai_.get("models");
+        }
+
+        // GET https://api.openai.com/v1/models/{model}
+        // Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
+        inline Json CategoryModel::retrieve(const std::string& model) {
+            return openai_.get("models/" + model);
+        }
+
+        // POST https://api.openai.com/v1/completions
+        // Creates a completion for the provided prompt and parameters
+        inline Json CategoryCompletion::create(Json input) {
+            return openai_.post("completions", input);
+        }
+
+        // POST https://api.openai.com/v1/chat/completions
+        // Creates a chat completion for the provided prompt and parameters
+        inline Json CategoryChat::create(Json input) {
+            return openai_.post("chat/completions", input);
+        }
+
+        // POST https://api.openai.com/v1/audio/transcriptions
+        // Transcribes audio into the input language.
+        inline Json CategoryAudio::transcribe(Json input) {
+            openai_.setMultiformPart({"file", input["file"].get<std::string>()},
+                                     std::map<std::string, std::string>{{"model", input["model"].get<std::string>()}});
+
+            return openai_.post("audio/transcriptions", std::string{""}, "multipart/form-data");
+        }
+
+        // POST https://api.openai.com/v1/audio/translations
+        // Translates audio into into English..
+        inline Json CategoryAudio::translate(Json input) {
+            openai_.setMultiformPart({"file", input["file"].get<std::string>()},
+                                     std::map<std::string, std::string>{{"model", input["model"].get<std::string>()}});
+
+            return openai_.post("audio/translations", std::string{""}, "multipart/form-data");
+        }
+
+        // POST https://api.openai.com/v1/translations
+        // Creates a new edit for the provided input, instruction, and parameters
+        inline Json CategoryEdit::create(Json input) {
+            return openai_.post("edits", input);
+        }
+
+        // POST https://api.openai.com/v1/images/generations
+        // Given a prompt and/or an input image, the model will generate a new image.
+        inline Json CategoryImage::create(Json input) {
+            return openai_.post("images/generations", input);
+        }
+
+        // POST https://api.openai.com/v1/images/edits
+        // Creates an edited or extended image given an original image and a prompt.
+        inline Json CategoryImage::edit(Json input) {
+            std::string prompt = input["prompt"].get<std::string>();  // required
+            // Default values
+            std::string mask            = "";
+            int n                       = 1;
+            std::string size            = "1024x1024";
+            std::string response_format = "url";
+            std::string user            = "";
+
+            if (input.contains("mask")) {
+                mask = input["mask"].get<std::string>();
+            }
+            if (input.contains("n")) {
+                n = input["n"].get<int>();
+            }
+            if (input.contains("size")) {
+                size = input["size"].get<std::string>();
+            }
+            if (input.contains("response_format")) {
+                response_format = input["response_format"].get<std::string>();
+            }
+            if (input.contains("user")) {
+                user = input["user"].get<std::string>();
+            }
+            openai_.setMultiformPart({"image", input["image"].get<std::string>()},
+                                     std::map<std::string, std::string>{{"prompt", prompt},
+                                                                        {"mask", mask},
+                                                                        {"n", std::to_string(n)},
+                                                                        {"size", size},
+                                                                        {"response_format", response_format},
+                                                                        {"user", user}});
+
+            return openai_.post("images/edits", std::string{""}, "multipart/form-data");
+        }
+
+        // POST https://api.openai.com/v1/images/variations
+        // Creates a variation of a given image.
+        inline Json CategoryImage::variation(Json input) {
+            // Default values
+            int n                       = 1;
+            std::string size            = "1024x1024";
+            std::string response_format = "url";
+            std::string user            = "";
+
+            if (input.contains("n")) {
+                n = input["n"].get<int>();
+            }
+            if (input.contains("size")) {
+                size = input["size"].get<std::string>();
+            }
+            if (input.contains("response_format")) {
+                response_format = input["response_format"].get<std::string>();
+            }
+            if (input.contains("user")) {
+                user = input["user"].get<std::string>();
+            }
+            openai_.setMultiformPart({"image", input["image"].get<std::string>()},
+                                     std::map<std::string, std::string>{{"n", std::to_string(n)},
+                                                                        {"size", size},
+                                                                        {"response_format", response_format},
+                                                                        {"user", user}});
+
+            return openai_.post("images/variations", std::string{""}, "multipart/form-data");
+        }
+
+        inline Json CategoryEmbedding::create(Json input) {
+            return openai_.post("embeddings", input);
+        }
+
+        inline Json CategoryFile::list() {
+            return openai_.get("files");
+        }
+
+        inline Json CategoryFile::upload(Json input) {
+            openai_.setMultiformPart(
+                {"file", input["file"].get<std::string>()},
+                std::map<std::string, std::string>{{"purpose", input["purpose"].get<std::string>()}});
+
+            return openai_.post("files", std::string{""}, "multipart/form-data");
+        }
+
+        inline Json CategoryFile::del(const std::string& file_id) {
+            return openai_.del("files/" + file_id);
+        }
+
+        inline Json CategoryFile::retrieve(const std::string& file_id) {
+            return openai_.get("files/" + file_id);
+        }
+
+        inline Json CategoryFile::content(const std::string& file_id) {
+            return openai_.get("files/" + file_id + "/content");
+        }
+
+        inline Json CategoryFineTune::create(Json input) {
+            return openai_.post("fine-tunes", input);
+        }
+
+        inline Json CategoryFineTune::list() {
+            return openai_.get("fine-tunes");
+        }
+
+        inline Json CategoryFineTune::retrieve(const std::string& fine_tune_id) {
+            return openai_.get("fine-tunes/" + fine_tune_id);
+        }
+
+        inline Json CategoryFineTune::content(const std::string& fine_tune_id) {
+            return openai_.get("fine-tunes/" + fine_tune_id + "/content");
+        }
+
+        inline Json CategoryFineTune::cancel(const std::string& fine_tune_id) {
+            return openai_.post("fine-tunes/" + fine_tune_id + "/cancel", Json{});
+        }
+
+        inline Json CategoryFineTune::events(const std::string& fine_tune_id) {
+            return openai_.get("fine-tunes/" + fine_tune_id + "/events");
+        }
+
+        inline Json CategoryFineTune::del(const std::string& model) {
+            return openai_.del("models/" + model);
+        }
+
+        inline Json CategoryModeration::create(Json input) {
+            return openai_.post("moderations", input);
+        }
+
+    }  // namespace _detail
+
+    // Public interface
+
+    using _detail::OpenAI;
+
+    // instance
+    using _detail::instance;
+    using _detail::start;
+
+    // Generic methods
+    using _detail::get;
+    using _detail::post;
+
+    // Helper categories access
+    using _detail::audio;
+    using _detail::chat;
+    using _detail::completion;
+    using _detail::edit;
+    using _detail::embedding;
+    using _detail::file;
+    using _detail::fineTune;
+    using _detail::image;
+    using _detail::model;
+    using _detail::moderation;
+
+    using _detail::Json;
+
+}  // namespace utility::openai
+
+#endif  // UTILITY_OPENAI_OPENAI_HPP


### PR DESCRIPTION
This PR adds a speech-to-text using Openai's whisper model https://openai.com/research/whisper. 

Audio is recorded for a specified duration, which is then transcribed into text using Whisper. This text can be forwarded to ChatGPT for a response. Additionally, ChatGPT's responses can be audibly relayed back to the user through the 'Say' task. 