### PR TITLE
Clean up modules and comments in roles

### DIFF
--- a/roles/fake/keyboardwalk.role
+++ b/roles/fake/keyboardwalk.role
@@ -1,13 +1,12 @@
-# This module is used to manually move the robot around with a very basic simulator.
-# It is primarily used for the recruitment task.
-# It does not require any physical robot hardware or external simulation.
+# This module is used to manually move the robot around with a very basic simulator. It is primarily used for the
+# recruitment task. It does not require any physical robot hardware or external simulation.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/fake/keyboardwalk.role
+++ b/roles/fake/keyboardwalk.role
@@ -1,10 +1,13 @@
+# This module is used to manually move the robot around with a very basic simulator.
+# It is primarily used for the recruitment task.
+# It does not require any physical robot hardware or external simulation.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # Config
-  actuation::KinematicsConfiguration
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
   # Network
   network::NUClearNet
   network::NetworkForwarder
@@ -15,8 +18,8 @@ nuclear_role(
   # Director
   extension::Director
   # Servos
-  actuation::Kinematics
   actuation::Servos
+  actuation::Kinematics
   actuation::FootController
   # Skills
   skill::Walk

--- a/roles/fake/visualmesh.role
+++ b/roles/fake/visualmesh.role
@@ -1,12 +1,12 @@
-# This role is used for testing VisualMesh output with an image.
-# It does not require any physical robot hardware or external simulation.
+# This role is used for testing VisualMesh output with an image. It does not require any physical robot hardware or
+# external simulation.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Support
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/fake/visualmesh.role
+++ b/roles/fake/visualmesh.role
@@ -1,15 +1,15 @@
+# This role is used for testing VisualMesh output with an image.
+# It does not require any physical robot hardware or external simulation.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  extension::FileWatcher
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
   # Support
   network::NUClearNet
   network::NetworkForwarder
-  support::configuration::SoccerConfig
   # Sensors
   input::FakeCamera
   input::ImageDecompressor

--- a/roles/firmwareinstaller.role
+++ b/roles/firmwareinstaller.role
@@ -1,9 +1,0 @@
-nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # Tools
-  tools::FirmwareInstaller
-)

--- a/roles/keyboardwalk.role
+++ b/roles/keyboardwalk.role
@@ -1,13 +1,12 @@
-# This module is used to manually move the real robot with the keyboard.
-# It is commonly used for motion testing and tuning.
-# It is commonly used during outreach events.
+# This module is used to manually move the real robot with the keyboard. It is commonly used for motion testing and
+# tuning. It is commonly used during outreach events.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
   network::PlotJuggler
   # Sensors

--- a/roles/keyboardwalk.role
+++ b/roles/keyboardwalk.role
@@ -1,10 +1,13 @@
+# This module is used to manually move the real robot with the keyboard.
+# It is commonly used for motion testing and tuning.
+# It is commonly used during outreach events.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # Config
-  actuation::KinematicsConfiguration
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
   # Network
   network::PlotJuggler
   # Sensors
@@ -13,8 +16,8 @@ nuclear_role(
   # Director
   extension::Director
   # Servos
-  actuation::Kinematics
   actuation::Servos
+  actuation::Kinematics
   actuation::FootController
   # Skills
   skill::Walk

--- a/roles/natnet.role
+++ b/roles/natnet.role
@@ -1,16 +1,11 @@
+# This role is used to test the connection with the OptiTrack Motive motion capture software.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  extension::FileWatcher
-  # support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
-  support::configuration::GlobalConfig
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Network
   network::NUClearNet
   network::NetworkForwarder
-  platform::${SUBCONTROLLER}::HardwareIO
-  input::SensorFilter
-  input::NatNet
-  support::logging::DataLogging
+  input::NatNet # Motion capture networking module
 )

--- a/roles/natnet.role
+++ b/roles/natnet.role
@@ -1,8 +1,8 @@
 # This role is used to test the connection with the OptiTrack Motive motion capture software.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Network
   network::NUClearNet

