### PR TITLE
Fix asan errors on main

### DIFF
--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
@@ -73,8 +73,8 @@ namespace module::strategy {
 
                 // Compute the current position error and heading error in field {f} space
                 const double position_error = (Hfr.translation().head(2) - rPFf.head(2)).norm();
-                const Eigen::Vector3d uXRf  = Hfr.linear().col(0).head(2);
-                const double heading_error  = std::acos(std::max(-1.0, std::min(1.0, uXRf.dot(uHFf.head(2)))));
+                Eigen::Vector2d uXRf        = Hfr.rotation().col(0).head<2>();
+                const double heading_error  = std::acos(std::max(-1.0, std::min(1.0, uXRf.dot(uHFf.head<2>()))));
 
                 // If we have stopped and our position and heading error is below resume tolerance, then remain stopped
                 if (stopped && position_error < cfg.resume_tolerance && heading_error < cfg.resume_tolerance) {

--- a/module/vision/VisualMesh/src/VisualMesh.cpp
+++ b/module/vision/VisualMesh/src/VisualMesh.cpp
@@ -120,7 +120,7 @@ namespace module::vision {
                             // rPCw * abs(rCWw.z) / rPCw.z) + rCWw
                             rPWw =
                                 (result.rays.array()
-                                 * (Hwc_translation.z() / result.rays.row(2).replicate(1, result.rays.cols()).array())
+                                 * (Hwc_translation.z() / result.rays.row(2).replicate(result.rays.rows(), 1).array())
                                        .abs())
                                     .matrix()
                                 + Hwc_translation.replicate(1, result.rays.cols());

--- a/shared/utility/localisation/OccupancyMap.hpp
+++ b/shared/utility/localisation/OccupancyMap.hpp
@@ -124,7 +124,11 @@ namespace module::localisation {
          */
         void add_rectangle(int x0, int y0, int width, int height, int inner_width) {
             for (int i = 0; i < inner_width; i++) {
-                add_rectangle(x0 + i, y0 + i, width - (2 * i), height - (2 * i));
+                int new_width  = width - (2 * i);
+                int new_height = height - (2 * i);
+                if (new_width > 0 && new_height > 0) {
+                    add_rectangle(x0 + i, y0 + i, new_width, new_height);
+                }
             }
         }
 


### PR DESCRIPTION
Main currently has three asan errors that occur during normal `robocup` play. 

- FieldLocalisation: the occupany map rectangles were sometimes being created with negative length/width
- Vision: size of the matrices in the one-liner for rPWw were wrong
- WalkToFieldPosition: a 3d vector was initialised with only two values, leaving the last value uninitialised