### PR TITLE
Add a module to convert NUClear Logs and ReactionStatistics to messages for recording

### DIFF
--- a/module/support/logging/DataLogging/data/config/DataLogging.yaml
+++ b/module/support/logging/DataLogging/data/config/DataLogging.yaml
@@ -20,3 +20,5 @@ messages:
   message.vision.VisualMesh: false
   message.localisation.Ball: false
   message.localisation.Field: false
+  message.nuclear.LogMessage: false
+  message.nuclear.ReactionStatistics: false

--- a/module/support/logging/MessageLogHandler/CMakeLists.txt
+++ b/module/support/logging/MessageLogHandler/CMakeLists.txt
@@ -1,0 +1,29 @@
+#[[
+MIT License
+
+Copyright (c) 2023 NUbots
+
+This file is part of the NUbots codebase.
+See https://github.com/NUbots/NUbots for further info.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+]]
+
+# Build our NUClear module
+nuclear_module()

--- a/module/support/logging/MessageLogHandler/CMakeLists.txt
+++ b/module/support/logging/MessageLogHandler/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2023 NUbots
+Copyright (c) 2013 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/logging/MessageLogHandler/README.md
+++ b/module/support/logging/MessageLogHandler/README.md
@@ -1,0 +1,25 @@
+# MessageLogHandler
+
+## Description
+
+This module provides an interface to take the LogMessage and ReactionStatistics messages from NUClear and recodes them into protobuf messages.
+These messages can then be sent using NetworkForwarder or recorded using DataLogging.
+Additionally it can be configured to ignore the display level of the logs so that the level can be adjusted at a later time for analysis.
+
+## Usage
+
+Include this module and configure NetworkForwarder or DataLogging to forward the LogMessage and ReactionStatistics messages.
+
+## Consumes
+
+- NUClear::message::LogMessage
+- NUClear::message::ReactionStatistics
+
+## Emits
+
+- message::nuclear::LogMessage
+- message::nuclear::ReactionStatistics
+
+## Dependencies
+
+None

--- a/module/support/logging/MessageLogHandler/data/config/MessageLogHandler.yaml
+++ b/module/support/logging/MessageLogHandler/data/config/MessageLogHandler.yaml
@@ -1,0 +1,8 @@
+# Controls the minimum log level that NUClear log will display from this module
+log_level: INFO
+
+log_settings:
+  # Sets the minimum log level that this module will handle for logs coming in
+  min_level: TRACE
+  # If true, will ignore the display level of the log and recode everything
+  log_all: true

--- a/module/support/logging/MessageLogHandler/src/MessageLogHandler.cpp
+++ b/module/support/logging/MessageLogHandler/src/MessageLogHandler.cpp
@@ -1,0 +1,120 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "MessageLogHandler.hpp"
+
+#include "extension/Configuration.hpp"
+
+#include "message/nuclear/LogMessage.hpp"
+#include "message/nuclear/ReactionStatistics.hpp"
+
+namespace module::support::logging {
+
+    using extension::Configuration;
+
+    namespace {
+        message::nuclear::ReactionStatistics to_message(const NUClear::message::ReactionStatistics& in) {
+
+            message::nuclear::ReactionStatistics out;
+
+            out.identifiers.name     = in.identifiers.name;
+            out.identifiers.reactor  = in.identifiers.reactor;
+            out.identifiers.dsl      = in.identifiers.dsl;
+            out.identifiers.function = in.identifiers.function;
+
+            out.reaction_id       = uint64_t(in.reaction_id);
+            out.task_id           = uint64_t(in.task_id);
+            out.cause_reaction_id = uint64_t(in.cause_reaction_id);
+            out.cause_task_id     = uint64_t(in.cause_task_id);
+            out.emitted           = in.emitted;
+            out.started           = in.started;
+            out.finished          = in.finished;
+
+            if (in.exception) {
+                try {
+                    std::rethrow_exception(in.exception);
+                }
+                catch (const std::exception& ex) {
+                    out.exception = ex.what();
+                }
+                catch (...) {
+                    // We don't actually want to crash
+                }
+            }
+
+            return out;
+        }
+
+        message::nuclear::LogLevel to_message(const NUClear::LogLevel& level) {
+            switch (level) {
+                case NUClear::LogLevel::TRACE: return message::nuclear::LogLevel::TRACE;
+                case NUClear::LogLevel::DEBUG: return message::nuclear::LogLevel::DEBUG;
+                case NUClear::LogLevel::INFO: return message::nuclear::LogLevel::INFO;
+                case NUClear::LogLevel::WARN: return message::nuclear::LogLevel::WARN;
+                case NUClear::LogLevel::ERROR: return message::nuclear::LogLevel::ERROR;
+                case NUClear::LogLevel::FATAL: return message::nuclear::LogLevel::FATAL;
+                case NUClear::LogLevel::UNKNOWN:
+                default: return message::nuclear::LogLevel::UNKNOWN;
+            }
+        }
+
+    }  // namespace
+
+    MessageLogHandler::MessageLogHandler(std::unique_ptr<NUClear::Environment> environment)
+        : Reactor(std::move(environment)), cfg{} {
+
+        on<Configuration>("MessageLogHandler.yaml").then([this](const Configuration& config) {
+            // Use configuration here from file MessageLogHandler.yaml
+            this->log_level = config["log_level"].as<NUClear::LogLevel>();
+            cfg.min_level   = config["log_settings"]["min_level"].as<NUClear::LogLevel>();
+            cfg.log_all     = config["log_settings"]["log_all"].as<bool>();
+        });
+
+        on<Trigger<NUClear::message::LogMessage>>().then([this](const NUClear::message::LogMessage& log_msg) {
+            // Skip if we are not logging this level
+            if (log_msg.level < cfg.min_level || (!cfg.log_all && log_msg.level < log_msg.display_level)) {
+                return;
+            }
+
+            auto msg           = std::make_unique<message::nuclear::LogMessage>();
+            msg->timestamp     = NUClear::clock::now();
+            msg->level         = to_message(log_msg.level);
+            msg->display_level = to_message(log_msg.display_level);
+            msg->message       = log_msg.message;
+            if (log_msg.task) {
+                msg->reaction_statistics = to_message(*log_msg.task);
+            }
+            emit(msg);
+        });
+
+        on<Trigger<NUClear::message::ReactionStatistics>>().then(
+            [this](const NUClear::message::ReactionStatistics& stats) {
+                auto msg = std::make_unique<message::nuclear::ReactionStatistics>(to_message(stats));
+                emit(msg);
+            });
+    }
+
+}  // namespace module::support::logging

