### PR TITLE
Stand in idle and don't roll over in getup

### DIFF
--- a/module/planning/PlanKick/data/config/PlanKick.yaml
+++ b/module/planning/PlanKick/data/config/PlanKick.yaml
@@ -1,5 +1,5 @@
 # Controls the minimum log level that NUClear log will display
-log_level: DEBUG
+log_level: INFO
 
 # How long since the last ball measurement before ignoring it and assuming the ball is lost, in milliseconds
 ball_timeout_threshold: 1000

--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -78,10 +78,12 @@ namespace module::purpose {
             // Without these emis, modules that need a Stability and WalkState messages may not run
             emit(std::make_unique<Stability>(Stability::UNKNOWN));
             emit(std::make_unique<WalkState>(WalkState::State::STOPPED));
+            // Idle stand if not doing anything
+            emit<Task>(std::make_unique<StandStill>());
             // This emit starts the tree to play soccer
-            emit<Task>(std::make_unique<FindPurpose>());
+            emit<Task>(std::make_unique<FindPurpose>(), 1);
             // The robot should always try to recover from falling, if applicable, regardless of purpose
-            emit<Task>(std::make_unique<FallRecovery>(), 1);
+            emit<Task>(std::make_unique<FallRecovery>(), 2);
         });
 
         on<Provide<FindPurpose>>().then([this] {
@@ -101,14 +103,12 @@ namespace module::purpose {
                 emit(std::make_unique<Stability>(Stability::UNKNOWN));
                 emit(std::make_unique<ResetFieldLocalisation>());
                 emit<Task>(std::unique_ptr<FindPurpose>(nullptr));
-                // emit<Task>(std::make_unique<StandStill>());
             }
         });
 
         on<Trigger<Unpenalisation>>().then([this](const Unpenalisation& self_unpenalisation) {
             // If the robot is unpenalised, stop standing still and find its purpose
             if (self_unpenalisation.context == GameEvents::Context::SELF) {
-                // emit<Task>(std::unique_ptr<StandStill>(nullptr));
                 emit<Task>(std::make_unique<FindPurpose>());
             }
         });
@@ -120,7 +120,6 @@ namespace module::purpose {
                 log<NUClear::INFO>("Force playing started.");
                 cfg.force_playing = true;
                 emit<Task>(std::make_unique<FindPurpose>());
-                // emit<Task>(std::unique_ptr<StandStill>(nullptr));
             }
         });
     }

--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -109,7 +109,7 @@ namespace module::purpose {
         on<Trigger<Unpenalisation>>().then([this](const Unpenalisation& self_unpenalisation) {
             // If the robot is unpenalised, stop standing still and find its purpose
             if (self_unpenalisation.context == GameEvents::Context::SELF) {
-                emit<Task>(std::make_unique<FindPurpose>());
+                emit<Task>(std::make_unique<FindPurpose>(), 1);
             }
         });
 
@@ -119,7 +119,7 @@ namespace module::purpose {
             if (!cfg.force_playing) {
                 log<NUClear::INFO>("Force playing started.");
                 cfg.force_playing = true;
-                emit<Task>(std::make_unique<FindPurpose>());
+                emit<Task>(std::make_unique<FindPurpose>(), 1);
             }
         });
     }

--- a/module/skill/GetUp/data/config/GetUp.yaml
+++ b/module/skill/GetUp/data/config/GetUp.yaml
@@ -8,15 +8,12 @@ scripts:
     - "StandUpFront.yaml"
     - "Stand.yaml"
   getup_back:
-    - "RollOverBack.yaml"
-    - "StandUpFront.yaml"
+    - "StandUpBack.yaml"
     - "Stand.yaml"
   getup_left:
-    - "RollLeft.yaml"
     - "StandUpFront.yaml"
     - "Stand.yaml"
   getup_right:
-    - "RollRight.yaml"
     - "StandUpFront.yaml"
     - "Stand.yaml"
   # We run relax when we are upside down


### PR DESCRIPTION
- Adds an idle stand in the background of Soccer
- Changes getup for back to StandUpBack rather than roll over and StandUpFront
- Removed roll left and roll right as they dont exist so it would just crash if those cases came up
- Changed PlanKick log level to `INFO`