--- a/roles/onboardwalkoptimisation.role
+++ b/roles/onboardwalkoptimisation.role
@@ -1,11 +1,11 @@
+# This role is used to run the NSGA2 walk optimiser on the real robot.
 nuclear_role(
-  # FileWatcher, Signal Catcher and ConsoleLogHandler Must Go First
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # Config
-  actuation::KinematicsConfiguration
-  support::configuration::GlobalConfig
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
   # Sensors
   platform::${SUBCONTROLLER}::HardwareIO
   input::SensorFilter

--- a/roles/onboardwalkoptimisation.role
+++ b/roles/onboardwalkoptimisation.role
@@ -1,11 +1,11 @@
 # This role is used to run the NSGA2 walk optimiser on the real robot.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Sensors
   platform::${SUBCONTROLLER}::HardwareIO
   input::SensorFilter

--- a/roles/playback.role
+++ b/roles/playback.role
@@ -1,11 +1,10 @@
-# This module is used to playback messages from an NBS file.
-# This is useful for logging sensor data on the real robot and
-# then playing it back without the robot, with other modules.
-# You will likely need to add modules to this role depending on your needs.
+# This module is used to playback messages from an NBS file. This is useful for logging sensor data on the real robot
+# and then playing it back without the robot, with other modules. You will likely need to add modules to this role
+# depending on your needs.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Network
   network::NUClearNet

--- a/roles/playback.role
+++ b/roles/playback.role
@@ -1,12 +1,16 @@
+# This module is used to playback messages from an NBS file.
+# This is useful for logging sensor data on the real robot and
+# then playing it back without the robot, with other modules.
+# You will likely need to add modules to this role depending on your needs.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Network
   network::NUClearNet
   network::NetworkForwarder
-  support::logging::DataPlayback
   output::Overview
+  # Playback messages from an NBS file
+  support::logging::DataPlayback
 )

--- a/roles/ps3walk.role
+++ b/roles/ps3walk.role
@@ -1,12 +1,12 @@
-# This module is used to manually move the real robot around with a PS3 controller.
-# It is commonly used at outreach events.
+# This module is used to manually move the real robot around with a PS3 controller. It is commonly used at outreach
+# events.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
   network::PlotJuggler
   # Sensors

--- a/roles/ps3walk.role
+++ b/roles/ps3walk.role
@@ -1,10 +1,12 @@
+# This module is used to manually move the real robot around with a PS3 controller.
+# It is commonly used at outreach events.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # Config
-  actuation::KinematicsConfiguration
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
   # Network
   network::PlotJuggler
   # Sensors

--- a/roles/robocup.role
+++ b/roles/robocup.role
@@ -1,19 +1,22 @@
+# This role is used for running the full autonomous soccer set up with a real robot.
+# It should be used with a computer on the network running GameController,
+# or set force_playing to true in Soccer.yaml to play without GameController.
+# This is used at the RoboCup competition for real games.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # Config
-  support::configuration::SoccerConfig
-  actuation::KinematicsConfiguration
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig  # Field description
   support::configuration::GlobalConfig
-  # Network
-  network::RobotCommunication
-  # Sensors
+  # Sensors and network (input)
   platform::${SUBCONTROLLER}::HardwareIO
   input::SensorFilter
   input::Camera
   input::GameController
+  network::RobotCommunication
   # Vision
   vision::VisualMesh
   vision::GreenHorizonDetector

--- a/roles/robocup.role
+++ b/roles/robocup.role
@@ -1,15 +1,14 @@
-# This role is used for running the full autonomous soccer set up with a real robot.
-# It should be used with a computer on the network running GameController,
-# or set force_playing to true in Soccer.yaml to play without GameController.
+# This role is used for running the full autonomous soccer set up with a real robot. It should be used with a computer
+# on the network running GameController, or set force_playing to true in Soccer.yaml to play without GameController.
 # This is used at the RoboCup competition for real games.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
-  support::configuration::SoccerConfig  # Field description
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig # Field description
   support::configuration::GlobalConfig
   # Sensors and network (input)
   platform::${SUBCONTROLLER}::HardwareIO

--- a/roles/scriptrunner.role
+++ b/roles/scriptrunner.role
@@ -1,15 +1,16 @@
+# This role is used to run scripts (keyframe animations) on the real robot.
+# Add the script name as an argument when running the binary and press the green button on the robot to play the script.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  support::logging::ConsoleLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Sensors
   platform::${SUBCONTROLLER}::HardwareIO
   input::SensorFilter
   # Director
   extension::Director
   # Servos
-  actuation::Kinematics
   actuation::Servos
   # Purpose
   purpose::ScriptRunner

