### PR TITLE
Update format.py to try to better track renames

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -346,6 +346,7 @@ RUN install-from-source https://github.com/Tom0Brien/tinyrobotics/archive/refs/t
 
 # Install python libraries
 RUN pip install \
+    pygit2==1.13.3 \
     xxhash \
     pylint \
     termcolor \

--- a/docker/usr/local/toolchain/generate_g4dnxlarge_toolchain.py
+++ b/docker/usr/local/toolchain/generate_g4dnxlarge_toolchain.py
@@ -3,7 +3,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2019 NUbots
+# Copyright (c) 2021 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/docker/usr/local/toolchain/generate_nuc12wshi7_toolchain.py
+++ b/docker/usr/local/toolchain/generate_nuc12wshi7_toolchain.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2019 NUbots
+# Copyright (c) 2023 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/docker/usr/local/toolchain/generate_nuc8i7beh_toolchain.py
+++ b/docker/usr/local/toolchain/generate_nuc8i7beh_toolchain.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2019 NUbots
+# Copyright (c) 2020 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/module/actuation/FootController/CMakeLists.txt
+++ b/module/actuation/FootController/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/actuation/Kinematics/CMakeLists.txt
+++ b/module/actuation/Kinematics/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2022 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/actuation/Servos/CMakeLists.txt
+++ b/module/actuation/Servos/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2022 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/CMakeLists.txt
+++ b/module/extension/Director/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2021 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/src/director/direct_priority.cpp
+++ b/module/extension/Director/src/director/direct_priority.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2021 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/src/director/hold_run_reason.cpp
+++ b/module/extension/Director/src/director/hold_run_reason.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2022 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/src/director/run_task_pack.cpp
+++ b/module/extension/Director/src/director/run_task_pack.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2021 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/src/information/get_task_data.cpp
+++ b/module/extension/Director/src/information/get_task_data.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2022 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/tests/change_subtask.cpp
+++ b/module/extension/Director/tests/change_subtask.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/tests/missing_provider.cpp
+++ b/module/extension/Director/tests/missing_provider.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/tests/past_self_intersection.cpp
+++ b/module/extension/Director/tests/past_self_intersection.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/tests/self_intersection.cpp
+++ b/module/extension/Director/tests/self_intersection.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/tests/watcher_removal_double.cpp
+++ b/module/extension/Director/tests/watcher_removal_double.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/tests/watcher_removal_double_priority.cpp
+++ b/module/extension/Director/tests/watcher_removal_double_priority.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/tests/watcher_removal_nullptr.cpp
+++ b/module/extension/Director/tests/watcher_removal_nullptr.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/extension/Director/tests/watcher_removal_trigger.cpp
+++ b/module/extension/Director/tests/watcher_removal_trigger.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/input/FakeCamera/CMakeLists.txt
+++ b/module/input/FakeCamera/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2020 NUbots
+Copyright (c) 2021 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/input/GameController/src/GameController.hpp
+++ b/module/input/GameController/src/GameController.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2014 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/input/SensorFilter/src/MotionModel.hpp
+++ b/module/input/SensorFilter/src/MotionModel.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2014 NUbots
+ * Copyright (c) 2016 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/input/SensorFilter/src/VirtualLoadSensor.hpp
+++ b/module/input/SensorFilter/src/VirtualLoadSensor.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2018 NUbots
+ * Copyright (c) 2016 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/localisation/BallLocalisation/CMakeLists.txt
+++ b/module/localisation/BallLocalisation/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/localisation/BallLocalisation/src/BallLocalisation.cpp
+++ b/module/localisation/BallLocalisation/src/BallLocalisation.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 NUbots
+ * Copyright (c) 2022 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/localisation/BallLocalisation/src/BallLocalisation.hpp
+++ b/module/localisation/BallLocalisation/src/BallLocalisation.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 NUbots
+ * Copyright (c) 2022 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/localisation/BallLocalisation/src/BallModel.hpp
+++ b/module/localisation/BallLocalisation/src/BallModel.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/localisation/FieldLocalisation/CMakeLists.txt
+++ b/module/localisation/FieldLocalisation/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/motion/IKKick/src/IKKick.hpp
+++ b/module/motion/IKKick/src/IKKick.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2015 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/network/NUClearNet/CMakeLists.txt
+++ b/module/network/NUClearNet/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/network/NUClearNet/src/NUClearNet.cpp
+++ b/module/network/NUClearNet/src/NUClearNet.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 NUbots
+ * Copyright (c) 2013 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/network/NUClearNet/src/NUClearNet.hpp
+++ b/module/network/NUClearNet/src/NUClearNet.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2014 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/network/NetworkForwarder/CMakeLists.txt
+++ b/module/network/NetworkForwarder/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2017 NUbots
+Copyright (c) 2021 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/network/NetworkForwarder/src/generate_handles.py
+++ b/module/network/NetworkForwarder/src/generate_handles.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2017 NUbots
+# Copyright (c) 2021 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/module/network/PlotJuggler/CMakeLists.txt
+++ b/module/network/PlotJuggler/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2022 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/output/Overview/CMakeLists.txt
+++ b/module/output/Overview/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2021 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/planning/FallingRelaxPlanner/CMakeLists.txt
+++ b/module/planning/FallingRelaxPlanner/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/planning/GetUpPlanner/CMakeLists.txt
+++ b/module/planning/GetUpPlanner/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/planning/PlanKick/CMakeLists.txt
+++ b/module/planning/PlanKick/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/planning/PlanLook/CMakeLists.txt
+++ b/module/planning/PlanLook/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/planning/PlanWalkPath/CMakeLists.txt
+++ b/module/planning/PlanWalkPath/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/platform/HardwareSimulator/src/HardwareSimulator.hpp
+++ b/module/platform/HardwareSimulator/src/HardwareSimulator.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2014 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/platform/OpenCR/HardwareIO/CMakeLists.txt
+++ b/module/platform/OpenCR/HardwareIO/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/platform/Webots/CMakeLists.txt
+++ b/module/platform/Webots/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2021 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/Defender/CMakeLists.txt
+++ b/module/purpose/Defender/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/Goalie/CMakeLists.txt
+++ b/module/purpose/Goalie/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/KeyboardWalk/CMakeLists.txt
+++ b/module/purpose/KeyboardWalk/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2014 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
+++ b/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2014 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/PS3Walk/CMakeLists.txt
+++ b/module/purpose/PS3Walk/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/ScriptRunner/CMakeLists.txt
+++ b/module/purpose/ScriptRunner/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/ScriptRunner/src/ScriptRunner.hpp
+++ b/module/purpose/ScriptRunner/src/ScriptRunner.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/ScriptTuner/CMakeLists.txt
+++ b/module/purpose/ScriptTuner/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/ScriptTuner/src/ScriptTuner.cpp
+++ b/module/purpose/ScriptTuner/src/ScriptTuner.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/Soccer/CMakeLists.txt
+++ b/module/purpose/Soccer/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/Striker/CMakeLists.txt
+++ b/module/purpose/Striker/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/purpose/Tester/CMakeLists.txt
+++ b/module/purpose/Tester/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/Dive/CMakeLists.txt
+++ b/module/skill/Dive/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/Dive/src/Dive.hpp
+++ b/module/skill/Dive/src/Dive.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/GetUp/CMakeLists.txt
+++ b/module/skill/GetUp/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/Look/CMakeLists.txt
+++ b/module/skill/Look/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/QuinticWalk/CMakeLists.txt
+++ b/module/skill/QuinticWalk/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/QuinticWalk/src/QuinticWalk.hpp
+++ b/module/skill/QuinticWalk/src/QuinticWalk.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/Say/CMakeLists.txt
+++ b/module/skill/Say/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/ScriptKick/CMakeLists.txt
+++ b/module/skill/ScriptKick/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2022 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/ScriptKick/src/ScriptKick.hpp
+++ b/module/skill/ScriptKick/src/ScriptKick.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 NUbots
+ * Copyright (c) 2022 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/SplineKick/CMakeLists.txt
+++ b/module/skill/SplineKick/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/skill/Walk/CMakeLists.txt
+++ b/module/skill/Walk/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/AlignBallToGoal/CMakeLists.txt
+++ b/module/strategy/AlignBallToGoal/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/DiveToBall/CMakeLists.txt
+++ b/module/strategy/DiveToBall/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/FallRecovery/CMakeLists.txt
+++ b/module/strategy/FallRecovery/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/FindObject/CMakeLists.txt
+++ b/module/strategy/FindObject/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/KickToGoal/CMakeLists.txt
+++ b/module/strategy/KickToGoal/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/Ready/CMakeLists.txt
+++ b/module/strategy/Ready/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/StandStill/CMakeLists.txt
+++ b/module/strategy/StandStill/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/StrategiseLook/CMakeLists.txt
+++ b/module/strategy/StrategiseLook/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/WalkInsideBoundedBox/CMakeLists.txt
+++ b/module/strategy/WalkInsideBoundedBox/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/WalkToBall/CMakeLists.txt
+++ b/module/strategy/WalkToBall/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/strategy/WalkToFieldPosition/CMakeLists.txt
+++ b/module/strategy/WalkToFieldPosition/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/LocalisationSimulator/CMakeLists.txt
+++ b/module/support/LocalisationSimulator/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2021 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/NUsightHarness/CMakeLists.txt
+++ b/module/support/NUsightHarness/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2019 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/NUsightHarness/src/NUsightHarness.cpp
+++ b/module/support/NUsightHarness/src/NUsightHarness.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2014 NUbots
+ * Copyright (c) 2019 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/support/NUsightHarness/src/NUsightHarness.hpp
+++ b/module/support/NUsightHarness/src/NUsightHarness.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2019 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/support/ReactionTimer/CMakeLists.txt
+++ b/module/support/ReactionTimer/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2016 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/SignalCatcher/CMakeLists.txt
+++ b/module/support/SignalCatcher/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/configuration/GlobalConfig/CMakeLists.txt
+++ b/module/support/configuration/GlobalConfig/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/configuration/GlobalConfig/src/GlobalConfig.cpp
+++ b/module/support/configuration/GlobalConfig/src/GlobalConfig.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2014 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/support/configuration/GlobalConfig/src/GlobalConfig.hpp
+++ b/module/support/configuration/GlobalConfig/src/GlobalConfig.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2014 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/support/configuration/SoccerConfig/CMakeLists.txt
+++ b/module/support/configuration/SoccerConfig/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/configuration/SoccerConfig/src/SoccerConfig.hpp
+++ b/module/support/configuration/SoccerConfig/src/SoccerConfig.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2014 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/support/logging/DataLogging/CMakeLists.txt
+++ b/module/support/logging/DataLogging/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/logging/DataLogging/src/DataLogging.cpp
+++ b/module/support/logging/DataLogging/src/DataLogging.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2017 NUbots
+ * Copyright (c) 2019 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/support/logging/FileLogHandler/CMakeLists.txt
+++ b/module/support/logging/FileLogHandler/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/support/logging/MessageLogHandler/CMakeLists.txt
+++ b/module/support/logging/MessageLogHandler/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/tools/FirmwareInstaller/CMakeLists.txt
+++ b/module/tools/FirmwareInstaller/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/vision/BallDetector/CMakeLists.txt
+++ b/module/vision/BallDetector/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2014 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/vision/BallDetector/src/BallDetector.hpp
+++ b/module/vision/BallDetector/src/BallDetector.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2014 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/vision/FieldLineDetector/CMakeLists.txt
+++ b/module/vision/FieldLineDetector/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2023 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/vision/GoalDetector/src/GoalDetector.cpp
+++ b/module/vision/GoalDetector/src/GoalDetector.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2014 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/module/vision/GreenHorizonDetector/CMakeLists.txt
+++ b/module/vision/GreenHorizonDetector/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2019 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/module/vision/VisualMesh/src/visualmesh/load_model.hpp
+++ b/module/vision/VisualMesh/src/visualmesh/load_model.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 NUbots
+ * Copyright (c) 2021 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/b.py
+++ b/nuclear/b.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2016 NUbots
+# Copyright (c) 2013 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/cmake/Scripts/build_outer_python_binding.py
+++ b/nuclear/cmake/Scripts/build_outer_python_binding.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2019 NUbots
+# Copyright (c) 2017 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/cmake/Scripts/generator/__init__.py
+++ b/nuclear/cmake/Scripts/generator/__init__.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2015 NUbots
+# Copyright (c) 2017 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/extension/extension.cpp
+++ b/nuclear/extension/extension.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2015 NUbots
+ * Copyright (c) 2016 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/message/CMakeLists.txt
+++ b/nuclear/message/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2016 NUbots
+Copyright (c) 2013 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/message/include/message/conversion/proto_neutron_sfinae.hpp
+++ b/nuclear/message/include/message/conversion/proto_neutron_sfinae.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 NUbots
+ * Copyright (c) 2022 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/message/message.cpp
+++ b/nuclear/message/message.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2015 NUbots
+ * Copyright (c) 2016 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/message/proto/Matrix.proto
+++ b/nuclear/message/proto/Matrix.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2016 NUbots
+// Copyright (c) 2014 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/message/proto/Neutron.proto
+++ b/nuclear/message/proto/Neutron.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017 NUbots
+// Copyright (c) 2016 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/message/proto/Transform.proto
+++ b/nuclear/message/proto/Transform.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2016 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/message/proto/Vector.proto
+++ b/nuclear/message/proto/Vector.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2016 NUbots
+// Copyright (c) 2014 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/module/python/__init__.py
+++ b/nuclear/module/python/__init__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2019 NUbots
+# Copyright (c) 2016 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/module/python/nuclear.py
+++ b/nuclear/module/python/nuclear.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2018 NUbots
+# Copyright (c) 2017 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/roles/CMakeLists.txt
+++ b/nuclear/roles/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 MIT License
 
