### PR TITLE
Tunes Frankie (nugus4) and small code changes for quality of life and fixes for the real robot and lab

### DIFF
--- a/module/input/Camera/data/config/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/Cameras/Left.yaml
@@ -7,9 +7,9 @@ settings:
   OffsetX: 0
   OffsetY: 0
   ExposureAuto: Continuous # Options: Off, Once, Continuous
-  AutoExposureExposureTimeUpperLimit: 4000 # Lower time reduces motion blur
+  AutoExposureExposureTimeUpperLimit: 6000 # Lower time reduces motion blur
   GainAuto: Off # Options: Off, Once, Continuous
-  Gain: 18
+  Gain: 10
   BalanceWhiteAuto: Off # Options: Off, Once, Continuous
   AcquisitionFrameRateEnable: true
   DeviceLinkThroughputLimit: 60000000 # Throughput can limit the framerate

--- a/module/input/Camera/data/config/nugus4/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus4/Cameras/Left.yaml
@@ -10,7 +10,7 @@ lens:
   # focal_length / (camera_pixel_size * width)
   # 1.98mm / (4.8µm * 1280px) = 0.322265625
 
-  # NOTE: all lens parameters are based on a full size image (without width/height/offset va>
+  # NOTE: all lens parameters are based on a full size image (without width/height/offset values)
 
   # Lens projection type
   projection: EQUIDISTANT
@@ -20,7 +20,7 @@ lens:
   centre: [0.02072339174622414, -0.0011612242293956145]
   # The polynomial distortion coefficients for the lens
   k: [0.38553542593448015, 0.1498415334589703]
-  # The angular diameter that the lens covers (the area that light hits on the sensor) or au>
+  # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
   fov: 180 * pi / 180
 
 # Camera kinematics
@@ -28,6 +28,6 @@ urdf_path: "models/robot.urdf"
 
 is_left_camera: true
 
-roll_offset: -2.5 * pi / 180
+roll_offset: 0.0 * pi / 180
 
-pitch_offset: 14.0 * pi / 180
+pitch_offset: 8.0 * pi / 180

--- a/module/input/Camera/data/config/nugus4/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus4/Cameras/Left.yaml
@@ -28,6 +28,6 @@ urdf_path: "models/robot.urdf"
 
 is_left_camera: true
 
-roll_offset: 0.0 * pi / 180
+roll_offset: -2.5 * pi / 180
 
-pitch_offset: 10.0 * pi / 180
+pitch_offset: 14.0 * pi / 180

--- a/module/input/Camera/data/config/nugus4/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/nugus4/Cameras/Left.yaml
@@ -1,4 +1,4 @@
-serial_number: 01188260
+serial_number: 0118847F
 
 lens:
   # Lens: Lensagon BF10M19828S118C
@@ -10,17 +10,17 @@ lens:
   # focal_length / (camera_pixel_size * width)
   # 1.98mm / (4.8µm * 1280px) = 0.322265625
 
-  # NOTE: all lens parameters are based on a full size image (without width/height/offset values)
+  # NOTE: all lens parameters are based on a full size image (without width/height/offset va>
 
   # Lens projection type
   projection: EQUIDISTANT
   # Normalised focal length: focal length in pixels / image width
-  focal_length: 0.34767878619271286
+  focal_length: 0.34
   # Normalised image centre offset: pixels from centre to optical axis / image width
-  centre: [-0.01370165657132854, -0.013645629277120971]
+  centre: [0.02072339174622414, -0.0011612242293956145]
   # The polynomial distortion coefficients for the lens
-  k: [0.46673390301927425, 0.15017118169604132]
-  # The angular diameter that the lens covers (the area that light hits on the sensor) or auto for the entire sensor
+  k: [0.38553542593448015, 0.1498415334589703]
+  # The angular diameter that the lens covers (the area that light hits on the sensor) or au>
   fov: 180 * pi / 180
 
 # Camera kinematics
@@ -28,6 +28,6 @@ urdf_path: "models/robot.urdf"
 
 is_left_camera: true
 
-roll_offset: 2.0 * pi / 180
+roll_offset: 0.0 * pi / 180
 
-pitch_offset: 0.0 * pi / 180
+pitch_offset: 10.0 * pi / 180

--- a/module/localisation/FieldLocalisation/src/FieldLineOccupanyMap.cpp
+++ b/module/localisation/FieldLocalisation/src/FieldLineOccupanyMap.cpp
@@ -71,30 +71,32 @@ namespace module::localisation {
                                              line_width);
 
         // Add left penalty area box