--- a/roles/scriptrunner.role
+++ b/roles/scriptrunner.role
@@ -1,9 +1,9 @@
-# This role is used to run scripts (keyframe animations) on the real robot.
-# Add the script name as an argument when running the binary and press the green button on the robot to play the script.
+# This role is used to run scripts (keyframe animations) on the real robot. Add the script name as an argument when
+# running the binary and press the green button on the robot to play the script.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Sensors
   platform::${SUBCONTROLLER}::HardwareIO

--- a/roles/scripttuner.role
+++ b/roles/scripttuner.role
@@ -1,9 +1,8 @@
-# This role is used to tune scripts on the real robot with a terminal interface.
-# NUsight is used to see logs
+# This role is used to tune scripts on the real robot with a terminal interface. NUsight is used to see logs.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Sensors
   platform::${SUBCONTROLLER}::HardwareIO

--- a/roles/scripttuner.role
+++ b/roles/scripttuner.role
@@ -1,19 +1,21 @@
+# This role is used to tune scripts on the real robot with a terminal interface.
+# NUsight is used to see logs
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  # Config
-  support::logging::MessageLogHandler
-  actuation::KinematicsConfiguration
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Sensors
   platform::${SUBCONTROLLER}::HardwareIO
   input::SensorFilter
-  # Networking
+  # Network
   network::NUClearNet
   network::NetworkForwarder
   output::Overview
+  support::logging::MessageLogHandler
   # Director
   extension::Director
   # Servos
-  actuation::Kinematics
   actuation::Servos
   # Purpose
   purpose::ScriptTuner

--- a/roles/systemconfiguration.role
+++ b/roles/systemconfiguration.role
@@ -1,10 +1,9 @@
-# This role is used to run the system configuration module.
-# The module ensures correct packages are installed on the robot.
-# It sets up the network configuration on the robot.
+# This role is used to run the system configuration module. The module ensures correct packages are installed on the
+# robot. It sets up the network configuration on the robot.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # System configuration module
   tools::SystemConfiguration

--- a/roles/systemconfiguration.role
+++ b/roles/systemconfiguration.role
@@ -1,6 +1,11 @@
+# This role is used to run the system configuration module.
+# The module ensures correct packages are installed on the robot.
+# It sets up the network configuration on the robot.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First.
-  support::logging::ConsoleLogHandler
-  extension::FileWatcher
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # System configuration module
   tools::SystemConfiguration
 )

--- a/roles/test/behaviour.role
+++ b/roles/test/behaviour.role
@@ -1,13 +1,14 @@
+# This role is used to test individual behaviours together in different configurations on the real robot.
+# Modify Tester.yaml to specify which behaviours to test.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # Config
-  support::configuration::SoccerConfig
-  actuation::KinematicsConfiguration
-  support::configuration::GlobalConfig
-  # NUsight
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig  # Field description
+  # Network
   network::NUClearNet
   network::NetworkForwarder
   output::Overview
@@ -16,7 +17,6 @@ nuclear_role(
   platform::${SUBCONTROLLER}::HardwareIO
   input::SensorFilter
   input::Camera
-  input::GameController
   # Vision
   vision::VisualMesh
   vision::GreenHorizonDetector
@@ -36,7 +36,6 @@ nuclear_role(
   skill::SplineKick
   skill::GetUp
   skill::Look
-  skill::Dive
   # Planners
   planning::PlanWalkPath
   planning::PlanLook
@@ -52,7 +51,6 @@ nuclear_role(
   strategy::FindObject
   strategy::KickToGoal
   strategy::AlignBallToGoal
-  strategy::DiveToBall
   # Purposes
   purpose::Tester
 )

--- a/roles/test/behaviour.role
+++ b/roles/test/behaviour.role
@@ -1,13 +1,13 @@
-# This role is used to test individual behaviours together in different configurations on the real robot.
-# Modify Tester.yaml to specify which behaviours to test.
+# This role is used to test individual behaviours together in different configurations on the real robot. Modify
+# Tester.yaml to specify which behaviours to test.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
-  support::configuration::SoccerConfig  # Field description
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig # Field description
   # Network
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/test/camera.role
+++ b/roles/test/camera.role
@@ -1,12 +1,11 @@
-# This role is used to see the camera output on the robots.
-# It is useful for focusing the camera lenses.
+# This role is used to see the camera output on the robots. It is useful for focusing the camera lenses.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/test/camera.role
+++ b/roles/test/camera.role
@@ -1,18 +1,19 @@
+# This role is used to see the camera output on the robots.
+# It is useful for focusing the camera lenses.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  # Network
   network::NUClearNet
   network::NetworkForwarder
-  support::configuration::GlobalConfig
+  output::Overview
+  output::ImageCompressor
+  # Sensor input
   platform::${SUBCONTROLLER}::HardwareIO
   input::SensorFilter
   input::Camera
-  output::Overview
-  output::ImageCompressor
-  support::configuration::SoccerConfig
 )

--- a/roles/test/director.role
+++ b/roles/test/director.role
@@ -1,9 +1,0 @@
-nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  extension::FileWatcher
-  support::logging::ConsoleLogHandler
-  network::NUClearNet
-  network::NetworkForwarder
-  extension::Director
-)

