### PR TITLE
Change default nuclearnetAddress address to use multicast

### DIFF
--- a/nusight2/src/server/dev.ts
+++ b/nusight2/src/server/dev.ts
@@ -16,7 +16,7 @@ import { WebSocketServer } from "./web_socket/web_socket_server";
 const args = minimist(process.argv.slice(2));
 
 const withVirtualRobots = args["virtual-robots"] || false;
-const nuclearnetAddress = args.address || "10.1.255.255";
+const nuclearnetAddress = args.address || "239.226.152.162";
 
 async function main() {
   const app = express();

--- a/nusight2/src/server/prod.ts
+++ b/nusight2/src/server/prod.ts
@@ -15,7 +15,7 @@ import { WebSocketServer } from "./web_socket/web_socket_server";
 
 const args = minimist(process.argv.slice(2));
 const withVirtualRobots = args["virtual-robots"] || false;
-const nuclearnetAddress = args.address || "10.1.255.255";
+const nuclearnetAddress = args.address || "239.226.152.162";
 
 const app = express();
 const server = http.createServer(app);


### PR DESCRIPTION
This PR solves unreliable connection between NUbots binary and NUsight. Works for both docker and real robot in lab.