### PR TITLE
Add localisation ground truth method

### DIFF
--- a/module/localisation/FieldLocalisation/data/config/FieldLocalisation.yaml
+++ b/module/localisation/FieldLocalisation/data/config/FieldLocalisation.yaml
@@ -27,3 +27,6 @@ min_observations: 50
 
 # Delay before the particle filter starts (allows odometry to settle)
 start_time_delay: 5
+
+# Bool to use ground truth for localisation
+use_ground_truth_localisation: false

--- a/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
+++ b/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
@@ -27,3 +27,6 @@ min_observations: 50
 
 # Delay before the particle filter starts (allows odometry to settle)
 start_time_delay: 5
+
+# Bool to use ground truth for localisation
+use_ground_truth_localisation: false

--- a/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
+++ b/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
@@ -1,5 +1,5 @@
 # Controls the minimum log level that NUClear log will display
-log_level: INFO
+log_level: DEBUG
 
 # Size of each cell in the occupancy map, each cell has an area of grid_size x grid_size [metres]
 grid_size: 1e-2

--- a/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
+++ b/module/localisation/FieldLocalisation/data/config/webots/FieldLocalisation.yaml
@@ -1,5 +1,5 @@
 # Controls the minimum log level that NUClear log will display
-log_level: DEBUG
+log_level: INFO
 
 # Size of each cell in the occupancy map, each cell has an area of grid_size x grid_size [metres]
 grid_size: 1e-2

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
@@ -49,7 +49,6 @@ namespace module::localisation {
     using utility::nusight::graph;
     using utility::support::Expression;
 
-
     using namespace std::chrono;
 
     FieldLocalisation::FieldLocalisation(std::unique_ptr<NUClear::Environment> environment)
@@ -173,8 +172,8 @@ namespace module::localisation {
         Eigen::Vector3d rPFf = compute_Hfw(particle) * rPWw;
 
         // Get the associated index in the field line map [x, y]
-        // Note: field space is placed in centre of the field, whereas the field line map origin (x,y) is top
-        // left corner of discretised field
+        // Note: field space is placed in centre of the field, whereas the field line map origin (x,y) is top left
+        // corner of discretised field
         return Eigen::Vector2i(fieldline_distance_map.get_length() / 2 - std::round(rPFf(1) / cfg.grid_size),
                                fieldline_distance_map.get_width() / 2 + std::round(rPFf(0) / cfg.grid_size));
     }

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
@@ -64,6 +64,7 @@ namespace module::localisation {
             cfg.process_noise.diagonal()        = Eigen::Vector3d(config["process_noise"].as<Expression>());
             cfg.starting_side                   = config["starting_side"].as<std::string>();
             cfg.start_time_delay                = config["start_time_delay"].as<double>();
+            cfg.use_ground_truth_localisation   = config["use_ground_truth_localisation"].as<bool>();
             filter.model.process_noise_diagonal = config["process_noise"].as<Expression>();
             filter.model.n_particles            = config["n_particles"].as<int>();
         });