-        int left_penalty_box_x0 = (fd.dimensions.border_strip_min_width) / cfg.grid_size;
-        int left_penalty_box_y0 =
-            (fd.dimensions.border_strip_min_width + (fd.dimensions.field_width - fd.dimensions.penalty_area_width) / 2)
-            / cfg.grid_size;
-        int left_penalty_box_width  = (fd.dimensions.penalty_area_width) / cfg.grid_size;
-        int left_penalty_box_length = (fd.dimensions.penalty_area_length) / cfg.grid_size;
-        fieldline_distance_map.add_rectangle(left_penalty_box_x0,
-                                             left_penalty_box_y0,
-                                             left_penalty_box_length,
-                                             left_penalty_box_width,
-                                             line_width);
+        if (fd.dimensions.penalty_area_length != 0 && fd.dimensions.penalty_area_width != 0) {
+            int left_penalty_box_x0 = (fd.dimensions.border_strip_min_width) / cfg.grid_size;
+            int left_penalty_box_y0 = (fd.dimensions.border_strip_min_width
+                                       + (fd.dimensions.field_width - fd.dimensions.penalty_area_width) / 2)
+                                      / cfg.grid_size;
+            int left_penalty_box_width  = (fd.dimensions.penalty_area_width) / cfg.grid_size;
+            int left_penalty_box_length = (fd.dimensions.penalty_area_length) / cfg.grid_size;
+            fieldline_distance_map.add_rectangle(left_penalty_box_x0,
+                                                 left_penalty_box_y0,
+                                                 left_penalty_box_length,
+                                                 left_penalty_box_width,
+                                                 line_width);
 
-        // Add right penalty area box
-        int right_penalty_box_x0 =
-            (fd.dimensions.border_strip_min_width + fd.dimensions.field_length - fd.dimensions.penalty_area_length)
-            / cfg.grid_size;
-        int right_penalty_box_y0     = left_penalty_box_y0;
-        int right_penalty_box_width  = left_penalty_box_width;
-        int right_penalty_box_length = left_penalty_box_length;
-        fieldline_distance_map.add_rectangle(right_penalty_box_x0,
-                                             right_penalty_box_y0,
-                                             right_penalty_box_length,
-                                             right_penalty_box_width,
-                                             line_width);
+            // Add right penalty area box
+            int right_penalty_box_x0 =
+                (fd.dimensions.border_strip_min_width + fd.dimensions.field_length - fd.dimensions.penalty_area_length)
+                / cfg.grid_size;
+            int right_penalty_box_y0     = left_penalty_box_y0;
+            int right_penalty_box_width  = left_penalty_box_width;
+            int right_penalty_box_length = left_penalty_box_length;
+            fieldline_distance_map.add_rectangle(right_penalty_box_x0,
+                                                 right_penalty_box_y0,
+                                                 right_penalty_box_length,
+                                                 right_penalty_box_width,
+                                                 line_width);
+        }
 
         // Add centre line
         int centre_line_x0    = (fd.dimensions.border_strip_min_width + fd.dimensions.field_length / 2) / cfg.grid_size;
@@ -107,34 +109,39 @@ namespace module::localisation {
                                              centre_line_width,
                                              line_width);
 
-        // Add left penalty cross in centre of penalty area
-        int left_penalty_cross_x0 =
-            (fd.dimensions.border_strip_min_width + fd.dimensions.penalty_mark_distance) / cfg.grid_size;
-        int left_penalty_cross_y0 =
-            (fd.dimensions.border_strip_min_width + fd.dimensions.field_width / 2) / cfg.grid_size;
-        int left_penalty_cross_width = 0.1 / cfg.grid_size;
-        fieldline_distance_map.add_cross(left_penalty_cross_x0,
-                                         left_penalty_cross_y0,
-                                         left_penalty_cross_width,
-                                         line_width);
 
-        // Add right penalty cross in centre of penalty area
-        int right_penalty_cross_x0 =
-            (fd.dimensions.border_strip_min_width + fd.dimensions.field_length - fd.dimensions.penalty_mark_distance)
-            / cfg.grid_size;
-        int right_penalty_cross_y0    = left_penalty_cross_y0;
-        int right_penalty_cross_width = 0.1 / cfg.grid_size;
-        fieldline_distance_map.add_cross(right_penalty_cross_x0,
-                                         right_penalty_cross_y0,
-                                         right_penalty_cross_width,
-                                         line_width);
+        if (fd.dimensions.penalty_mark_distance != 0) {
+            // Add left penalty cross in centre of penalty area
+            int left_penalty_cross_x0 =
+                (fd.dimensions.border_strip_min_width + fd.dimensions.penalty_mark_distance) / cfg.grid_size;
+            int left_penalty_cross_y0 =
+                (fd.dimensions.border_strip_min_width + fd.dimensions.field_width / 2) / cfg.grid_size;
+            int left_penalty_cross_width = 0.1 / cfg.grid_size;
+            fieldline_distance_map.add_cross(left_penalty_cross_x0,
+                                             left_penalty_cross_y0,
+                                             left_penalty_cross_width,
+                                             line_width);
 
-        // Add centre cross in centre of field
-        int centre_cross_x0 =
-            (fd.dimensions.border_strip_min_width + fd.dimensions.field_length / 2) / cfg.grid_size + line_width / 2;
-        int centre_cross_y0    = left_penalty_cross_y0;
-        int centre_cross_width = 0.1 / cfg.grid_size;
-        fieldline_distance_map.add_cross(centre_cross_x0, centre_cross_y0, centre_cross_width, line_width);
+            // Add right penalty cross in centre of penalty area
+            int right_penalty_cross_x0 = (fd.dimensions.border_strip_min_width + fd.dimensions.field_length
+                                          - fd.dimensions.penalty_mark_distance)
+                                         / cfg.grid_size;
+            int right_penalty_cross_y0    = left_penalty_cross_y0;
+            int right_penalty_cross_width = 0.1 / cfg.grid_size;
+            fieldline_distance_map.add_cross(right_penalty_cross_x0,
+                                             right_penalty_cross_y0,
+                                             right_penalty_cross_width,
+                                             line_width);
+
+            // Add centre cross in centre of field
+            int centre_cross_x0 =
+                (fd.dimensions.border_strip_min_width + fd.dimensions.field_length / 2) / cfg.grid_size
+                + line_width / 2;
+            int centre_cross_y0    = left_penalty_cross_y0;
+            int centre_cross_width = 0.1 / cfg.grid_size;
+            fieldline_distance_map.add_cross(centre_cross_x0, centre_cross_y0, centre_cross_width, line_width);
+        }
+
 
         // Add centre circle
         int centre_circle_x0 = (fd.dimensions.border_strip_min_width + fd.dimensions.field_length / 2) / cfg.grid_size;

