### PR TITLE
Fix check for in/out of convex hull

### DIFF
--- a/module/vision/BallDetector/src/BallDetector.cpp
+++ b/module/vision/BallDetector/src/BallDetector.cpp
@@ -124,13 +124,8 @@ namespace module::vision {
 
                 // Partition the clusters such that clusters above the green horizons are removed,
                 // and then resize the vector to remove them
-                auto green_boundary = utility::vision::visualmesh::check_green_horizon_side(clusters.begin(),
-                                                                                            clusters.end(),
-                                                                                            horizon.horizon.begin(),
-                                                                                            horizon.horizon.end(),
-                                                                                            uPCw,
-                                                                                            false,
-                                                                                            true);
+                auto green_boundary =
+                    utility::vision::visualmesh::check_green_horizon_side(clusters, horizon.horizon, uPCw, false, true);
                 clusters.resize(std::distance(clusters.begin(), green_boundary));
 
                 log<NUClear::DEBUG>(fmt::format("Found {} clusters below green horizon", clusters.size()));

--- a/module/vision/FieldLineDetector/src/FieldLineDetector.cpp
+++ b/module/vision/FieldLineDetector/src/FieldLineDetector.cpp
@@ -90,13 +90,8 @@ namespace module::vision {
             log<NUClear::DEBUG>(fmt::format("Found {} clusters", clusters.size()));
             // Partition the clusters such that clusters above the green horizons are removed,
             // and then resize the vector to remove them
-            auto green_boundary = utility::vision::visualmesh::check_green_horizon_side(clusters.begin(),
-                                                                                        clusters.end(),
-                                                                                        horizon.horizon.begin(),
-                                                                                        horizon.horizon.end(),
-                                                                                        uPCw,
-                                                                                        false,
-                                                                                        true);
+            auto green_boundary =
+                utility::vision::visualmesh::check_green_horizon_side(clusters, horizon.horizon, uPCw, false, true);
             clusters.resize(std::distance(clusters.begin(), green_boundary));
             log<NUClear::DEBUG>(fmt::format("Found {} clusters below green horizon", clusters.size()));
 

--- a/module/vision/GoalDetector/src/GoalDetector.cpp
+++ b/module/vision/GoalDetector/src/GoalDetector.cpp
@@ -116,13 +116,8 @@ namespace module::vision {
 
                 log<NUClear::DEBUG>(fmt::format("Found {} clusters", clusters.size()));
 
-                auto green_boundary = utility::vision::visualmesh::check_green_horizon_side(clusters.begin(),
-                                                                                            clusters.end(),
-                                                                                            horizon.horizon.begin(),
-                                                                                            horizon.horizon.end(),
-                                                                                            rays,
-                                                                                            true,
-                                                                                            true);
+                auto green_boundary =
+                    utility::vision::visualmesh::check_green_horizon_side(clusters, horizon.horizon, rays, true, true);
                 clusters.resize(std::distance(clusters.begin(), green_boundary));
 
                 log<NUClear::DEBUG>(fmt::format("Found {} clusters that intersect the green horizon", clusters.size()));

--- a/shared/tests/data/TestConvexHull.yaml
+++ b/shared/tests/data/TestConvexHull.yaml
@@ -44,3 +44,19 @@ polygon:
     - [0.1, 0.1]
     - [0.5, 1.5]
   hull: [4, 10, 7, 2, 0, 4]
+  check_points:
+    - [2.0, 2.0]
+    - [2.0, -2.0]
+    - [-2.0, 2.0]
+    - [-2.0, -2.0]
+    - [0.2, 0.3]
+    - [0.4, 0.5]
+    - [0.3, 0.7]
+  check_results:
+    - false
+    - false
+    - false
+    - false
+    - true
+    - true
+    - true

--- a/shared/utility/math/geometry/ConvexHull.hpp
+++ b/shared/utility/math/geometry/ConvexHull.hpp
@@ -376,7 +376,7 @@ namespace utility::math::geometry {
     };
 
     /// @brief Determine if point is in the convex hull
-    /// @param hull_indices The indices of the points in the convex hull, corresponding to `points`
+    /// @param hull_indices The indices of the points in the convex hull, corresponding to `points`, ordered
     /// @param points All the points in our space, including points not to be used in the convex hull algorithm
     /// @param point The point to check if it is in the convex hull
     /// @return The location of the point relative to the convex hull
@@ -389,18 +389,9 @@ namespace utility::math::geometry {
             Eigen::Vector3d p1 = hull[i];
             Eigen::Vector3d p2 = hull[(i + 1) % hull.size()];
 
-            // if ((point - p1).dot(p2 - p1) >= 0 && (point - p2).dot(p1 - p2) >= 0) {
-            //     return PointLocation::ON_BOUNDARY;
-            // }
-
             double angle = calculate_angle(point, p1, p2);
 
-            if ((p2 - p1).y() >= 0) {
-                winding_number -= angle;
-            }
-            else {
-                winding_number += angle;
-            }
+            winding_number += angle;
         }
 
         if (std::abs(winding_number) < 1e-6) {

--- a/shared/utility/vision/visualmesh/VisualMesh.hpp
+++ b/shared/utility/vision/visualmesh/VisualMesh.hpp
@@ -125,37 +125,44 @@ namespace utility::vision::visualmesh {
         }
     }
 
-    template <typename Iterator, typename HorizonIt>
-    Iterator check_green_horizon_side(Iterator first,
-                                      Iterator last,
-                                      HorizonIt horizon_first,
-                                      HorizonIt horizon_last,
-                                      const Eigen::Matrix<double, 3, Eigen::Dynamic>& rays,
-                                      const bool& up   = true,
-                                      const bool& down = true) {
+    auto check_green_horizon_side(std::vector<std::vector<int>>& clusters,
+                                  const std::vector<Eigen::Vector3d>& horizon,
+                                  const Eigen::Matrix<double, 3, Eigen::Dynamic>& rays,
+                                  const bool& outside = true,
+                                  const bool& inside  = true) {
 
-        using value_type = typename std::iterator_traits<Iterator>::value_type;
-
-        auto success = [&](const bool& a, const bool& b) {
-            return (up && a && !down)     // We were looking for above and found them, we weren't looking for below
-                   || (down && b && !up)  // We were looking for below and found them, we weren't looking for above
-                   || ((up && a) || (down && b));  // We were looking for everything and we found it
+        auto success = [&](const bool& cluster_outside, const bool& cluster_inside) {
+            if (outside && inside) {
+                return cluster_outside && cluster_inside;
+            }
+            else if (outside) {
+                return cluster_outside && !cluster_inside;
+            }
+            else {
+                return cluster_inside && !cluster_outside;
+            }
         };
 
         // Move any clusters that dont intersect the green horizon to the end of the list
         // We need to find one point above the green horizon and one below it
-        return std::partition(first, last, [&](const value_type& cluster) {
-            bool above = false;
-            bool below = false;
-            for (unsigned int idx = 0; idx < cluster.size() && !success(above, below); ++idx) {
-                if (utility::math::geometry::point_under_hull(rays.col(cluster[idx]), horizon_first, horizon_last)) {
-                    above = true;
+        return std::partition(clusters.begin(), clusters.end(), [&](const std::vector<int>& cluster) {
+            bool out = false;
+            bool in  = false;
+
+            for (unsigned int idx = 0; idx < cluster.size(); ++idx) {
+                auto position = utility::math::geometry::point_in_convex_hull(horizon,
+                                                                              rays,
+                                                                              Eigen::Vector3d(rays.col(cluster[idx])));
+                NUClear::log<NUClear::INFO>("Point in convex hull: ", position);
+
+                if (position == utility::math::geometry::PointLocation::INSIDE) {
+                    in = true;
                 }
                 else {
-                    below = true;
+                    out = true;
                 }
             }
-            return success(above, below);
+            return success(out, in);
         });
     }
 }  // namespace utility::vision::visualmesh

--- a/shared/utility/vision/visualmesh/VisualMesh.hpp
+++ b/shared/utility/vision/visualmesh/VisualMesh.hpp
@@ -143,24 +143,18 @@ namespace utility::vision::visualmesh {
             }
         };
 
-        // Move any clusters that dont intersect the green horizon to the end of the list
+        // Move any clusters that don't intersect the green horizon to the end of the list
         // We need to find one point above the green horizon and one below it
         return std::partition(clusters.begin(), clusters.end(), [&](const std::vector<int>& cluster) {
             bool out = false;
             bool in  = false;
 
             for (unsigned int idx = 0; idx < cluster.size(); ++idx) {
-                auto position = utility::math::geometry::point_in_convex_hull(horizon,
-                                                                              rays,
-                                                                              Eigen::Vector3d(rays.col(cluster[idx])));
-                NUClear::log<NUClear::INFO>("Point in convex hull: ", position);
-
-                if (position == utility::math::geometry::PointLocation::INSIDE) {
-                    in = true;
-                }
-                else {
-                    out = true;
-                }
+                bool position =
+                    utility::math::geometry::point_in_convex_hull(horizon, Eigen::Vector3d(rays.col(cluster[idx])));
+                // Only set if it is in or out as we want to find across the cluster
+                in  = position ? true : in;
+                out = !position ? true : out;
             }
             return success(out, in);
         });


### PR DESCRIPTION
Check was broken since it assumed above/below but we don't have above/below we have in/out. 

Added in tests for hull side check.