@@ -112,28 +113,36 @@ namespace module::localisation {
                 auto time_since_startup =
                     std::chrono::duration_cast<std::chrono::seconds>(NUClear::clock::now() - startup_time).count();
                 bool fallen = stability == Stability::FALLEN || stability == Stability::FALLING;
-                if (!fallen && field_lines.rPWw.size() > cfg.min_observations
-                    && time_since_startup > cfg.start_time_delay) {
 
-                    // Measurement update (using field line observations)
-                    for (int i = 0; i < cfg.n_particles; i++) {
-                        auto weight = calculate_weight(filter.get_particle(i), field_lines.rPWw);
-                        filter.set_particle_weight(weight, i);
-                    }
-
-                    // Time update (includes resampling)
-                    const double dt =
-                        duration_cast<duration<double>>(NUClear::clock::now() - last_time_update_time).count();
-                    last_time_update_time = NUClear::clock::now();
-                    filter.time(dt);
-
+                if (cfg.use_ground_truth_localisation) {
                     auto field(std::make_unique<Field>());
-                    field->Hfw = compute_Hfw(filter.get_state());
-                    if (log_level <= NUClear::DEBUG && raw_sensors.localisation_ground_truth.exists) {
-                        debug_field_localisation(field->Hfw, raw_sensors);
-                    }
-                    field->covariance = filter.get_covariance();
+                    field->Hfw = raw_sensors.localisation_ground_truth.Hfw;
                     emit(field);
+                }
+                else {
+                    if (!fallen && field_lines.rPWw.size() > cfg.min_observations
+                        && time_since_startup > cfg.start_time_delay) {
+
+                        // Measurement update (using field line observations)
+                        for (int i = 0; i < cfg.n_particles; i++) {
+                            auto weight = calculate_weight(filter.get_particle(i), field_lines.rPWw);
+                            filter.set_particle_weight(weight, i);
+                        }
+
+                        // Time update (includes resampling)
+                        const double dt =
+                            duration_cast<duration<double>>(NUClear::clock::now() - last_time_update_time).count();
+                        last_time_update_time = NUClear::clock::now();
+                        filter.time(dt);
+
+                        auto field(std::make_unique<Field>());
+                        field->Hfw = compute_Hfw(filter.get_state());
+                        if (log_level <= NUClear::DEBUG && raw_sensors.localisation_ground_truth.exists) {
+                            debug_field_localisation(field->Hfw, raw_sensors);
+                        }
+                        field->covariance = filter.get_covariance();
+                        emit(field);
+                    }
                 }
             });
     }

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
@@ -152,11 +152,9 @@ namespace module::localisation {
 
         // Graph translation and error from ground truth
         emit(graph("Hfw true translation (rFWw)", true_rFWw.x(), true_rFWw.y(), true_rFWw.z()));
-        emit(graph("Hfw estimated translation (rFWw)", rFWw.x(), rFWw.y(), rFWw.z()));
         emit(graph("Hfw translation error", error_rFWw.x(), error_rFWw.y(), error_rFWw.z()));
         // Graph rotation and error from ground truth
         emit(graph("Rfw true angles (rpy)", true_Rfw.x(), true_Rfw.y(), true_Rfw.z()));
-        emit(graph("Rfw estimated angles (rpy)", Rfw.x(), Rfw.y(), Rfw.z()));
         emit(graph("Rfw error (rpy)", error_Rfw.x(), error_Rfw.y(), error_Rfw.z()));
         emit(graph("Quaternion rotational error", quat_rot_error));
     }

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
@@ -114,12 +114,15 @@ namespace module::localisation {
                     std::chrono::duration_cast<std::chrono::seconds>(NUClear::clock::now() - startup_time).count();
                 bool fallen = stability == Stability::FALLEN || stability == Stability::FALLING;
 
+                // Emit field message using ground truth if available
                 if (cfg.use_ground_truth_localisation) {
                     auto field(std::make_unique<Field>());
                     field->Hfw = raw_sensors.localisation_ground_truth.Hfw;
                     emit(field);
                     return;
                 }
+
+                // Otherwise calculate using field lines
                 if (!fallen && field_lines.rPWw.size() > cfg.min_observations
                     && time_since_startup > cfg.start_time_delay) {
 

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
@@ -154,16 +154,18 @@ namespace module::localisation {
 
         // Graph translation and its error
         emit(graph("Hfw true translation (rFWw)", true_rFWw.x(), true_rFWw.y(), true_rFWw.z()));
+        emit(graph("Hfw estimated translation (rFWw)", estimated_rFWw.x(), estimated_rFWw.y(), estimated_rFWw.z()));
         emit(graph("Hfw translation error", error_rFWw.x(), error_rFWw.y(), error_rFWw.z()));
         // Graph rotation and its error
         emit(graph("Rfw true rotation (rpy)", true_Rfw.x(), true_Rfw.y(), true_Rfw.z()));
+        emit(graph("Rfw estimated rotation (rpy)", estimated_Rfw.x(), estimated_Rfw.y(), estimated_Rfw.z()));
         emit(graph("Rfw error (rpy)", error_Rfw.x(), error_Rfw.y(), error_Rfw.z()));
         emit(graph("Quaternion rotational error", quat_rot_error));
     }
 
     Eigen::Isometry3d FieldLocalisation::compute_Hfw(const Eigen::Vector3d& particle) {
-        Eigen::Isometry3d Hfw = Eigen::Translation<double, 3>(particle.x(), particle.y(), 0)
-                                * Eigen::AngleAxis<double>(particle.z(), Eigen::Matrix<double, 3, 1>::UnitZ());
+        return Eigen::Translation<double, 3>(particle.x(), particle.y(), 0)
+               * Eigen::AngleAxis<double>(particle.z(), Eigen::Matrix<double, 3, 1>::UnitZ());
     }
 
     Eigen::Vector2i FieldLocalisation::position_in_map(const Eigen::Vector3d& particle, const Eigen::Vector3d& rPWw) {

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.cpp
@@ -140,24 +140,23 @@ namespace module::localisation {
 
     void FieldLocalisation::debug_field_localisation(Eigen::Isometry3d Hfw, const RawSensors& raw_sensors) {
         const Eigen::Isometry3d true_Hfw = Eigen::Isometry3d(raw_sensors.localisation_ground_truth.Hfw);
-        // Localisation information
-        Eigen::Vector3d estimated_Rfw  = MatrixToEulerIntrinsic(Hfw.rotation());
-        Eigen::Vector3d estimated_rFWw = (Hfw.translation());
         // Determine translational distance error
         Eigen::Vector3d true_rFWw  = true_Hfw.translation();
-        Eigen::Vector3d error_rFWw = (true_rFWw - estimated_rFWw).cwiseAbs();
-        // Determine rotational distance error
+        Eigen::Vector3d rFWw       = (Hfw.translation());
+        Eigen::Vector3d error_rFWw = (true_rFWw - rFWw).cwiseAbs();
+        // Determine yaw, pitch, and roll error
         Eigen::Vector3d true_Rfw  = MatrixToEulerIntrinsic(true_Hfw.rotation());
-        Eigen::Vector3d error_Rfw = (true_Rfw - estimated_Rfw).cwiseAbs();
+        Eigen::Vector3d Rfw       = MatrixToEulerIntrinsic(Hfw.rotation());
+        Eigen::Vector3d error_Rfw = (true_Rfw - Rfw).cwiseAbs();
         double quat_rot_error     = Eigen::Quaterniond(true_Hfw.linear() * Hfw.inverse().linear()).w();
 
-        // Graph translation and its error
+        // Graph translation and error from ground truth
         emit(graph("Hfw true translation (rFWw)", true_rFWw.x(), true_rFWw.y(), true_rFWw.z()));
-        emit(graph("Hfw estimated translation (rFWw)", estimated_rFWw.x(), estimated_rFWw.y(), estimated_rFWw.z()));
+        emit(graph("Hfw estimated translation (rFWw)", rFWw.x(), rFWw.y(), rFWw.z()));
         emit(graph("Hfw translation error", error_rFWw.x(), error_rFWw.y(), error_rFWw.z()));
-        // Graph rotation and its error
-        emit(graph("Rfw true rotation (rpy)", true_Rfw.x(), true_Rfw.y(), true_Rfw.z()));
-        emit(graph("Rfw estimated rotation (rpy)", estimated_Rfw.x(), estimated_Rfw.y(), estimated_Rfw.z()));
+        // Graph rotation and error from ground truth
+        emit(graph("Rfw true angles (rpy)", true_Rfw.x(), true_Rfw.y(), true_Rfw.z()));
+        emit(graph("Rfw estimated angles (rpy)", Rfw.x(), Rfw.y(), Rfw.z()));
         emit(graph("Rfw error (rpy)", error_Rfw.x(), error_Rfw.y(), error_Rfw.z()));
         emit(graph("Quaternion rotational error", quat_rot_error));
     }

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.hpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.hpp
@@ -34,6 +34,7 @@
 
 #include "message/eye/DataPoint.hpp"
 #include "message/localisation/Field.hpp"
+#include "message/platform/RawSensors.hpp"
 #include "message/support/FieldDescription.hpp"
 #include "message/vision/FieldLines.hpp"
 
@@ -46,6 +47,7 @@
 
 namespace module::localisation {
 
+    using message::platform::RawSensors;
     using message::support::FieldDescription;
 
     struct StartingSide {
@@ -142,6 +144,8 @@ namespace module::localisation {
          * @return Hfw, the homogenous transformation matrix from world {w} to field {f} space
          */
         Eigen::Isometry3d compute_Hfw(const Eigen::Vector3d& particle);
+
+        void debug_field_localisation(Eigen::Isometry3d Hfw, const RawSensors& raw_sensors);
 
         /**
          * @brief Transform a field line point from world {w} to position in the distance map {m}

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.hpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.hpp
@@ -145,6 +145,12 @@ namespace module::localisation {
          */
         Eigen::Isometry3d compute_Hfw(const Eigen::Vector3d& particle);
 
+        /**
+         * @brief Find error between computed Hfw and ground truth if available
+         *
+         * @param Hfw Computed Hfw to be compared against ground truth
+         * @param raw_sensors The raw sensor data
+         */
         void debug_field_localisation(Eigen::Isometry3d Hfw, const RawSensors& raw_sensors);
 
         /**

--- a/module/localisation/FieldLocalisation/src/FieldLocalisation.hpp
+++ b/module/localisation/FieldLocalisation/src/FieldLocalisation.hpp
@@ -117,6 +117,9 @@ namespace module::localisation {
             /// @brief Start time delay for the particle filter
             double start_time_delay = 0.0;
 
+            /// @brief Bool to enable/disable using ground truth for localisation
+            bool use_ground_truth_localisation;
+
             /// @brief Starting side of the field (LEFT, RIGHT, EITHER, or CUSTOM)
             StartingSide starting_side = StartingSide::UNKNOWN;
         } cfg;

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -733,7 +733,7 @@ namespace module::platform {
 
         log(sensor_measurements.localisation_ground_truth.exists) {
             log<NUClear::TRACE>("  sm.localisation_ground_truth:");
-            log<NUClear::TRACE>("    Hfw:\n", sensor_measurements.localisation_ground_truth);
+            log<NUClear::TRACE>("    Hfw:\n", sensor_measurements.localisation_ground_truth.Hfw);
         }
 
         // Parse the errors and warnings from Webots and log them.

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -731,7 +731,7 @@ namespace module::platform {
             log<NUClear::TRACE>("    Htw:\n", sensor_measurements.odometry_ground_truth.Htw);
         }
 
-        log(sensor_measurements.localisation_ground_truth.exists) {
+        if (sensor_measurements.localisation_ground_truth.exists) {
             log<NUClear::TRACE>("  sm.localisation_ground_truth:");
             log<NUClear::TRACE>("    Hfw:\n", sensor_measurements.localisation_ground_truth.Hfw);
         }

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -731,6 +731,11 @@ namespace module::platform {
             log<NUClear::TRACE>("    Htw:\n", sensor_measurements.odometry_ground_truth.Htw);
         }
 
+        log(sensor_measurements.localisation_ground_truth.exists) {
+            log<NUClear::TRACE>("  sm.localisation_ground_truth:");
+            log<NUClear::TRACE>("    Hfw:\n", sensor_measurements.localisation_ground_truth);
+        }
+
         // Parse the errors and warnings from Webots and log them.
         // Note that this is where we should deal with specific messages passed in SensorMeasurements.messages.
         // Or check if those messages have specific information
@@ -811,6 +816,10 @@ namespace module::platform {
             if (sensor_measurements.odometry_ground_truth.exists) {
                 sensor_data->odometry_ground_truth.exists = true;
                 sensor_data->odometry_ground_truth.Htw    = sensor_measurements.odometry_ground_truth.Htw;
+            }
+            if (sensor_measurements.localisation_ground_truth.exists) {
+                sensor_data->localisation_ground_truth.exists = true;
+                sensor_data->localisation_ground_truth.Hfw    = sensor_measurements.localisation_ground_truth.Hfw;
             }
 
             emit(sensor_data);

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -183,7 +183,8 @@ message RawSensors {
     FSRs     fsr           = 11;
 
     /// Ground truth from a simulator
-    webots.OdometryGroundTruth odometry_ground_truth = 12;
+    webots.OdometryGroundTruth     odometry_ground_truth     = 12;
+    webots.LocalisationGroundTruth localisation_ground_truth = 13;
 }
 
 message ButtonLeftDown {}

--- a/shared/message/platform/webots/messages.proto
+++ b/shared/message/platform/webots/messages.proto
@@ -118,16 +118,16 @@ message SensorMeasurements {
     // simulation time stamp at which the measurements were performed expressed in [ms] from the start of the connection
     uint32 time = 1;
     // real unix time stamp at which the measurements were performed in [ms]
-    uint64                               real_time      = 2;
-    repeated Message                     messages       = 3;
-    repeated AccelerometerMeasurement    accelerometers = 4;
-    repeated BumperMeasurement           bumpers        = 5;
-    repeated CameraMeasurement           cameras        = 6;
-    repeated ForceMeasurement            forces         = 7;
-    repeated Force3DMeasurement          force3ds       = 8;
-    repeated Force6DMeasurement force6ds t "message/platform/webots/messages.  = 9;
-        repeated GyroMeasurement         gyros            = 10;
-    repeated PositionSensorMeasurement   position_sensors = 11;
+    uint64                             real_time        = 2;
+    repeated Message                   messages         = 3;
+    repeated AccelerometerMeasurement  accelerometers   = 4;
+    repeated BumperMeasurement         bumpers          = 5;
+    repeated CameraMeasurement         cameras          = 6;
+    repeated ForceMeasurement          forces           = 7;
+    repeated Force3DMeasurement        force3ds         = 8;
+    repeated Force6DMeasurement        force6ds         = 9;
+    repeated GyroMeasurement           gyros            = 10;
+    repeated PositionSensorMeasurement position_sensors = 11;
     // NUbots-specific data. Set to 100 in case other data is added in by the RoboCup TC
     OdometryGroundTruth     odometry_ground_truth     = 100;
     LocalisationGroundTruth localisation_ground_truth = 101;

--- a/shared/message/platform/webots/messages.proto
+++ b/shared/message/platform/webots/messages.proto
@@ -102,6 +102,11 @@ message OdometryGroundTruth {
     mat4 Htw = 2;
 }
 
+message LocalisationGroundTruth {
+    bool exists = 1;
+    mat4 Hfw    = 2;
+}
+
 message VisionGroundTruth {
     /// Indicates if this message exists
     bool exists = 1;
@@ -113,21 +118,21 @@ message SensorMeasurements {
     // simulation time stamp at which the measurements were performed expressed in [ms] from the start of the connection
     uint32 time = 1;
     // real unix time stamp at which the measurements were performed in [ms]
-    uint64                             real_time        = 2;
-    repeated Message                   messages         = 3;
-    repeated AccelerometerMeasurement  accelerometers   = 4;
-    repeated BumperMeasurement         bumpers          = 5;
-    repeated CameraMeasurement         cameras          = 6;
-    repeated ForceMeasurement          forces           = 7;
-    repeated Force3DMeasurement        force3ds         = 8;
-    repeated Force6DMeasurement        force6ds         = 9;
-    repeated GyroMeasurement           gyros            = 10;
-    repeated PositionSensorMeasurement position_sensors = 11;
+    uint64                               real_time      = 2;
+    repeated Message                     messages       = 3;
+    repeated AccelerometerMeasurement    accelerometers = 4;
+    repeated BumperMeasurement           bumpers        = 5;
+    repeated CameraMeasurement           cameras        = 6;
+    repeated ForceMeasurement            forces         = 7;
+    repeated Force3DMeasurement          force3ds       = 8;
+    repeated Force6DMeasurement force6ds t "message/platform/webots/messages.  = 9;
+        repeated GyroMeasurement         gyros            = 10;
+    repeated PositionSensorMeasurement   position_sensors = 11;
     // NUbots-specific data. Set to 100 in case other data is added in by the RoboCup TC
-    OdometryGroundTruth odometry_ground_truth = 100;
-    VisionGroundTruth   vision_ground_truth   = 101;
+    OdometryGroundTruth     odometry_ground_truth     = 100;
+    LocalisationGroundTruth localisation_ground_truth = 101;
+    VisionGroundTruth       vision_ground_truth       = 102;
 }
-
 message MotorPosition {
     string name     = 1;
     double position = 2;  // linear or angular target position expressed in [m] or [rad]

--- a/shared/message/platform/webots/messages.proto
+++ b/shared/message/platform/webots/messages.proto
@@ -105,9 +105,12 @@ message OdometryGroundTruth {
     mat4 Htw = 2;
 }
 
+/// NUbots specific data sent from our own controllers rather than the official RoboCup Webots controller
 message LocalisationGroundTruth {
+    /// Indicates if this message exists
     bool exists = 1;
-    mat4 Hfw    = 2;
+    /// Isometry3d transform from localisation (world) space to field space
+    mat4 Hfw = 2;
 }
 
 message VisionGroundTruth {

--- a/shared/message/platform/webots/messages.proto
+++ b/shared/message/platform/webots/messages.proto
@@ -133,13 +133,14 @@ message SensorMeasurements {
     repeated PositionSensorMeasurement position_sensors = 11;
     // NUbots-specific data. Set to 100 in case other data is added in by the RoboCup TC
     // Ground truth data
-    OdometryGroundTruth odometry_ground_truth = 100;
+    OdometryGroundTruth     odometry_ground_truth     = 100;
     LocalisationGroundTruth localisation_ground_truth = 101;
-    VisionGroundTruth   vision_ground_truth   = 101;
+    VisionGroundTruth       vision_ground_truth       = 102;
     // Walk optimisation data
-    support.optimisation.OptimisationRobotPosition robot_position = 102;
-    bool                                           reset_done     = 103;
+    support.optimisation.OptimisationRobotPosition robot_position = 103;
+    bool                                           reset_done     = 104;
 }
+
 message MotorPosition {
     string name     = 1;
     double position = 2;  // linear or angular target position expressed in [m] or [rad]


### PR DESCRIPTION
Adds graphs for debugging localisation error using Webots ground truth data, like #1132 does for odometry.

Relevant changes to NUWebots:
https://github.com/NUbots/NUWebots/pull/111