--- a/module/support/logging/MessageLogHandler/src/MessageLogHandler.hpp
+++ b/module/support/logging/MessageLogHandler/src/MessageLogHandler.hpp
@@ -1,0 +1,51 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef MODULE_SUPPORT_LOGGING_MESSAGELOGHANDLER_HPP
+#define MODULE_SUPPORT_LOGGING_MESSAGELOGHANDLER_HPP
+
+#include <nuclear>
+
+namespace module::support::logging {
+
+    class MessageLogHandler : public NUClear::Reactor {
+    private:
+        /// The configuration variables for this reactor
+        struct {
+            /// The minimum log level to forward
+            NUClear::LogLevel min_level{NUClear::TRACE};
+            /// If the display level should be ignored and all messages logged
+            bool log_all{true};
+        } cfg{};
+
+    public:
+        /// @brief Called by the powerplant to build and setup the MessageLogHandler reactor.
+        explicit MessageLogHandler(std::unique_ptr<NUClear::Environment> environment);
+    };
+
+}  // namespace module::support::logging
+
+#endif  // MODULE_SUPPORT_LOGGING_MESSAGELOGHANDLER_HPP

--- a/roles/test/messageloghandler.role
+++ b/roles/test/messageloghandler.role
@@ -1,0 +1,7 @@
+nuclear_role(
+  # FileWatcher and ConsoleLogHandler must go first.
+  extension::FileWatcher
+  support::logging::ConsoleLogHandler
+  support::logging::MessageLogHandler
+  support::logging::DataLogging
+)

--- a/shared/message/nuclear/LogMessage.proto
+++ b/shared/message/nuclear/LogMessage.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package message.nuclear;
+
+import "google/protobuf/timestamp.proto";
+import "message/nuclear/ReactionStatistics.proto";
+
+/**
+ * Replicates the LogLevel enum from NUClear
+ */
+enum LogLevel {
+    UNKNOWN = 0;
+    TRACE   = 1;
+    DEBUG   = 2;
+    INFO    = 3;
+    WARN    = 4;
+    ERROR   = 5;
+    FATAL   = 6;
+}
+
+/**
+ * Replicates a NUClear::LogMessage type as a protobuf message
+ */
+message LogMessage {
+
+    /// The timestamp of the log message
+    google.protobuf.Timestamp timestamp = 1;
+    /// The log level of the message
+    LogLevel level = 2;
+    /// The level that the emitting reactor wanted to display at
+    LogLevel display_level = 3;
+    /// The message to be logged
+    string message = 4;
+    /// The information about the reaction that logged this message
+    ReactionStatistics reaction_statistics = 5;
+}

--- a/shared/message/nuclear/ReactionStatistics.proto
+++ b/shared/message/nuclear/ReactionStatistics.proto
@@ -1,0 +1,45 @@
+
+syntax = "proto3";
+
+package message.nuclear;
+
+import "google/protobuf/timestamp.proto";
+
+/**
+ * Replicates the ReactionStatistics class from NUClear as a protobuf message
+ */
+message ReactionStatistics {
+
+    /**
+     * The identifiers of the reaction
+     */
+    message Identifiers {
+        /// The name of the reaction provided by the user
+        string name = 1;
+        /// The name of the reactor that this reaction belongs to
+        string reactor = 2;
+        /// The DSL that this reaction was created from
+        string dsl = 3;
+        /// The callback function that this reaction is bound to
+        string function = 4;
+    }
+
+    /// The identifiers of the reaction
+    Identifiers identifiers = 1;
+    /// The id of the reaction
+    uint64 reaction_id = 2;
+    /// The id of the task
+    uint64 task_id = 3;
+    /// The id of the reaction that caused this task to be run
+    uint64 cause_reaction_id = 4;
+    /// The id of the task that caused this task to be run
+    uint64 cause_task_id = 5;
+    /// The time that this reaction was emitted
+    google.protobuf.Timestamp emitted = 6;
+    /// The time that this reaction started processing
+    google.protobuf.Timestamp started = 7;
+    /// The time that this reaction finished processing
+    google.protobuf.Timestamp finished = 8;
+    /// The exception that was thrown by this reaction (if any)
+    string exception = 9;
+}


### PR DESCRIPTION
This PR adds a new module `support::logging::MessageLogHandler`  that listens for `LogMessage` and `ReactionStatistics` messages from NUClear and recodes them into protobuf messages. This make it possible to record those messages to NBS files for later playback and analysis.

I'm hoping to get this in to use it for my NUsight workshop on Friday.

### PR Checklist:

- [x] Updated relevant module READMEs
- [x] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [x] Added a descriptive title and relevant labels to the PR
