### PR TITLE
Temporarily remove formatting license headers

### DIFF
--- a/tools/format.py
+++ b/tools/format.py
@@ -48,40 +48,41 @@ repo = pygit2.Repository(b.project_dir)
 # The extensions that are handled by the various formatters
 formatters = OrderedDict()
 
-formatters["licence"] = {
-    "format": [
-        [
-            "licenseheaders",
-            "-t",
-            os.path.join(b.project_dir, ".licence.tmpl"),
-            "--years={added}",
-            "--owner=NUbots",
-            f"--projname=NUbots",
-            "--projurl=https://github.com/NUbots/NUbots",
-            "-f",
-            "{path}",
-        ]
-    ],
-    "include": [
-        "*.cpp",
-        "*.hpp",
-        "*.h",
-        "*.c",
-        "*.py",
-        "*.sh",
-        "*.cmake",
-        "*.proto",
-        "CMakeLists.txt",
-        "**/CMakeLists.txt",
-        "Dockerfile",
-        "**/Dockerfile",
-    ],
-    "exclude": [
-        "shared/utility/motion/splines/*",
-        "shared/utility/platform/models/nugus/nugus.proto",
-        "nusight2/src/assets/robot-models/nugus/nugus.proto",
-    ],  # TODO exclude files that are not ours
-}
+# TODO: Fix this
+# formatters["licence"] = {
+#     "format": [
+#         [
+#             "licenseheaders",
+#             "-t",
+#             os.path.join(b.project_dir, ".licence.tmpl"),
+#             "--years={added}",
+#             "--owner=NUbots",
+#             f"--projname=NUbots",
+#             "--projurl=https://github.com/NUbots/NUbots",
+#             "-f",
+#             "{path}",
+#         ]
+#     ],
+#     "include": [
+#         "*.cpp",
+#         "*.hpp",
+#         "*.h",
+#         "*.c",
+#         "*.py",
+#         "*.sh",
+#         "*.cmake",
+#         "*.proto",
+#         "CMakeLists.txt",
+#         "**/CMakeLists.txt",
+#         "Dockerfile",
+#         "**/Dockerfile",
+#     ],
+#     "exclude": [
+#         "shared/utility/motion/splines/*",
+#         "shared/utility/platform/models/nugus/nugus.proto",
+#         "nusight2/src/assets/robot-models/nugus/nugus.proto",
+#     ],  # TODO exclude files that are not ours
+# }
 formatters["clang-format"] = {
     "format": [["clang-format", "-i", "-style=file", "{path}"]],
     "include": ["*.h", "*.c", "*.cc", "*.cxx", "*.cpp", "*.hpp", "*.ipp", "*.frag", "*.glsl", "*.vert", "*.proto"],


### PR DESCRIPTION
The formatting of license headers is causing too many issues with CI. This PR temporarily comments out the formatting of license header files so that other PR's can be merged while it is fixed.