### PR TITLE
Add delay and starting side options for field localisation

### DIFF
--- a/module/localisation/FieldLocalisation/data/config/FieldLocalisation.yaml
+++ b/module/localisation/FieldLocalisation/data/config/FieldLocalisation.yaml
@@ -8,10 +8,10 @@ grid_size: 0.01
 n_particles: 1000
 
 # Our confidence in the initial guess of where the robot starts (x is overwritten by field length / 2)
-initial_covariance: [3.0, 0.5, 0.5]
+initial_covariance: [1.0, 0.25, 0.5]
 
 # Amount of noise added to the particles (how much world can move to adjust for drift) at each time update
-process_noise: [0.001, 0.001, 0.001]
+process_noise: [0.0001, 0.0001, 0.001]
 
 # Amount of uncertainty in our field line measurements
 measurement_noise: 0.01
@@ -27,3 +27,9 @@ min_observations: 100
 
 # Penalty factor for observations being outside map
 outside_map_penalty_factor: 1
+
+# Delay before the particle filter starts (allows odometry to settle)
+start_time_delay: 5
+
+# Starting side of the field (LEFT, RIGHT or EITHER)
+starting_side: LEFT

--- a/module/localisation/FieldLocalisation/data/config/FieldLocalisation.yaml
+++ b/module/localisation/FieldLocalisation/data/config/FieldLocalisation.yaml
@@ -31,5 +31,5 @@ outside_map_penalty_factor: 1
 # Delay before the particle filter starts (allows odometry to settle)
 start_time_delay: 5
 
-# Starting side of the field (LEFT, RIGHT or EITHER)
+# Starting side of the field looking towards own goal from centre of field (LEFT, RIGHT or EITHER)
 starting_side: LEFT

--- a/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
+++ b/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
@@ -31,5 +31,5 @@ outside_map_penalty_factor: 0.9
 # Delay before the particle filter starts (allows odometry to settle)
 start_time_delay: 5
 
-# Starting side of the field (LEFT, RIGHT or EITHER)
+# Starting side of the field looking towards own goal from centre of field (LEFT, RIGHT or EITHER)
 starting_side: EITHER

--- a/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
+++ b/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
@@ -27,3 +27,9 @@ min_observations: 100
 
 # Penalty factor for observations being outside map
 outside_map_penalty_factor: 0.9
