### PR TITLE
Add simple method for goal detection

### DIFF
--- a/module/strategy/StrategiseLook/src/StrategiseLook.cpp
+++ b/module/strategy/StrategiseLook/src/StrategiseLook.cpp
@@ -53,7 +53,7 @@ namespace module::strategy {
                 // If we have goals, with at least one measurement and the goals are recent, look at the goals
                 if (!goals.goals.empty() && (NUClear::clock::now() - goals.timestamp < cfg.goal_search_timeout)) {
                     // Convert goal measurement to cartesian coordinates
-                    Eigen::Vector3d rGCc = sphericalToCartesian(goals.goals[0].measurements[0].srGCc.cast<double>());
+                    Eigen::Vector3d rGCc = goals.goals[0].measurements[0].rGCc;
                     // Convert to torso space
                     Eigen::Vector3d rGCt = (sensors.Htw * goals.Hcw.inverse()).rotation() * rGCc;
                     // Look at the goal

--- a/module/vision/GoalDetector/data/config/GoalDetector.yaml
+++ b/module/vision/GoalDetector/data/config/GoalDetector.yaml
@@ -2,7 +2,7 @@
 log_level: INFO
 
 confidence_threshold: 0.8 # How confident do we need to be that this is a goal point
-cluster_points: 10 # How many points do we need to claim this cluster is a viable goal
+cluster_points: 35 # How many points do we need to claim this cluster is a viable goal
 disagreement_ratio:
   0.5 # How much can the measured goal width vary from actual goal width before we
   # treat the posts as part of separate goals

--- a/module/vision/GoalDetector/src/GoalDetector.hpp
+++ b/module/vision/GoalDetector/src/GoalDetector.hpp
@@ -28,13 +28,13 @@ namespace module::vision {
     class GoalDetector : public NUClear::Reactor {
     private:
         struct {
-            float confidence_threshold                 = 0.0f;
+            double confidence_threshold                = 0.0f;
             int cluster_points                         = 0;
-            float disagreement_ratio                   = 0.0f;
-            Eigen::Vector3f goal_projection_covariance = Eigen::Vector3f::Zero();
+            double disagreement_ratio                  = 0.0f;
+            Eigen::Vector3d goal_projection_covariance = Eigen::Vector3d::Zero();
             bool use_median                            = false;
-            float max_goal_distance                    = 0;
-        } config{};
+            double max_goal_distance                   = 0;
+        } cfg{};
 
     public:
         /// @brief Called by the powerplant to build and setup the GoalDetector reactor.

--- a/shared/message/vision/Goal.proto
+++ b/shared/message/vision/Goal.proto
@@ -46,22 +46,22 @@ message Goal {
     message Measurement {
         MeasurementType type = 1;
         /// Normal vectors point inwards towards the centre of the object
-        fvec3 srGCc      = 2;  // Spherical Reciprocal Coordinates (1/distance, phi, theta)
-        fmat3 covariance = 3;
+        vec3 rGCc = 2; // Goal from camera in camera space
+        mat3 covariance = 3;
     }
     message Post {
         /// Vector pointing to top point of post in camera space
-        fvec3 top = 1;
+        vec3 top = 1;
         /// Vector pointing to bottom point of post in camera space
-        fvec3 bottom = 2;
+        vec3 bottom = 2;
         /// Distance from camera to goals, in metres
-        float distance = 3;
+        double distance = 3;
     }
     Side                 side           = 1;
     Post                 post           = 3;
     repeated Measurement measurements   = 4;
-    fvec2                screen_angular = 5;
-    fvec2                angular_size   = 6;
+    vec2                screen_angular = 5;
+    vec2                angular_size   = 6;
 }
 
 message Goals {
@@ -71,4 +71,6 @@ message Goals {
     iso3 Hcw = 3;
 
     repeated Goal goals = 4;
+    /// Goal detections projected onto the ground plane
+    repeated vec3 rGWw = 6;
 }

--- a/shared/message/vision/Goal.proto
+++ b/shared/message/vision/Goal.proto
@@ -46,7 +46,7 @@ message Goal {
     message Measurement {
         MeasurementType type = 1;
         /// Normal vectors point inwards towards the centre of the object
-        vec3 rGCc = 2; // Goal from camera in camera space
+        vec3 rGCc       = 2;  // Goal from camera in camera space
         mat3 covariance = 3;
     }
     message Post {
@@ -60,8 +60,8 @@ message Goal {
     Side                 side           = 1;
     Post                 post           = 3;
     repeated Measurement measurements   = 4;
-    vec2                screen_angular = 5;
-    vec2                angular_size   = 6;
+    vec2                 screen_angular = 5;
+    vec2                 angular_size   = 6;
 }
 
 message Goals {


### PR DESCRIPTION
This PR adds a new method for detecting the bottom of the goal posts. It simply grabs the closest point in a cluster and assumes this is the bottom of the goal post. Addionally, the float types of the goal detector are converted to double.