--- a/roles/test/gamecontroller.role
+++ b/roles/test/gamecontroller.role
@@ -1,19 +1,20 @@
+# This role is used to test the robot's connection with the GameController software.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
-  # Hardware for button testing
-  platform::${SUBCONTROLLER}::HardwareIO
-  input::SensorFilter
-  # Support and Configuration
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  # GlobalConfig is used by GameController
   support::configuration::GlobalConfig
-  support::configuration::SoccerConfig
+  # Network
   network::NUClearNet
   network::NetworkForwarder
   output::Overview
+  # Sensors for button testing
+  platform::${SUBCONTROLLER}::HardwareIO
+  input::SensorFilter
+  # GameController communications
   input::GameController
 )

--- a/roles/test/gamecontroller.role
+++ b/roles/test/gamecontroller.role
@@ -1,11 +1,11 @@
 # This role is used to test the robot's connection with the GameController software.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # GlobalConfig is used by GameController
   support::configuration::GlobalConfig
   # Network

--- a/roles/test/localisation.role
+++ b/roles/test/localisation.role
@@ -1,15 +1,15 @@
-# This role is similar to keyboard walk where you can manually control the robot with the keyboard.
-# Unlike keyboard walk, this role includes vision and localisation modules.
-# This can be used to move the robot around and test vision and localisation.
+# This role is similar to keyboard walk where you can manually control the robot with the keyboard. Unlike keyboard
+# walk, this role includes vision and localisation modules. This can be used to move the robot around and test vision
+# and localisation.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   support::configuration::GlobalConfig
-  support::configuration::SoccerConfig  # Field description
+  support::configuration::SoccerConfig # Field description
   # Network
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/test/localisation.role
+++ b/roles/test/localisation.role
@@ -1,15 +1,16 @@
+# This role is similar to keyboard walk where you can manually control the robot with the keyboard.
+# Unlike keyboard walk, this role includes vision and localisation modules.
+# This can be used to move the robot around and test vision and localisation.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run support::SignalCatcher
-  extension::FileWatcher
-  support::logging::FileLogHandler
-  support::logging::ConsoleLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
-  # Support and Configuration
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
   support::configuration::GlobalConfig
-  support::configuration::SoccerConfig
-  # NUsight
+  support::configuration::SoccerConfig  # Field description
+  # Network
   network::NUClearNet
   network::NetworkForwarder
   output::Overview

--- a/roles/test/messageloghandler.role
+++ b/roles/test/messageloghandler.role
@@ -1,7 +1,0 @@
-nuclear_role(
-  # FileWatcher and ConsoleLogHandler must go first.
-  extension::FileWatcher
-  support::logging::ConsoleLogHandler
-  support::logging::MessageLogHandler
-  support::logging::DataLogging
-)

--- a/roles/test/nusight.role
+++ b/roles/test/nusight.role
@@ -1,8 +1,8 @@
 # This role is for testing connection with NUsight.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Network
   network::NUClearNet

--- a/roles/test/nusight.role
+++ b/roles/test/nusight.role
@@ -1,11 +1,12 @@
+# This role is for testing connection with NUsight.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  support::logging::ConsoleLogHandler
-  # Config
-  extension::FileWatcher
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Network
   network::NUClearNet
   network::NetworkForwarder
   output::Overview
-  support::NUsightHarness
+  support::NUsightHarness # emits graph data for testing NUsight
 )