+
+# Delay before the particle filter starts (allows odometry to settle)
+start_time_delay: 5
+
+# Starting side of the field (LEFT, RIGHT or EITHER)
+starting_side: EITHER

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
@@ -38,6 +38,8 @@ namespace module::localisation {
             cfg.max_range                     = config["max_range"].as<double>();
             cfg.min_observations              = config["min_observations"].as<size_t>();
             cfg.outside_map_penalty_factor    = config["outside_map_penalty_factor"].as<double>();
+            cfg.start_time_delay              = config["start_time_delay"].as<double>();
+            cfg.starting_side                 = config["starting_side"].as<std::string>();
         });
 
         on<Trigger<ResetFieldLocalisation>>().then([this] {
@@ -197,13 +199,16 @@ namespace module::localisation {
 
             // Intialise the particles to be distrbuted along either sides of the positive half of the field, facing
             // towards the field
-            cfg.initial_state.emplace_back((fd.dimensions.field_length / 2.0),
-                                           (fd.dimensions.field_width / 2.0),
-                                           -M_PI_2);
-            cfg.initial_state.emplace_back((fd.dimensions.field_length / 2.0),
-                                           (-fd.dimensions.field_width / 2.0),
-                                           M_PI_2);
-
+            if (cfg.starting_side == StartingSide::LEFT || cfg.starting_side == StartingSide::EITHER) {
+                cfg.initial_state.emplace_back((fd.dimensions.field_length / 4.0),
+                                               (fd.dimensions.field_width / 2.0),
+                                               -M_PI_2);
+            }
+            if (cfg.starting_side == StartingSide::RIGHT || cfg.starting_side == StartingSide::EITHER) {
+                cfg.initial_state.emplace_back((fd.dimensions.field_length / 4.0),
+                                               (-fd.dimensions.field_width / 2.0),
+                                               M_PI_2);
+            }
 
             // Initialise the particles with a multivariate normal distribution
             state      = cfg.initial_state[0];
@@ -222,6 +227,9 @@ namespace module::localisation {
 
             // Set the time update time to now
             last_time_update_time = NUClear::clock::now();
+
+            // Set the startup time to now
+            startup_time = NUClear::clock::now();
         });
 
         on<Trigger<Stability>>().then([this](const Stability& stability) {
@@ -235,7 +243,11 @@ namespace module::localisation {
 
         on<Trigger<FieldLines>>().then("Particle Filter", [this](const FieldLines& field_lines) {
             Eigen::Isometry3d Hcw = Eigen::Isometry3d(field_lines.Hcw);
-            if (!falling && field_lines.rPWw.size() > cfg.min_observations) {
+            auto time_since_startup =
+                std::chrono::duration_cast<std::chrono::seconds>(NUClear::clock::now() - startup_time).count();
+            log<NUClear::DEBUG>("Time since startup: ", time_since_startup);
+            if (!falling && field_lines.rPWw.size() > cfg.min_observations
+                && time_since_startup > cfg.start_time_delay) {
                 // Add noise to the particles
                 add_noise();
 

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.hpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.hpp
@@ -22,6 +22,41 @@ namespace module::localisation {
         double weight         = 1.0;
     };
 
+
+    struct StartingSide {
+        enum Value { UNKNOWN = 0, LEFT = 1, RIGHT = 2, EITHER = 3 };
+        Value value = Value::UNKNOWN;
+
+        // Constructors
+        StartingSide() = default;
+        StartingSide(int const& v) : value(static_cast<Value>(v)) {}
+        StartingSide(Value const& v) : value(v) {}
+        StartingSide(std::string const& str) {
+            // clang-format off
+                        if      (str == "LEFT") { value = Value::LEFT; }
+                        else if (str == "RIGHT") { value = Value::RIGHT; }
+                        else if (str == "EITHER")  { value = Value::EITHER; }
+                        else {
+                            value = Value::UNKNOWN;
+                            throw std::runtime_error("String " + str + " did not match any enum for StartingSide");
+                        }
+            // clang-format on
+        }
+
+        // Conversions
+        [[nodiscard]] operator Value() const {
+            return value;
+        }
+        [[nodiscard]] operator std::string() const {
+            switch (value) {
+                case Value::LEFT: return "LEFT";
+                case Value::RIGHT: return "RIGHT";
+                case Value::EITHER: return "EITHER";
+                default: throw std::runtime_error("enum Method's value is corrupt, unknown value stored");
+            }
+        }
+    };
+
     class FieldLocalisation : public NUClear::Reactor {
     private:
         /// @brief Stores configuration values
@@ -46,6 +81,10 @@ namespace module::localisation {
             size_t min_observations = 0;
             /// @brief Penalty factor for observations being outside map
             double outside_map_penalty_factor = 0.0;
+            /// @brief Start time delay for the particle filter
+            double start_time_delay = 0.0;
+            /// @brief Starting side of the field (left, right, or either)
+            StartingSide starting_side = StartingSide::UNKNOWN;
         } cfg;
 
         NUClear::clock::time_point last_time_update_time;
@@ -65,6 +104,8 @@ namespace module::localisation {
         /// @brief Particles used in the particle filter
         std::vector<Particle> particles{};
 
+        /// @brief The time of startup
+        NUClear::clock::time_point startup_time;
 
     public:
         /// @brief Called by the powerplant to build and setup the FieldLocalisation reactor.

--- a/module/vision/FieldLineDetector/data/config/FieldLineDetector.yaml
+++ b/module/vision/FieldLineDetector/data/config/FieldLineDetector.yaml
@@ -1,5 +1,5 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-confidence_threshold: 0.6 # How confident do we need to be that this is a field line
+confidence_threshold: 0.7 # How confident do we need to be that this is a field line
 cluster_points: 1 # How many points do we need to claim this cluster is a field line


### PR DESCRIPTION
This PR adds a config value for the following:

- Delaying the start of the filter (useful for letting odometry converge before beginning)
- Selecting a starting side (left, right or either)