### PR TITLE
Change DataLogging default directory to `recordings`

### DIFF
--- a/module/support/logging/DataLogging/data/config/DataLogging.yaml
+++ b/module/support/logging/DataLogging/data/config/DataLogging.yaml
@@ -1,7 +1,7 @@
 log_level: INFO
 
 output:
-  directory: log
+  directory: recordings
   split_size: 5 * GiB
 
 # You can put any messages that is emitted in the system here and it will be logged


### PR DESCRIPTION
This PR updates the default output directory for DataLogging from `logs` to `recordings`. This makes it easier to access the recorded  files since `recordings` in the container is symlinked to the local `recordings` folder.

Let me know if there's something special about the `log` directory that I'm missing. I know that on the robots we currently log to `log`, but changing that to recordings should be fine right? As long as we update docs.

NUbook PR: https://github.com/NUbots/NUbook/pull/301