--- a/roles/test/plotjuggler.role
+++ b/roles/test/plotjuggler.role
@@ -1,8 +1,0 @@
-nuclear_role(
-  # FileWatcher and ConsoleLogHandler must go first.
-  extension::FileWatcher
-  support::logging::ConsoleLogHandler
-  # Networking
-  network::NUClearNet
-  network::PlotJuggler
-)

--- a/roles/test/sensor.role
+++ b/roles/test/sensor.role
@@ -1,11 +1,11 @@
 # This role is for testing connection with the sensors and visualising the kinematics in NUsight
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
   network::NetworkForwarder
   network::NUClearNet

--- a/roles/test/sensor.role
+++ b/roles/test/sensor.role
@@ -1,16 +1,17 @@
+# This role is for testing connection with the sensors and visualising the kinematics in NUsight
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  extension::FileWatcher
-  # support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
-  support::configuration::GlobalConfig
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  # Network
   network::NetworkForwarder
   network::NUClearNet
   network::PlotJuggler
+  output::Overview
+  # Sensors
   platform::${SUBCONTROLLER}::HardwareIO
   input::SensorFilter
-  output::Overview
 )

--- a/roles/test/speak.role
+++ b/roles/test/speak.role
@@ -1,8 +1,8 @@
 # Test the speaking functionality of the Say module
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Director
   extension::Director

--- a/roles/test/speak.role
+++ b/roles/test/speak.role
@@ -1,10 +1,11 @@
+# Test the speaking functionality of the Say module
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  extension::FileWatcher
-  support::logging::ConsoleLogHandler
-  network::NUClearNet
-  network::NetworkForwarder
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Director
   extension::Director
+  # Specify something to say in the config of the Say module
   skill::Say
 )

--- a/roles/test/visualmesh.role
+++ b/roles/test/visualmesh.role
@@ -1,13 +1,12 @@
-# This role is used for testing the VisualMesh on the real robot.
-# This does not move the robot's servos, so it is recommended to stand the robot first.
-# This role is commonly used to record data for automatic camera calibration.
+# This role is used for testing the VisualMesh on the real robot. This does not move the robot's servos, so it is
+# recommended to stand the robot first. This role is commonly used to record data for automatic camera calibration.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/test/visualmesh.role
+++ b/roles/test/visualmesh.role
@@ -1,26 +1,26 @@
+# This role is used for testing the VisualMesh on the real robot.
+# This does not move the robot's servos, so it is recommended to stand the robot first.
+# This role is commonly used to record data for automatic camera calibration.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  extension::FileWatcher
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
-  # Support
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  # Network
   network::NUClearNet
   network::NetworkForwarder
   output::Overview
-  # support::VirtualCamera
-  support::configuration::SoccerConfig
+  output::ImageCompressor
   # Sensors
   input::Camera
   platform::${SUBCONTROLLER}::HardwareIO
-  input::SensorFilter
+  input::SensorFilter # VisualMesh uses odometry
   # Vision
   vision::VisualMesh
   vision::GreenHorizonDetector
   vision::BallDetector
   vision::GoalDetector
-  output::ImageCompressor
-  # Data logger support::logging::DataLogging
+  # Data logging is commonly used with this role for camera calibration: support::logging::DataLogging
 )

--- a/roles/webots/behaviour.role
+++ b/roles/webots/behaviour.role
@@ -1,13 +1,13 @@
-# This role is used with Webots to test individual behaviours together in different configurations.
-# Modify Tester.yaml to specify which behaviours to test.
+# This role is used with Webots to test individual behaviours together in different configurations. Modify Tester.yaml
+# to specify which behaviours to test.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
-  support::configuration::SoccerConfig  # Field description
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig # Field description
   # Network (output)
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/webots/behaviour.role
+++ b/roles/webots/behaviour.role
@@ -1,18 +1,19 @@
+# This role is used with Webots to test individual behaviours together in different configurations.
+# Modify Tester.yaml to specify which behaviours to test.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # Config
-  support::configuration::SoccerConfig
-  actuation::KinematicsConfiguration
-  support::configuration::GlobalConfig
-  # NUsight
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig  # Field description
+  # Network (output)
   network::NUClearNet
   network::NetworkForwarder
   output::Overview
   output::ImageCompressor
-  # Sensors
+  # Sensors and network input
   input::GameController
   network::RobotCommunication
   input::SensorFilter