-Copyright (c) 2013 NUbots
+Copyright (c) 2016 NUbots
 
 This file is part of the NUbots codebase.
 See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/roles/generate_role.py
+++ b/nuclear/roles/generate_role.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2016 NUbots
+# Copyright (c) 2013 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/tools/module/generate.py
+++ b/nuclear/tools/module/generate.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2015 NUbots
+# Copyright (c) 2020 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/nuclear/utility/utility.cpp
+++ b/nuclear/utility/utility.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2015 NUbots
+ * Copyright (c) 2016 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/extension/FileWatch.hpp
+++ b/shared/extension/FileWatch.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2017 NUbots
+ * Copyright (c) 2015 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/extension/behaviour/InformationSource.cpp
+++ b/shared/extension/behaviour/InformationSource.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 NUbots
+ * Copyright (c) 2021 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/actuation/BodySide.proto
+++ b/shared/message/actuation/BodySide.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2020 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/actuation/ServoCommand.proto
+++ b/shared/message/actuation/ServoCommand.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2022 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/behaviour/state/Stability.proto
+++ b/shared/message/behaviour/state/Stability.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2021 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/behaviour/state/WalkState.proto
+++ b/shared/message/behaviour/state/WalkState.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/localisation/Ball.proto
+++ b/shared/message/localisation/Ball.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2017 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/localisation/Field.proto
+++ b/shared/message/localisation/Field.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2014 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/output/Buzzer.proto
+++ b/shared/message/output/Buzzer.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/output/CompressedImage.proto
+++ b/shared/message/output/CompressedImage.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2019 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/planning/GetUpWhenFallen.proto
+++ b/shared/message/planning/GetUpWhenFallen.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/planning/KickTo.proto
+++ b/shared/message/planning/KickTo.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/planning/LookAround.proto
+++ b/shared/message/planning/LookAround.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/planning/RelaxWhenFalling.proto
+++ b/shared/message/planning/RelaxWhenFalling.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/planning/WalkPath.proto
+++ b/shared/message/planning/WalkPath.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/platform/ServoLED.proto
+++ b/shared/message/platform/ServoLED.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/purpose/Defender.proto
+++ b/shared/message/purpose/Defender.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/purpose/FindPurpose.proto
+++ b/shared/message/purpose/FindPurpose.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/purpose/Goalie.proto
+++ b/shared/message/purpose/Goalie.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/purpose/Striker.proto
+++ b/shared/message/purpose/Striker.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/skill/ControlFoot.proto
+++ b/shared/message/skill/ControlFoot.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/skill/Dive.proto
+++ b/shared/message/skill/Dive.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/skill/GetUp.proto
+++ b/shared/message/skill/GetUp.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/skill/Look.proto
+++ b/shared/message/skill/Look.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/skill/Say.proto
+++ b/shared/message/skill/Say.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/skill/Walk.proto
+++ b/shared/message/skill/Walk.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/AlignBallToGoal.proto
+++ b/shared/message/strategy/AlignBallToGoal.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/DiveToBall.proto
+++ b/shared/message/strategy/DiveToBall.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/FallRecovery.proto
+++ b/shared/message/strategy/FallRecovery.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/FindFeature.proto
+++ b/shared/message/strategy/FindFeature.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/KickToGoal.proto
+++ b/shared/message/strategy/KickToGoal.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/LookAtFeature.proto
+++ b/shared/message/strategy/LookAtFeature.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/Ready.proto
+++ b/shared/message/strategy/Ready.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/StandStill.proto
+++ b/shared/message/strategy/StandStill.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/WalkInsideBoundedBox.proto
+++ b/shared/message/strategy/WalkInsideBoundedBox.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/WalkToBall.proto
+++ b/shared/message/strategy/WalkToBall.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/strategy/WalkToFieldPosition.proto
+++ b/shared/message/strategy/WalkToFieldPosition.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/support/nuclear/ReactionStatistics.proto
+++ b/shared/message/support/nuclear/ReactionStatistics.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2014 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/support/nusight/Overview.proto
+++ b/shared/message/support/nusight/Overview.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2015 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/vision/Ball.proto
+++ b/shared/message/vision/Ball.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2019 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/vision/FieldLines.proto
+++ b/shared/message/vision/FieldLines.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2023 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/vision/Goal.proto
+++ b/shared/message/vision/Goal.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2019 NUbots
+// Copyright (c) 2013 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/vision/GreenHorizon.proto
+++ b/shared/message/vision/GreenHorizon.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2019 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/message/vision/VisualMesh.proto
+++ b/shared/message/vision/VisualMesh.proto
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2013 NUbots
+// Copyright (c) 2018 NUbots
 //
 // This file is part of the NUbots codebase.
 // See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/input/FrameID.cpp