--- a/module/network/NetworkForwarder/src/NetworkForwarder.hpp
+++ b/module/network/NetworkForwarder/src/NetworkForwarder.hpp
@@ -74,7 +74,7 @@ namespace module::network {
             // However if because of the low priority other modules are taking all the thread time this module won't
             // queue indefinitely killing all the ram in the system.
             handle->reaction =
-                on<Trigger<T>, Buffer<10>, Priority::LOW>()
+                on<Trigger<T>, Single, Priority::LOW>()
                     .then(
                         type,
                         [this, type, handle](std::shared_ptr<const T> msg) {

--- a/module/planning/PlanKick/data/config/PlanKick.yaml
+++ b/module/planning/PlanKick/data/config/PlanKick.yaml
@@ -1,13 +1,13 @@
 # Controls the minimum log level that NUClear log will display
-log_level: INFO
+log_level: DEBUG
 
 # How long since the last ball measurement before ignoring it and assuming the ball is lost, in milliseconds
 ball_timeout_threshold: 1000
 
 # Maximum distance of the ball required to kick the ball (in metres)
-ball_distance_threshold: 0.2
+ball_distance_threshold: 0.22
 # Maximum angle of the ball from the torso's x-axis required to kick the ball (in radians), both clockwise and anticlockwise
-ball_angle_threshold: 0.4
+ball_angle_threshold: 0.2
 
 # Maximum angle of the target from the torso's x-axis required to kick the ball (in radians), both clockwise and anticlockwise
 target_angle_threshold: 23 * pi / 180

--- a/module/planning/PlanKick/src/PlanKick.cpp
+++ b/module/planning/PlanKick/src/PlanKick.cpp
@@ -26,6 +26,7 @@
  */
 #include "PlanKick.hpp"
 
+#include <fmt/format.h>
 #include <string>
 
 #include "extension/Behaviour.hpp"
@@ -93,6 +94,9 @@ namespace module::planning {
 
                 // Need to be near the ball to consider kicking it
                 if (ball_distance > cfg.ball_distance_threshold || ball_angle > cfg.ball_angle_threshold) {
+                    log<NUClear::DEBUG>(fmt::format("Ball not close enough, distance {}m and angle {} radians.",
+                                                    ball_distance,
+                                                    ball_angle));
                     return;
                 }
 
@@ -101,6 +105,7 @@ namespace module::planning {
 
                 // Don't kick if we should align but we're not aligned to the target
                 if (align_angle > cfg.target_angle_threshold) {
+                    log<NUClear::DEBUG>("Robot is not aligned to the kick target.");
                     return;
                 }
 
@@ -114,6 +119,7 @@ namespace module::planning {
 
                 // If the robot is not standing, make it stand before kicking
                 if (stability != Stability::STANDING) {
+                    log<NUClear::DEBUG>("Standing to kick!");
                     emit<Task>(std::make_unique<Walk>(Eigen::Vector3d::Zero()));
                     return;
                 }
@@ -121,9 +127,11 @@ namespace module::planning {
                 // If the kick leg is forced left, kick left. If the kick leg is auto,
                 // kick with left leg if ball is more to the left
                 if (cfg.kick_leg == LimbID::LEFT_LEG || (cfg.kick_leg == LimbID::UNKNOWN && rBRr.y() > 0.0)) {
+                    log<NUClear::INFO>("LEFT KICK!");
                     emit<Task>(std::make_unique<Kick>(LimbID::LEFT_LEG));
                 }
                 else {  // kick leg is forced right or ball is more to the right and kick leg is auto
+                    log<NUClear::INFO>("RIGHT KICK!");
                     emit<Task>(std::make_unique<Kick>(LimbID::RIGHT_LEG));
                 }
             });

--- a/module/platform/OpenCR/HardwareIO/data/config/nugus4/HardwareIO.yaml
+++ b/module/platform/OpenCR/HardwareIO/data/config/nugus4/HardwareIO.yaml
@@ -1,5 +1,5 @@
 # Controls the minimum log level that NUClear log will display
-log_level: ERROR
+log_level: INFO
 
 battery:
   charged_voltage: 16.8

--- a/module/platform/OpenCR/HardwareIO/data/config/nugus4/HardwareIO.yaml
+++ b/module/platform/OpenCR/HardwareIO/data/config/nugus4/HardwareIO.yaml
@@ -1,5 +1,5 @@
 # Controls the minimum log level that NUClear log will display
-log_level: DEBUG
+log_level: ERROR
 
 battery:
   charged_voltage: 16.8
@@ -24,7 +24,7 @@ servos:
     simulated: false
   - # [2]  R_SHOULDER_ROLL
     direction: -1
-    offset: -pi / 4
+    offset: -pi / 4 + 0.123
     simulated: false
   - # [3]  L_SHOULDER_ROLL
     direction: -1
@@ -56,19 +56,19 @@ servos:
     simulated: false
   - # [10] R_HIP_PITCH
     direction: 1
-    offset: pi / 8
+    offset: 0.23
     simulated: false
   - # [11] L_HIP_PITCH
     direction: -1
-    offset: pi / 8 + 0.047
+    offset: 0.066
     simulated: false
   - # [12] R_KNEE
     direction: -1
-    offset: pi / 8
+    offset: pi / 4
     simulated: false
   - # [13] L_KNEE
     direction: 1
-    offset: pi / 8
+    offset: pi / 4
     simulated: false
   - # [14] R_ANKLE_PITCH
     direction: -1
@@ -76,7 +76,7 @@ servos:
     simulated: false
   - # [15] L_ANKLE_PITCH
     direction: 1
-    offset: 0.029
+    offset: 0.0
     simulated: false
   - # [16] R_ANKLE_ROLL
     direction: -1
@@ -84,13 +84,13 @@ servos:
     simulated: false
   - # [17] L_ANKLE_ROLL
     direction: -1
-    offset: -0.069
+    offset: 0.0
     simulated: false
   - # [18] HEAD_YAW
     direction: 1
-    offset: 0.2
+    offset: 0.02
     simulated: false
   - # [19] HEAD_PITCH
     direction: 1
-    offset: 0.17
+    offset: -0.167
     simulated: false

--- a/module/skill/Walk/data/config/nugus4/Walk.yaml
+++ b/module/skill/Walk/data/config/nugus4/Walk.yaml
@@ -16,9 +16,9 @@ walk:
     # Torso height (in meters)
     height: 0.46
     # Torso pitch (in radians)
-    pitch: 20 * pi / 180
+    pitch: 14 * pi / 180
     # Torso constant position offset
-    position_offset: [0.05, 0, 0]
+    position_offset: [0.01, 0, 0]
     # Torso offset from the planted foot [x,y,z] (in meters), at time = torso_sway_ratio*step_period
     sway_offset: [0, 0.05, 0]
     # Ratio of the step_period where the torso should be at its maximum sway, between [0 1]

--- a/module/vision/BallDetector/data/config/BallDetector.yaml
+++ b/module/vision/BallDetector/data/config/BallDetector.yaml
@@ -1,13 +1,13 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-confidence_threshold: 0.7 # Minimum confidence required for a ball point to be a ball point
-cluster_points: 3 # Minimum number of points for a cluster to be a viable ball
-minimum_ball_distance: 0.20 # Minimum distance for a cluster to be a viable ball
+confidence_threshold: 0.6 # Minimum confidence required for a ball point to be a ball point
+cluster_points: 1 # Minimum number of points for a cluster to be a viable ball
+minimum_ball_distance: 0.1 # Minimum distance for a cluster to be a viable ball
 distance_disagreement:
-  0.30 # Percentage difference between width and projection based distances. 0.0 means
+  1.0 # Percentage difference between width and projection based distances. 0.0 means
   # the distance measurements must match perfectly
 maximum_deviation:
-  0.30 # A threshold on how large the standard deviation of the angle between ray and
+  0.3 # A threshold on how large the standard deviation of the angle between ray and
   # cone axis can be
 ball_angular_cov: [0.01, 0.01, 0.01] # Measurement certainties for ball localisation

--- a/module/vision/GreenHorizonDetector/data/config/GreenHorizonDetector.yaml
+++ b/module/vision/GreenHorizonDetector/data/config/GreenHorizonDetector.yaml
@@ -1,4 +1,4 @@
 log_level: INFO
 
-confidence_threshold: 0.9 # How confident do we need to be that this is a green horizon point
+confidence_threshold: 0.95 # How confident do we need to be that this is a green horizon point
 cluster_points: 50 # How many points do we need to claim this cluster is a viable part of the green horizon

--- a/roles/scripttuner.role
+++ b/roles/scripttuner.role
@@ -2,9 +2,14 @@ nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
   extension::FileWatcher
   # Config
+  support::logging::MessageLogHandler
   actuation::KinematicsConfiguration
   platform::${SUBCONTROLLER}::HardwareIO
   input::SensorFilter
+  # Networking
+  network::NUClearNet
+  network::NetworkForwarder
+  output::Overview
   # Director
   extension::Director
   # Servos

--- a/shared/utility/skill/scripts/nugus4/StandUpFront.yaml
+++ b/shared/utility/skill/scripts/nugus4/StandUpFront.yaml
@@ -1,820 +1,656 @@
-- duration: 1200
+- duration: 1000
   targets:
-    - id: L_KNEE
-      position: -0.312274247
-      gain: 10
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.132645056
-      gain: 15
+    - id: HEAD_YAW
+      position: -0.21038346
+      gain: 6.63999987
       torque: 100
     - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
-    - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
-      torque: 100
-    - id: R_KNEE
-      position: -0.242523059
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: -0.0537561402
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: -0.0107512278
-      gain: 10
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.0261101238
-      gain: 10
-      torque: 100
-    - id: L_HIP_YAW
-      position: -0.0230383463
-      gain: 10
-      torque: 100
-    - id: R_HIP_YAW
-      position: 0.153588966
-      gain: 10
+      position: -0.405062914
+      gain: 6.63999987
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.5619998
-      gain: 15
+      position: 1.56046391
+      gain: 6.63999987
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 1.64340198
-      gain: 15
-      torque: 100
-    - id: L_ELBOW
-      position: 0.122871175
-      gain: 15
-      torque: 100
-    - id: R_ELBOW
-      position: 0.144373626
-      gain: 15
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.0552920289
-      gain: 10
-      torque: 100
-    - id: L_HIP_PITCH
-      position: 0.337407053
-      gain: 10
-      torque: 100
-    - id: R_HIP_PITCH
-      position: 0.326655835
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.51438725
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.45584154
-      gain: 10
+      position: 1.64186609
+      gain: 6.63999987
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.194080636
-      gain: 10
+      position: -0.138659775
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.175649986
+      gain: 6.63999987
+      torque: 100
+    - id: R_ELBOW
+      position: 0.124407068
+      gain: 6.63999987
+      torque: 100
+    - id: L_ELBOW
+      position: 0.173555538
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_YAW
+      position: 0.00614355877
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0399331301
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0829380453
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0798662603
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.0833215043
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.024530977
+      gain: 6.63999987
+      torque: 100
+    - id: R_KNEE
+      position: 0.171042308
+      gain: 6.63999987
+      torque: 100
+    - id: L_KNEE
+      position: 0.0466352478
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.56046391
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.5236026
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.00767944846
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0691150352
+      gain: 6.63999987
       torque: 100
 - duration: 1000
   targets:
-    - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
     - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
+      position: -0.21038346
+      gain: 6.63999987
       torque: 100
-    - id: R_ANKLE_ROLL
-      position: -0.0537561402
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: -0.0107512278
-      gain: 10
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.0261101238
-      gain: 10
-      torque: 100
-    - id: L_HIP_YAW
-      position: -0.0230383463
-      gain: 10
+    - id: HEAD_PITCH
+      position: -0.405062914
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_YAW
-      position: 0.153588966
-      gain: 10
+      position: 0.00614355877
+      gain: 6.63999987
       torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.43759274
-      gain: 10
+    - id: L_HIP_YAW
+      position: 0.0399331301
+      gain: 6.63999987
       torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.43587506
-      gain: 10
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 2.63097906
-      gain: 15
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 2.67398405
-      gain: 15
-      torque: 100
-    - id: R_HIP_PITCH
-      position: 0.799709857
-      gain: 10
+    - id: R_HIP_ROLL
+      position: -0.0829380453
+      gain: 6.63999987
       torque: 100
     - id: L_HIP_ROLL
-      position: -0.0322536826
-      gain: 10
+      position: 0.0798662603
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -0.0833215043
+      gain: 6.63999987
       torque: 100
     - id: L_HIP_PITCH
-      position: 0.793566287
-      gain: 10
-      torque: 100
-    - id: L_KNEE
-      position: 0.607723653
-      gain: 10
+      position: 0.024530977
+      gain: 6.63999987
       torque: 100
     - id: R_KNEE
-      position: 0.763484657
-      gain: 10
+      position: 0.171042308
+      gain: 6.63999987
       torque: 100
-    - id: R_ELBOW
-      position: -1.06590748
-      gain: 10
+    - id: L_KNEE
+      position: 0.0466352478
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.56046391
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.5236026
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.00767944846
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0691150352
+      gain: 6.63999987
       torque: 100
     - id: L_ELBOW
-      position: -1.28707552
-      gain: 10
+      position: -2.42516971
+      gain: 6.63999987
       torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.148003921
-      gain: 10
+    - id: R_ELBOW
+      position: -2.50657201
+      gain: 6.63999987
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.224798426
-      gain: 10
+      position: 0.127049148
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: -0.0578052625
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 3.00420022
+      gain: 6.63999987
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 2.86289835
+      gain: 6.63999987
       torque: 100
 - duration: 1000
   targets:
-    - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
     - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
+      position: -0.21038346
+      gain: 6.63999987
       torque: 100
-    - id: R_ANKLE_ROLL
-      position: -0.0537561402
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: -0.0107512278
-      gain: 10
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.0261101238
-      gain: 10
-      torque: 100
-    - id: L_HIP_YAW
-      position: -0.0230383463
-      gain: 10
+    - id: HEAD_PITCH
+      position: -0.405062914
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_YAW
-      position: 0.153588966
-      gain: 10
+      position: 0.00614355877
+      gain: 6.63999987
       torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.43759274
-      gain: 10
+    - id: L_HIP_YAW
+      position: 0.0399331301
+      gain: 6.63999987
       torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.43587506
-      gain: 10
-      torque: 100
-    - id: R_HIP_PITCH
-      position: 0.799709857
-      gain: 10
+    - id: R_HIP_ROLL
+      position: -0.0829380453
+      gain: 6.63999987
       torque: 100
     - id: L_HIP_ROLL
-      position: -0.0322536826
-      gain: 10
-      torque: 100
-    - id: L_HIP_PITCH
-      position: 0.793566287
-      gain: 10
-      torque: 100
-    - id: L_KNEE
-      position: 0.607723653
-      gain: 10
+      position: 0.0798662603
+      gain: 6.63999987
       torque: 100
     - id: R_KNEE
-      position: 0.763484657
-      gain: 10
+      position: 0.171042308
+      gain: 6.63999987
+      torque: 100
+    - id: L_KNEE
+      position: 0.0466352478
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.56046391
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.5236026
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.00767944846
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0691150352
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_PITCH
+      position: 0.74947089
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_PITCH
+      position: 0.667728543
+      gain: 6.63999987
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 2.89822388
-      gain: 10
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 2.81989336
-      gain: 10
+      position: 2.18710685
+      gain: 6.63999987
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.0527787581
-      gain: 10
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: -0.06241294
-      gain: 10
+      position: 0.0103214942
+      gain: 6.63999987
       torque: 100
     - id: R_ELBOW
-      position: -2.72313237
-      gain: 10
+      position: -2.21321702
+      gain: 6.63999987
       torque: 100
     - id: L_ELBOW
-      position: -2.79378343
-      gain: 10
+      position: -2.07345104
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.123429693
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.28540397
+      gain: 6.63999987
       torque: 100
 - duration: 1000
   targets:
-    - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
     - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
+      position: -0.21038346
+      gain: 6.63999987
       torque: 100
-    - id: L_ANKLE_ROLL
-      position: -0.0107512278
-      gain: 10
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.0261101238
-      gain: 10
-      torque: 100
-    - id: L_HIP_YAW
-      position: -0.0230383463
-      gain: 10
+    - id: HEAD_PITCH
+      position: -0.405062914
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_YAW
-      position: 0.153588966
-      gain: 10
+      position: 0.00614355877
+      gain: 6.63999987
       torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.146468088
-      gain: 15
+    - id: L_HIP_YAW
+      position: 0.0399331301
+      gain: 6.63999987
       torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.0881042257
-      gain: 15
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.09029984
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.07051516
-      gain: 10
-      torque: 100
-    - id: L_KNEE
-      position: 1.02241385
-      gain: 10
-      torque: 100
-    - id: R_KNEE
-      position: 1.1105957
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.113655835
-      gain: 10
+    - id: R_HIP_ROLL
+      position: -0.0829380453
+      gain: 6.63999987
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.0230383463
-      gain: 10
+      position: 0.0798662603
+      gain: 6.63999987
       torque: 100
-    - id: R_HIP_PITCH
-      position: 1.06695461
-      gain: 10
+    - id: R_ANKLE_PITCH
+      position: -1.56046391
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.5236026
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.00767944846
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0691150352
+      gain: 6.63999987
+      torque: 100
+    - id: L_KNEE
+      position: 1.5241611
+      gain: 6.63999987
+      torque: 100
+    - id: R_KNEE
+      position: 1.53337646
+      gain: 6.63999987
       torque: 100
     - id: L_HIP_PITCH
-      position: 1.09460068
-      gain: 10
+      position: -1.46681798
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.50555539
+      gain: 6.63999987
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.73401952
-      gain: 15
+      position: 0.830916345
+      gain: 6.63999987
       torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.81542158
-      gain: 15
-      torque: 100
-    - id: R_ELBOW
-      position: -2.34837532
-      gain: 15
+    - id: R_SHOULDER_ROLL
+      position: 0.00571387634
+      gain: 6.63999987
       torque: 100
     - id: L_ELBOW
-      position: -2.35912657
-      gain: 15
+      position: -1.40687501
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.115750231
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 0.884672463
+      gain: 6.63999987
+      torque: 100
+    - id: R_ELBOW
+      position: -1.7954551
+      gain: 6.63999987
       torque: 100
 - duration: 1000
   targets:
-    - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
     - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
+      position: -0.21038346
+      gain: 6.63999987
       torque: 100
-    - id: L_ANKLE_ROLL
-      position: -0.0107512278
-      gain: 10
-      torque: 100
-    - id: L_HIP_YAW
-      position: -0.0230383463
-      gain: 10
+    - id: HEAD_PITCH
+      position: -0.405062914
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_YAW
-      position: 0.153588966
-      gain: 10
+      position: 0.00614355877
+      gain: 6.63999987
       torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.09029984
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.07051516
-      gain: 10
-      torque: 100
-    - id: L_KNEE
-      position: 1.02241385
-      gain: 10
-      torque: 100
-    - id: R_KNEE
-      position: 1.1105957
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.113655835
-      gain: 10
-      torque: 100
-    - id: R_HIP_PITCH
-      position: 0.896470904
-      gain: 10
-      torque: 100
-    - id: L_HIP_PITCH
-      position: 0.894935012
-      gain: 10
+    - id: L_HIP_YAW
+      position: 0.0399331301
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_ROLL
-      position: 0.0322536826
-      gain: 10
+      position: -0.0829380453
+      gain: 6.63999987
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.0598996989
-      gain: 10
+      position: 0.0798662603
+      gain: 6.63999987
       torque: 100
-    - id: L_ELBOW
-      position: -2.05809212
-      gain: 15
+    - id: R_ANKLE_PITCH
+      position: -1.56046391
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.5236026
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.00767944846
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0691150352
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -2.19977736
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -2.18100667
+      gain: 6.63999987
+      torque: 100
+    - id: R_KNEE
+      position: 2.7405858
+      gain: 6.63999987
+      torque: 100
+    - id: L_KNEE
+      position: 2.73290634
+      gain: 6.63999987
       torque: 100
     - id: R_ELBOW
-      position: -2.05348444
-      gain: 15
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.061994113
-      gain: 15
+      position: -1.10430467
+      gain: 6.63999987
       torque: 100
     - id: R_SHOULDER_ROLL
-      position: -0.151075706
-      gain: 15
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.59118176
-      gain: 15
+      position: -0.06954474
+      gain: 6.63999987
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.59425354
-      gain: 15
+      position: 0.61281997
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 0.617427647
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.100391366
+      gain: 6.63999987
+      torque: 100
+    - id: L_ELBOW
+      position: -0.901567221
+      gain: 6.63999987
       torque: 100
 - duration: 1000
   targets:
-    - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
     - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
+      position: -0.21038346
+      gain: 6.63999987
       torque: 100
-    - id: L_ANKLE_ROLL
-      position: -0.0107512278
-      gain: 10
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.0261101238
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.09029984
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.07051516
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.113655835
-      gain: 10
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.0230383463
-      gain: 10
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -1.07714736
-      gain: 10
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -1.0731523
-      gain: 10
-      torque: 100
-    - id: R_KNEE
-      position: 2.25
-      gain: 10
-      torque: 100
-    - id: L_KNEE
-      position: 2.24958968
-      gain: 10
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 0.193522096
-      gain: 15
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 0.359398186
-      gain: 15
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.151075706
-      gain: 15
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.155683383
-      gain: 15
-      torque: 100
-    - id: R_ELBOW
-      position: 0.0215024557
-      gain: 15
-      torque: 100
-    - id: L_ELBOW
-      position: -0.281067818
-      gain: 15
-      torque: 100
-    - id: L_HIP_YAW
-      position: -0.0230383463
-      gain: 10
+    - id: HEAD_PITCH
+      position: -0.405062914
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_YAW
-      position: -0.0982969403
-      gain: 10
+      position: 0.00614355877
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0399331301
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0829380453
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0798662603
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.56046391
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.5236026
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.00767944846
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_ROLL
+      position: -0.0691150352
+      gain: 6.63999987
+      torque: 100
+    - id: L_KNEE
+      position: 2.73290634
+      gain: 6.63999987
+      torque: 100
+    - id: R_KNEE
+      position: 2.74519348
+      gain: 6.63999987
+      torque: 100
+    - id: R_ELBOW
+      position: -0.0660432577
+      gain: 6.63999987
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: 0.0640776679
+      gain: 6.63999987
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 0.585173965
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 0.721868157
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.0527787581
+      gain: 6.63999987
+      torque: 100
+    - id: L_ELBOW
+      position: -0.156660751
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.90795851
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.89379525
+      gain: 6.63999987
       torque: 100
 - duration: 1000
   targets:
-    - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
     - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
+      position: -0.21038346
+      gain: 6.63999987
       torque: 100
-    - id: L_KNEE
-      position: 2.24958968
-      gain: 10
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.151075706
-      gain: 15
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.155683383
-      gain: 15
-      torque: 100
-    - id: R_ELBOW
-      position: 0.0215024557
-      gain: 15
-      torque: 100
-    - id: L_ELBOW
-      position: -0.281067818
-      gain: 15
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.45755935
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.53146386
-      gain: 10
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -1.52931154
-      gain: 10
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -1.5701679
-      gain: 10
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 0.476125807
-      gain: 10
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 0.672719657
-      gain: 10
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.0383972414
-      gain: 10
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.130550623
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.0860098228
-      gain: 10
-      torque: 100
-    - id: R_KNEE
-      position: 2.15807247
-      gain: 10
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0.224239901
-      gain: 10
+    - id: HEAD_PITCH
+      position: -0.405062914
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_YAW
-      position: 0.158196643
-      gain: 10
+      position: 0.00614355877
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_YAW
+      position: 0.0399331301
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_ROLL
+      position: -0.0829380453
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_ROLL
+      position: 0.0798662603
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -1.56046391
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -1.5236026
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_ROLL
+      position: 0.00767944846
+      gain: 6.63999987
       torque: 100
     - id: L_ANKLE_ROLL
-      position: 0.00307177939
-      gain: 10
+      position: -0.0691150352
+      gain: 6.63999987
       torque: 100
-- duration: 1200
+    - id: L_KNEE
+      position: 2.73290634
+      gain: 6.63999987
+      torque: 100
+    - id: R_KNEE
+      position: 2.74519348
+      gain: 6.63999987
+      torque: 100
+    - id: R_HIP_PITCH
+      position: -1.26288474
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.23182678
+      gain: 6.63999987
+      torque: 100
+    - id: R_SHOULDER_PITCH
+      position: 1.89835966
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_PITCH
+      position: 2.11184835
+      gain: 6.63999987
+      torque: 100
+    - id: R_SHOULDER_ROLL
+      position: -0.215454251
+      gain: 6.63999987
+      torque: 100
+    - id: L_SHOULDER_ROLL
+      position: 0.318487674
+      gain: 6.63999987
+      torque: 100
+    - id: R_ELBOW
+      position: -1.60961235
+      gain: 6.63999987
+      torque: 100
+    - id: L_ELBOW
+      position: -1.21642458
+      gain: 6.63999987
+      torque: 100
+- duration: 1000
   targets:
-    - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
     - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
+      position: -0.21038346
+      gain: 6.63999987
       torque: 100
-    - id: R_HIP_ROLL
-      position: -0.0261101238
-      gain: 10
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.0230383463
-      gain: 10
-      torque: 100
-    - id: R_ELBOW
-      position: 0.0215024557
-      gain: 15
-      torque: 100
-    - id: L_ELBOW
-      position: -0.281067818
-      gain: 15
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.31029582
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.27786016
-      gain: 10
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0.0122871175
-      gain: 10
+    - id: HEAD_PITCH
+      position: -0.405062914
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_YAW
-      position: -0.0307177939
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: -0.0382822044
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.0967610478
-      gain: 10
-      torque: 100
-    - id: R_KNEE
-      position: 2.25
-      gain: 10
-      torque: 100
-    - id: L_KNEE
-      position: 2.25
-      gain: 10
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 0.738762915
-      gain: 10
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 0.837059855
-      gain: 10
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.241693243
-      gain: 10
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.128037378
-      gain: 10
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -1.69764674
-      gain: 10
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -1.73358476
-      gain: 10
-      torque: 100
-- duration: 1300
-  targets:
-    - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
-    - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
-      torque: 100
-    - id: R_HIP_ROLL
-      position: -0.0261101238
-      gain: 10
-      torque: 100
-    - id: L_HIP_ROLL
-      position: 0.0230383463
-      gain: 10
+      position: 0.00614355877
+      gain: 6.63999987
       torque: 100
     - id: L_HIP_YAW
-      position: 0.0122871175
-      gain: 10
-      torque: 100
-    - id: R_HIP_YAW
-      position: -0.0307177939
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: -0.0382822044
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_ROLL
-      position: 0.0967610478
-      gain: 10
-      torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.241693243
-      gain: 10
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.128037378
-      gain: 10
-      torque: 100
-    - id: R_SHOULDER_PITCH
-      position: 1.63418663
-      gain: 10
-      torque: 100
-    - id: L_SHOULDER_PITCH
-      position: 1.70176578
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -1.46234882
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -1.4268415
-      gain: 10
-      torque: 100
-    - id: L_KNEE
-      position: 2.27877164
-      gain: 10
-      torque: 100
-    - id: R_KNEE
-      position: 2.27723575
-      gain: 10
-      torque: 100
-    - id: R_ELBOW
-      position: -0.628178895
-      gain: 10
-      torque: 100
-    - id: L_ELBOW
-      position: -0.660432577
-      gain: 10
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -0.891917348
-      gain: 10
-      torque: 100
-    - id: R_HIP_PITCH
-      position: -0.975778639
-      gain: 10
-      torque: 100
-- duration: 1200
-  targets:
-    - id: HEAD_PITCH
-      position: 0.11211995
-      gain: 15
-      torque: 100
-    - id: HEAD_YAW
-      position: 0.13823007
-      gain: 15
+      position: 0.0399331301
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_ROLL
-      position: -0.0261101238
-      gain: 10
+      position: -0.0829380453
+      gain: 6.63999987
       torque: 100
     - id: L_HIP_ROLL
-      position: 0.0230383463
-      gain: 10
-      torque: 100
-    - id: L_HIP_YAW
-      position: 0.0122871175
-      gain: 10
-      torque: 100
-    - id: R_HIP_YAW
-      position: -0.0307177939
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_ROLL
-      position: -0.0382822044
-      gain: 10
+      position: 0.0798662603
+      gain: 6.63999987
       torque: 100
     - id: R_ANKLE_ROLL
-      position: 0.0967610478
-      gain: 10
+      position: 0.00767944846
+      gain: 6.63999987
       torque: 100
-    - id: R_SHOULDER_ROLL
-      position: -0.241693243
-      gain: 10
-      torque: 100
-    - id: L_SHOULDER_ROLL
-      position: 0.128037378
-      gain: 10
+    - id: L_ANKLE_ROLL
+      position: -0.0691150352
+      gain: 6.63999987
       torque: 100
     - id: R_SHOULDER_PITCH
-      position: 1.63418663
-      gain: 10
+      position: 1.89835966
+      gain: 6.63999987
       torque: 100
     - id: L_SHOULDER_PITCH
-      position: 1.70176578
-      gain: 10
+      position: 2.11184835
+      gain: 6.63999987
       torque: 100
-    - id: L_KNEE
-      position: 0.478708893
-      gain: 10
+    - id: R_SHOULDER_ROLL
+      position: -0.215454251
+      gain: 6.63999987
       torque: 100
-    - id: R_KNEE
-      position: 0.534000933
-      gain: 10
+    - id: L_SHOULDER_ROLL
+      position: 0.318487674
+      gain: 6.63999987
       torque: 100
     - id: R_ELBOW
-      position: -0.594389319
-      gain: 10
+      position: -1.60961235
+      gain: 6.63999987
       torque: 100
     - id: L_ELBOW
-      position: -0.896959603
-      gain: 10
-      torque: 100
-    - id: L_ANKLE_PITCH
-      position: -0.315039277
-      gain: 10
-      torque: 100
-    - id: R_ANKLE_PITCH
-      position: -0.402403086
-      gain: 10
-      torque: 100
-    - id: L_HIP_PITCH
-      position: -0.443437487
-      gain: 10
+      position: -1.21642458
+      gain: 6.63999987
       torque: 100
     - id: R_HIP_PITCH
-      position: -0.539586008
-      gain: 10
+      position: -1.09393692
+      gain: 6.63999987
+      torque: 100
+    - id: L_HIP_PITCH
+      position: -1.06441486
+      gain: 6.63999987
+      torque: 100
+    - id: R_KNEE
+      position: 1.27227521
+      gain: 6.63999987
+      torque: 100
+    - id: L_KNEE
+      position: 1.31681597
+      gain: 6.63999987
+      torque: 100
+    - id: R_ANKLE_PITCH
+      position: -3.13768315
+      gain: 6.63999987
+      torque: 100
+    - id: L_ANKLE_PITCH
+      position: -0.514523029
+      gain: 6.63999987
       torque: 100


### PR DESCRIPTION
- Frankie's nuc was swapped for Kevin's, so now Frankie is `nugus4`. As such, Frankie's HardwareIO, Walk and Camera tunes have been moved to `nugus4`. The `nugus1` nuc isn't in a robot so nothing to change it to. 
- Adjusted the camera to make it brighter
- Tuned the `nugus4` Left.yaml pitch and yaw so field lines in localisation look correct
- Added back in the logic to field occupancy map to not draw the penalty box and crosses for the lab field
- Changed NetworkForwarder from `Buffer<10>` to `Single`. The reaction will only run one at a time and therefore should only be using one thread. This appears to fix our issues with the robot not walking if NetworkForwarder is in the role, and allows us to use nusight with the real robot while its moving.
-  Tuned kick planner a little bit to get the robot kicking at the right time
- Tuned the green horizon to be more picky about what is a field point
- Tuned the ball detector. Basically took out the distance disagreement and then some small tuning. Robot chases the ball, if it does lose it when it's close it finds it again pretty quick. 
- Added in the StandUpFront for Frankie which was in another PR but now that the robot number has changed it's out of date so just including it in here.
-  Added in networking things and the message log handler in scripttuner so that we can see logs in NUsight when running script tuner.

Overall, this PR results in Frankie correctly seeing the ball, walking to it, and attempting to kick it when close. Ran it from the side of the field and it walked around kicking the ball a few times around the field, with correct localisation. After about the third kick localisation had drifted perpendicular of what it should have been. It appeared that when the robot was unsteady (ie would have falled over but I held it up) localisation got worse. 

### Next Steps

Not part of this PR, but noticeable problems to fix are

- Kick tune, as it is unsteady
- Walk planning tuning for turning, as it is a bit unsteady when turning dramatically
- Walk tuning for turning while facing the ball (pivoting), which is needed for aligning to the goal
- Tuning/improvements to localisation to keep it steady and not drift
- Walk fixes to linearly interpolate some of the positions rather than using splines as the foot moves in an awkward curve on the y-axis
- Testing/tuning for ready positioning, aligning to goal and kicking to goal (localisation may be good enough for small tests)
- StandUpBack has not been looked at. This should be done FROM SCRATCH. Old scripts have issues on the robots as positions overextend the limbs. Going from scratch with StandUpFront had no issues and no servos were broken. 