### PR TITLE
Reduce default gains in various scripts and ScriptTuner

### DIFF
--- a/module/purpose/ScriptTuner/src/ScriptTuner.hpp
+++ b/module/purpose/ScriptTuner/src/ScriptTuner.hpp
@@ -62,7 +62,7 @@ namespace module::purpose {
         bool angle_or_gain;
 
         /// @brief Default gain for new frames
-        const size_t default_gain = 10;
+        const double default_gain = 6.64;
 
         /// @brief Default duration for new frames
         const size_t default_duration = 1000;

--- a/module/skill/Walk/data/config/Walk.yaml
+++ b/module/skill/Walk/data/config/Walk.yaml
@@ -29,7 +29,7 @@ walk:
     final_position_ratio: [0.5, 0.5, 1]
 
 gains:
-  arms: 8
+  arms: 1
 
 # Fixed position of the arm joints during walking
 arms:

--- a/module/skill/Walk/data/config/nugus1/Walk.yaml
+++ b/module/skill/Walk/data/config/nugus1/Walk.yaml
@@ -29,7 +29,7 @@ walk:
     final_position_ratio: [0.5, 0.5, 1]
 
 gains:
-  arms: 8
+  arms: 1
 
 # Fixed position of the arm joints during walking
 arms:

--- a/module/skill/Walk/data/config/nugus3/Walk.yaml
+++ b/module/skill/Walk/data/config/nugus3/Walk.yaml
@@ -29,7 +29,7 @@ walk:
     final_position_ratio: [0.5, 0.5, 1]
 
 gains:
-  arms: 8
+  arms: 1
 
 # Fixed position of the arm joints during walking
 arms:

--- a/module/skill/Walk/data/config/nugus4/Walk.yaml
+++ b/module/skill/Walk/data/config/nugus4/Walk.yaml
@@ -29,7 +29,7 @@ walk:
     final_position_ratio: [0.5, 0.5, 1]
 
 gains:
-  arms: 8
+  arms: 1
 
 # Fixed position of the arm joints during walking
 arms:

--- a/shared/utility/skill/scripts/nugus/Stand.yaml
+++ b/shared/utility/skill/scripts/nugus/Stand.yaml
@@ -2,73 +2,73 @@
   targets:
     - id: R_HIP_YAW
       position: -0.0291527491
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: L_HIP_YAW
       position: 0.0289999992
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: R_HIP_ROLL
       position: -0.0979999974
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: L_HIP_ROLL
       position: 0.0981987417
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: R_HIP_PITCH
       position: -0.490999997
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: L_HIP_PITCH
       position: -0.490993708
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: R_KNEE
       position: 0.785494089
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: L_KNEE
       position: 0.785000026
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: R_ANKLE_PITCH
       position: -0.400000000
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: L_ANKLE_PITCH
       position: -0.400000000
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: R_ANKLE_ROLL
       position: 0.155000000
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: L_ANKLE_ROLL
       position: -0.155000000
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: R_SHOULDER_PITCH
       position: 2.06800008
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: R_SHOULDER_ROLL
       position: 0.175999999
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: R_ELBOW
       position: -1.57424903
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: L_SHOULDER_PITCH
       position: 2.06811905
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: L_SHOULDER_ROLL
       position: 0.175999999
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: L_ELBOW
       position: -1.57424903
-      gain: 10
+      gain: 6.64
       torque: 100

--- a/shared/utility/skill/scripts/nugus/Zombie.yaml
+++ b/shared/utility/skill/scripts/nugus/Zombie.yaml
@@ -1,82 +1,82 @@
 - targets:
     - id: R_SHOULDER_PITCH
       position: 0
-      gain: 10
+      gain: 6.64
       torque: 100
-    - gain: 10
+    - gain: 6.64
       position: 0
       id: L_SHOULDER_PITCH
       torque: 100
     - id: R_SHOULDER_ROLL
-      gain: 10
+      gain: 6.64
       position: 0
       torque: 100
     - position: 0
       id: L_SHOULDER_ROLL
-      gain: 10
+      gain: 6.64
       torque: 100
     - position: 0
-      gain: 10
+      gain: 6.64
       id: R_ELBOW
       torque: 100
     - position: 0
       id: L_ELBOW
-      gain: 10
+      gain: 6.64
       torque: 100
     - id: R_HIP_YAW
-      gain: 10
+      gain: 6.64
       position: 0
       torque: 100
-    - gain: 10
+    - gain: 6.64
       position: 0
       id: L_HIP_YAW
       torque: 100
     - position: 0
-      gain: 10
+      gain: 6.64
       id: R_HIP_ROLL
       torque: 100
     - position: 0
       id: L_HIP_ROLL
-      gain: 10
+      gain: 6.64
       torque: 100
-    - gain: 10
+    - gain: 6.64
       id: R_HIP_PITCH
       position: 0
       torque: 100
     - id: L_HIP_PITCH
-      gain: 10
+      gain: 6.64
       position: 0
       torque: 100
     - id: R_KNEE
-      gain: 10
+      gain: 6.64
       position: 0
       torque: 100
     - id: L_KNEE
-      gain: 10
+      gain: 6.64
       position: 0
       torque: 100
-    - gain: 10
+    - gain: 6.64
       position: 0
       id: R_ANKLE_PITCH
       torque: 100
     - id: L_ANKLE_PITCH
       position: 0
-      gain: 10
+      gain: 6.64
       torque: 100
-    - gain: 10
+    - gain: 6.64
       position: 0
       id: R_ANKLE_ROLL
       torque: 100
     - id: L_ANKLE_ROLL
-      gain: 10
+      gain: 6.64
       position: 0
       torque: 100
     - id: HEAD_PITCH
-      gain: 10
+      gain: 6.64
       position: 0
       torque: 100
     - id: HEAD_YAW
       position: 0
-      gain: 10
+      gain: 6.64
       torque: 100
   duration: 1000


### PR DESCRIPTION
This PR reduces arm gains in walk engine as intermediate step to reduce the erratic movement when starting walk engine, however, we should figure out a better solution for this going forward.

Also reduces default gains in script tuner and various other scripts to prevent oscillations from overshoot.