+++ b/shared/utility/input/FrameID.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2017 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/input/FrameID.hpp
+++ b/shared/utility/input/FrameID.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2023 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/input/LimbID.cpp
+++ b/shared/utility/input/LimbID.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2017 NUbots
+ * Copyright (c) 2014 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/localisation/transform.hpp
+++ b/shared/utility/localisation/transform.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2014 NUbots
+ * Copyright (c) 2013 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/math/comparison.hpp
+++ b/shared/utility/math/comparison.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2015 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/math/filter/ParticleFilter.hpp
+++ b/shared/utility/math/filter/ParticleFilter.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2014 NUbots
+ * Copyright (c) 2019 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/math/filter/UKF.hpp
+++ b/shared/utility/math/filter/UKF.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2014 NUbots
+ * Copyright (c) 2019 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/math/ransac/NPartiteRansac.hpp
+++ b/shared/utility/math/ransac/NPartiteRansac.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2015 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/math/ransac/RansacResult.hpp
+++ b/shared/utility/math/ransac/RansacResult.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2014 NUbots
+ * Copyright (c) 2015 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/nusight/NUhelpers.hpp
+++ b/shared/utility/nusight/NUhelpers.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2014 NUbots
+ * Copyright (c) 2013 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/skill/Script.hpp
+++ b/shared/utility/skill/Script.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 NUbots
+ * Copyright (c) 2022 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/support/math_string.hpp
+++ b/shared/utility/support/math_string.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUbots
+ * Copyright (c) 2017 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/shared/utility/vision/fourcc.hpp
+++ b/shared/utility/vision/fourcc.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016 NUbots
+ * Copyright (c) 2020 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2015 NUbots
+# Copyright (c) 2016 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/tools/format.py
+++ b/tools/format.py
@@ -151,7 +151,6 @@ def _get_history_dates(path):
 # For example the year the file was added and the year it was last modified for a licence header
 def _get_args(path):
     modified, added = _get_history_dates(path)
