### PR TITLE
Fix bug in Odometry

### DIFF
--- a/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
@@ -4,8 +4,10 @@ buttons:
   debounce_threshold: 7
 
 foot_down:
-  method: FSR # Foot sensor reading
-  threshold: 1 # Webots uses a bool sensor, this could be anything > 0. Normal robot uses FSR which is non bool
+  # method: FSR # Foot sensor reading
+  # threshold: 1 # Webots uses a bool sensor, this could be anything > 0. Normal robot uses FSR which is non bool
+  method: Z_HEIGHT # Foot sensor reading
+  threshold: 0.01 # Height difference of the Z for the Z height method
 
 # Mahony filter for roll + pitch
 mahony:

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -172,7 +172,7 @@ namespace module::input {
             if (rRLl_z > cfg.foot_down.threshold) {
                 sensors->feet[BodySide::RIGHT].down = false;
             }
-            // The left foot is not down if the z height ff the right foot is below a threshold (in left foot space)
+            // The left foot is not down if the z height if the right foot is below a threshold (in left foot space)
             if (rRLl_z < -cfg.foot_down.threshold) {
                 sensors->feet[BodySide::LEFT].down = false;
             }

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -349,16 +349,16 @@ namespace module::input {
             }
 
             // Compute torso pose using kinematics from anchor frame (current support foot)
-            Eigen::Isometry3d Hat = Eigen::Isometry3d::Identity();
+            Eigen::Isometry3d Hpt = Eigen::Isometry3d::Identity();
             if (current_walk_phase.value == WalkState::Phase::RIGHT) {
-                Hat = sensors->Htx[FrameID::R_FOOT_BASE].inverse();
+                Hpt = sensors->Htx[FrameID::R_FOOT_BASE].inverse();
             }
             else {
-                Hat = sensors->Htx[FrameID::L_FOOT_BASE].inverse();
+                Hpt = sensors->Htx[FrameID::L_FOOT_BASE].inverse();
             }
 
             // Perform Anchor Update (x, y, z, yaw)
-            Eigen::Isometry3d Hwt_anchor = Hwp * Hat;
+            Eigen::Isometry3d Hwt_anchor = Hwp * Hpt;
             Eigen::Vector3d rpy_anchor   = mat_to_rpy_intrinsic(Hwt_anchor.linear());
 
             // Perform Mahony update (roll, pitch)

--- a/module/input/SensorFilter/src/SensorFilter.hpp
+++ b/module/input/SensorFilter/src/SensorFilter.hpp
@@ -151,14 +151,12 @@ namespace module::input {
         void update_odometry(std::unique_ptr<Sensors>& sensors,
                              const std::shared_ptr<const Sensors>& previous_sensors,
                              const RawSensors& raw_sensors,
-                             const std::shared_ptr<const WalkState>& walk_state);
+                             const WalkState& walk_state);
 
         /// @brief Display debug information
         /// @param sensors The sensors message to update
         /// @param raw_sensors The raw sensor data
-        void debug_sensor_filter(std::unique_ptr<Sensors>& sensors,
-                                 const RawSensors& raw_sensors,
-                                 const std::shared_ptr<const WalkState>& walk_state);
+        void debug_sensor_filter(std::unique_ptr<Sensors>& sensors, const RawSensors& raw_sensors);
     };
 }  // namespace module::input
 #endif  // MODULES_INPUT_SENSORFILTER_HPP

--- a/shared/message/behaviour/state/WalkState.proto
+++ b/shared/message/behaviour/state/WalkState.proto
@@ -28,7 +28,6 @@ syntax = "proto3";
 package message.behaviour.state;
 
 import "Vector.proto";
-import "Transform.proto";
 
 message WalkState {
     enum State {


### PR DESCRIPTION
Currently if walk state doesn't exist or the walk phase is double support, the component of odometry using kinematics for torso z height results in 0... This PR fixes this by making the  `WalkState` message not optional. On startup a `WalkState` message is emitted to ensure odometry still runs for roles which don't have walk.

Note, we should really change this logic to use foot down information which I will do in later PR.