### PR TITLE
Fix Webots for Multiple Robots

### DIFF
--- a/docker/nugus_sim/run.py
+++ b/docker/nugus_sim/run.py
@@ -116,9 +116,9 @@ def update_config_files(args: dict) -> None:
     os.chdir(args["config_dir"])
 
     # Set `player_id` in GlobalConfig.yaml from ROBOCUP_ROBOT_ID
-    global_config = read_config("GlobalConfig.yaml")
+    global_config = read_config("webots/GlobalConfig.yaml")
     global_config["player_id"] = int(env_vars["ROBOCUP_ROBOT_ID"])
-    write_config("GlobalConfig.yaml", global_config)
+    write_config("webots/GlobalConfig.yaml", global_config)
 
     # Set `player_id` in GameController.yaml from ROBOCUP_ROBOT_ID
     game_controller_config = read_config("GameController.yaml")
@@ -137,9 +137,9 @@ def update_config_files(args: dict) -> None:
 
     # Set `team_id` if it is provided
     if "ROBOCUP_TEAM_ID" in env_vars:
-        global_config = read_config("GlobalConfig.yaml")
+        global_config = read_config("webots/GlobalConfig.yaml")
         global_config["team_id"] = int(env_vars["ROBOCUP_TEAM_ID"])
-        write_config("GlobalConfig.yaml", global_config)
+        write_config("webots/GlobalConfig.yaml", global_config)
 
     # Configure logging to /robocup-logs if it exists
     if os.path.exists("/robocup-logs"):


### PR DESCRIPTION
- corrects the path for webots so that multiple robots can be run. The run.py script was updating the wrong yaml file, so when running multiple robots in webots, they were all using the default settings. 

### Reviewers, Note

To test this, if you want: 
- make sure the GameController.yaml log level is set to "DEBUG"
- Print out the value of player_id in GameController::sendReplyMessage
log<NUClear::DEBUG>("packet->player", int(packet->player));
- run multiple robots (in the guides webots/running multiple robots) 
- check that each robot has a different player id