-    print(modified, added)
     return {"added": f"{added}", "modified": f"{modified}"}
 
 

--- a/tools/format.py
+++ b/tools/format.py
@@ -133,11 +133,11 @@ def _get_history_dates(path):
 
     dates = []
     for i in range(len(all_dates)):
-        sha, file, date = all_dates[i]
+        file, sha, date = all_dates[i]
         dates.append(date)
 
         if i + 1 != len(all_dates):
-            _, next_file, __ = all_dates[i + 1]
+            next_file, _, __ = all_dates[i + 1]
             if (
                 file != next_file
                 and 0 != sp_run(["git", "show", f"{sha}:{next_file}"], stderr=STDOUT, stdout=DEVNULL).returncode
@@ -151,6 +151,7 @@ def _get_history_dates(path):
 # For example the year the file was added and the year it was last modified for a licence header
 def _get_args(path):
     modified, added = _get_history_dates(path)
+    print(modified, added)
     return {"added": f"{added}", "modified": f"{modified}"}
 
 

--- a/tools/nbs/camera_calibration/__init__.py
+++ b/tools/nbs/camera_calibration/__init__.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2015 NUbots
+# Copyright (c) 2020 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/tools/requirements.map
+++ b/tools/requirements.map
@@ -11,3 +11,4 @@ tqdm            tqdm
 xxhash          xxhash
 si_prefix       si-prefix
 pytimeparse     pytimeparse
+pygit2          pygit2

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -11,3 +11,4 @@ tqdm~=4.48.2
 xxhash~=1.4.2
 si-prefix~=1.2.2
 pytimeparse~=1.1.8
+pygit2~=1.13.3

--- a/tools/utility/__init__.py
+++ b/tools/utility/__init__.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2015 NUbots
+# Copyright (c) 2021 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/tools/utility/dockerise/platform.py
+++ b/tools/utility/dockerise/platform.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2021 NUbots
+# Copyright (c) 2019 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.

--- a/tools/utility/nbs/protobuf_types.py
+++ b/tools/utility/nbs/protobuf_types.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2019 NUbots
+# Copyright (c) 2017 NUbots
 #
 # This file is part of the NUbots codebase.
 # See https://github.com/NUbots/NUbots for further info.


### PR DESCRIPTION
For formatting in the licence git was not doing the best job of tracking the dates of changes as it was tracking through what it considered copies not just through actual renames.

The result was lots of files were considered to be older than they were which made PRs sometimes fail as when they were squashed into the merge queue as some of the files would go from being copies to not etc.

That may still happen but it should happen less now?

### Reviewers, Note

I don't like how this works, and it makes things much slower.
Please find a better option thanks