### PR TITLE
Fix Python protobuf types trying to compile robot `.proto` files

### DIFF
--- a/tools/utility/nbs/protobuf_types.py
+++ b/tools/utility/nbs/protobuf_types.py
@@ -59,7 +59,7 @@ with tempfile.TemporaryDirectory() as protobuf_path:
 
     proto_files = [
         *glob.glob(os.path.join(nuclear_proto_dir, "**", "*.proto"), recursive=True),
-        *glob.glob(os.path.join(user_proto_dir, "**", "*.proto"), recursive=True),
+        *glob.glob(os.path.join(user_proto_dir, "message", "**", "*.proto"), recursive=True),
     ]
 
     # Build the protocol buffers


### PR DESCRIPTION
This PR updates the Python protobuf message generator to look for `*.proto` files in `shared/message` instead of just `shared/` to avoid attempting to compile robot model proto files as protobuf messages.

This fixes tools like `./b nbs stats`, which are currently broken on main.