@@ -36,7 +37,6 @@ nuclear_role(
   skill::SplineKick
   skill::GetUp
   skill::Look
-  skill::Dive
   skill::Say
   # Planners
   planning::PlanWalkPath
@@ -47,12 +47,10 @@ nuclear_role(
   # Strategies
   strategy::FallRecovery
   strategy::StandStill
+  strategy::WalkToFieldPosition
   strategy::StrategiseLook
   strategy::WalkToBall
-  strategy::WalkToFieldPosition
   strategy::FindObject
-  strategy::Ready
-  strategy::DiveToBall
   strategy::KickToGoal
   strategy::AlignBallToGoal
   # Purposes

--- a/roles/webots/keyboardwalk.role
+++ b/roles/webots/keyboardwalk.role
@@ -1,21 +1,18 @@
+# This module is used to manually move the robot around in Webots.
+# It is primarily used for testing motions.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run support::SignalCatcher
-  extension::FileWatcher
-  support::logging::FileLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
-  # Support and Configuration
-  support::configuration::GlobalConfig
-  support::configuration::SoccerConfig
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
   # Network
-  network::NUClearNet
-  network::PlotJuggler
-  # NUsight
   network::NUClearNet
   network::NetworkForwarder
   output::Overview
-  # Platform
+  network::PlotJuggler
+  # Sensors
   input::SensorFilter
   platform::Webots
   # Director

--- a/roles/webots/keyboardwalk.role
+++ b/roles/webots/keyboardwalk.role
@@ -1,12 +1,11 @@
-# This module is used to manually move the robot around in Webots.
-# It is primarily used for testing motions.
+# This module is used to manually move the robot around in Webots. It is primarily used for testing motions.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/webots/localisation.role
+++ b/roles/webots/localisation.role
@@ -1,26 +1,24 @@
+# This role is similar to keyboard walk where you can manually control a robot in Webots with the keyboard.
+# Unlike keyboard walk, this role includes vision and localisation modules.
+# This can be used to move the robot around and test vision and localisation.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run support::SignalCatcher
-  extension::FileWatcher
-  support::logging::FileLogHandler
-  support::logging::ConsoleLogHandler
-  support::logging::MessageLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
-  # Support and Configuration
-  support::configuration::GlobalConfig
-  support::configuration::SoccerConfig
-  # NUsight
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig  # Field description
+  # Network
   network::NUClearNet
   network::NetworkForwarder
   output::Overview
   output::ImageCompressor
+  support::logging::MessageLogHandler # Used to send log messages and reaction statistics to NUsight
+  network::PlotJuggler
   # Platform
   input::SensorFilter
   platform::Webots
-  # Network
-  network::NUClearNet
-  network::PlotJuggler
   # Vision
   vision::VisualMesh
   vision::GreenHorizonDetector

--- a/roles/webots/localisation.role
+++ b/roles/webots/localisation.role
@@ -1,14 +1,14 @@
-# This role is similar to keyboard walk where you can manually control a robot in Webots with the keyboard.
-# Unlike keyboard walk, this role includes vision and localisation modules.
-# This can be used to move the robot around and test vision and localisation.
+# This role is similar to keyboard walk where you can manually control a robot in Webots with the keyboard. Unlike
+# keyboard walk, this role includes vision and localisation modules. This can be used to move the robot around and test
+# vision and localisation.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
-  support::configuration::SoccerConfig  # Field description
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig # Field description
   # Network
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/webots/robocup.role
+++ b/roles/webots/robocup.role
@@ -1,14 +1,14 @@
-# This role is used for running the full autonomous soccer set up with a robot in Webots.
-# It should be used with the official RoboCup Webots environment, or set force_playing to true in Soccer.yaml
-# if you are using a Webots environment without GameController.
+# This role is used for running the full autonomous soccer set up with a robot in Webots. It should be used with the
+# official RoboCup Webots environment, or set force_playing to true in Soccer.yaml if you are using a Webots environment
+# without GameController.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
-  support::configuration::SoccerConfig  # Field description
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig # Field description
   support::configuration::GlobalConfig
   # Network (output)
   network::NUClearNet

--- a/roles/webots/robocup.role
+++ b/roles/webots/robocup.role
@@ -1,21 +1,25 @@
+# This role is used for running the full autonomous soccer set up with a robot in Webots.
+# It should be used with the official RoboCup Webots environment, or set force_playing to true in Soccer.yaml
+# if you are using a Webots environment without GameController.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # Config
-  support::configuration::SoccerConfig
-  actuation::KinematicsConfiguration
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig  # Field description
   support::configuration::GlobalConfig
-  # Network
-  network::PlotJuggler
+  # Network (output)
   network::NUClearNet
-  network::RobotCommunication
   network::NetworkForwarder
   output::Overview
   output::ImageCompressor
-  # Sensors
+  support::logging::MessageLogHandler # Used to send log messages and reaction statistics to NUsight
+  network::PlotJuggler
+  # Sensors and network input
   input::GameController
+  network::RobotCommunication
   input::SensorFilter
   platform::Webots
   # Vision
@@ -52,7 +56,6 @@ nuclear_role(
   strategy::WalkToBall
   strategy::WalkToFieldPosition
   strategy::FindObject
-  strategy::Ready
   strategy::DiveToBall
   strategy::KickToGoal
   strategy::AlignBallToGoal

--- a/roles/webots/scripttuner.role
+++ b/roles/webots/scripttuner.role
@@ -1,11 +1,10 @@
-# This role is used to tune scripts in Webots with a terminal interface.
-# NUsight is used to see logs
+# This role is used to tune scripts in Webots with a terminal interface. NUsight is used to see logs.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
   network::NUClearNet
   network::NetworkForwarder

--- a/roles/webots/scripttuner.role
+++ b/roles/webots/scripttuner.role
@@ -1,14 +1,22 @@
+# This role is used to tune scripts in Webots with a terminal interface.
+# NUsight is used to see logs
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
-  extension::FileWatcher
-  # Config
-  actuation::KinematicsConfiguration
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  # Network
+  network::NUClearNet
+  network::NetworkForwarder
+  output::Overview
+  support::logging::MessageLogHandler # Used to send log messages and reaction statistics to NUsight
+  # Sensors
   platform::Webots
   input::SensorFilter
   # Director
   extension::Director
   # Servos
-  actuation::Kinematics
   actuation::Servos
   # Purpose
   purpose::ScriptTuner

--- a/roles/webots/walkoptimisation.role
+++ b/roles/webots/walkoptimisation.role
@@ -1,11 +1,11 @@
 # This role is used to run the NSGA2 walk optimiser in Webots.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
-  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Sensors
   platform::Webots
   input::SensorFilter

--- a/roles/webots/walkoptimisation.role
+++ b/roles/webots/walkoptimisation.role
@@ -1,12 +1,12 @@
+# This role is used to run the NSGA2 walk optimiser in Webots.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First. KinematicsConfiguration usually goes after these
-  # and without it many roles do not run
-  extension::FileWatcher
-  support::SignalCatcher
-  support::logging::ConsoleLogHandler
-  # This must come first as it emits config which many roles depend on (e.g. SensorFilter, WalkEngine)
-  actuation::KinematicsConfiguration
-  support::configuration::GlobalConfig
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration  # Must go early in the role as other modules depend on it
+  # Sensors
   platform::Webots
   input::SensorFilter
   # Director

--- a/roles/webots/webots.role
+++ b/roles/webots/webots.role
@@ -1,11 +1,9 @@
+# This role is used to test the connection with Webots.
 nuclear_role(
-  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First.
-  extension::FileWatcher
-  support::logging::ConsoleLogHandler
-  # Support and Configuration GlobalConfig must go before Webots
-  support::configuration::GlobalConfig
-  # Image Handling
-  input::ImageDecompressor
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher  # Watches configuration files for changes
+  support::SignalCatcher  # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Simulator Connection
   platform::Webots
 )

--- a/roles/webots/webots.role
+++ b/roles/webots/webots.role
@@ -1,8 +1,8 @@
 # This role is used to test the connection with Webots.
 nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
-  extension::FileWatcher  # Watches configuration files for changes
-  support::SignalCatcher  # Allows for graceful shutdown
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
   support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Simulator Connection
   platform::Webots


### PR DESCRIPTION
- Remove unnecessary modules in some roles
- Clean up the grouping of modules
- Added/cleaned up comments for modules that might not be self explanatory
-  Added in a header for every role file explaining it's purpose
- Removed some roles. These were mostly ones made when testing during development of certain modules and for running CI, but other roles cover this testing now. 

For Jira DQA-4.