### PR TITLE
More thoroughly reset odometry when resetting localisation 

### DIFF
--- a/module/input/SensorFilter/data/config/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/SensorFilter.yaml
@@ -73,7 +73,7 @@ mahony:
   # Mahony "Integral" Gain used to compute bias
   Ki: 0.3
   # Mahony Filter initial bias
-  bias: [0, 0, 0]
+  initial_bias: [0, 0, 0]
 
 # Tuning parameters to scale walk command to match actual achieved velocity for deckreckoning x, y, theta
 deadreckoning_scale: [1, 1, 0.6]

--- a/module/input/SensorFilter/data/config/nugus/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/nugus/SensorFilter.yaml
@@ -73,7 +73,7 @@ mahony:
   # Mahony "Integral" Gain used to compute bias
   Ki: 0.3
   # Mahony Filter initial bias
-  bias: [0, 0, 0]
+  initial_bias: [0, 0, 0]
 
 # Tuning parameters to scale walk command to match actual achieved velocity for deckreckoning x, y, theta
 deadreckoning_scale: [1, 1, 0.6]

--- a/module/input/SensorFilter/src/sensorfilter/KalmanFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/KalmanFilter.cpp
@@ -57,9 +57,13 @@ namespace module::input {
         // Initialise the Kalman filter
         kf.update(cfg.Ac, cfg.Bc, cfg.C, cfg.Q, cfg.R);
         kf.reset(Eigen::VectorXd::Zero(n_states), Eigen::MatrixXd::Identity(n_states, n_states));
-        Hwt.translation() = Eigen::VectorXd(config["initial_rTWw"].as<Expression>());
-        Hwt.linear()      = EulerIntrinsicToMatrix(Eigen::Vector3d(config["initial_rpy"].as<Expression>()));
+        Hwt = cfg.initial_Hwt;
         update_loop.enable();
+    }
+
+    void SensorFilter::reset_kf() {
+        kf.reset(Eigen::VectorXd::Zero(n_states), Eigen::MatrixXd::Identity(n_states, n_states));
+        Hwt = cfg.initial_Hwt;
     }
 
     void SensorFilter::update_odometry_kf(std::unique_ptr<Sensors>& sensors,

--- a/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/MahonyFilter.cpp
@@ -53,12 +53,16 @@ namespace module::input {
 
     void SensorFilter::configure_mahony(const Configuration& config) {
         // Mahony Filter Config
-        cfg.Ki            = config["mahony"]["Ki"].as<Expression>();
-        cfg.Kp            = config["mahony"]["Kp"].as<Expression>();
-        cfg.bias          = Eigen::Vector3d(config["mahony"]["bias"].as<Expression>());
-        Hwt.translation() = Eigen::VectorXd(config["initial_rTWw"].as<Expression>());
-        Hwt.linear()      = EulerIntrinsicToMatrix(Eigen::Vector3d(config["initial_rpy"].as<Expression>()));
-        Hwt_mahony        = Hwt;
+        cfg.Ki           = config["mahony"]["Ki"].as<Expression>();
+        cfg.Kp           = config["mahony"]["Kp"].as<Expression>();
+        cfg.initial_bias = Eigen::Vector3d(config["mahony"]["initial_bias"].as<Expression>());
+        bias_mahony      = cfg.initial_bias;
+        Hwt_mahony       = cfg.initial_Hwt;
+    }
+
+    void SensorFilter::reset_mahony() {
+        bias_mahony = cfg.initial_bias;
+        Hwt_mahony  = cfg.initial_Hwt;
     }
 
     void SensorFilter::update_odometry_mahony(std::unique_ptr<Sensors>& sensors,
@@ -83,7 +87,7 @@ namespace module::input {
                                             dt,
                                             cfg.Ki,
                                             cfg.Kp,
-                                            cfg.bias);
+                                            bias_mahony);
 
         // Convert the rotation matrices from anchor and mahony method into euler angles
         Eigen::Vector3d rpy_mahony = MatrixToEulerIntrinsic(Hwt_mahony.linear());

--- a/module/input/SensorFilter/src/sensorfilter/UKF.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/UKF.cpp
@@ -113,6 +113,14 @@ namespace module::input {
         reset_filter.store(true);
     }
 
+    void SensorFilter::reset_ukf() {
+        // Set our initial state with the config means and covariances, flagging the filter to reset it
+        ukf.set_state(cfg.initial_mean.getStateVec(), cfg.initial_covariance.asDiagonal());
+
+        // Don't filter any sensors until we have initialised the filter
+        reset_filter.store(true);
+    }
+
     void SensorFilter::update_odometry_ukf(std::unique_ptr<Sensors>& sensors,
                                            const std::shared_ptr<const Sensors>& previous_sensors,
                                            const RawSensors& raw_sensors) {

--- a/roles/webots/localisation.role
+++ b/roles/webots/localisation.role
@@ -28,7 +28,6 @@ nuclear_role(
   vision::BallDetector
   vision::RobotDetector
   vision::FieldLineDetector
-  output::ImageCompressor
   # Localisation
   localisation::BallLocalisation
   localisation::FieldLocalisation

--- a/roles/webots/robocup.role
+++ b/roles/webots/robocup.role
@@ -11,6 +11,8 @@ nuclear_role(
   network::PlotJuggler
   network::NUClearNet
   network::NetworkForwarder
+  output::Overview
+  output::ImageCompressor
   # Sensors
   input::GameController
   input::SensorFilter

--- a/shared/message/vision/Robot.proto
+++ b/shared/message/vision/Robot.proto
@@ -47,7 +47,6 @@ package message.vision;
 
 import "google/protobuf/timestamp.proto";
 import "Vector.proto";
-import "Matrix.proto";
 import "Transform.proto";
 
 message Robot {


### PR DESCRIPTION
When the robot gets penalised, it's localisation becomes very off because it is moved in simulation or physically moved to a new position. We have a localisation reset to fix this, but it doesn't fully reset odometry when it resets localisation.

This PR resets the fiilters and odometry to the initial values from config.
