### PR TITLE
Fix scripts cutting out when running / explicitly disable the model watchdog

### DIFF
--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -231,6 +231,7 @@ namespace module::platform::OpenCR {
 
                         // Stop the model watchdog since we have it now
                         // Start the packet watchdog since the main loop is now starting
+                        model_watchdog.disable();
                         model_watchdog.unbind();
                         log<NUClear::WARN>("Packet watchdog enabled");
                         packet_watchdog.enable();


### PR DESCRIPTION
I'm not really sure why this works, maybe unbind doesn't actually disable it? But the problem with running scripts was that the model watchdog was enabled, and at some point in the script the packet watchdog ran and brought up that 'cannot run packet watchdog when model watchdog is enabled' log. At that point the hardware io loop is broken and the robot won't move again.
Adding the disable stops this from happening and the scripts all run fine (ran many times on two different robots).