### PR TITLE
Fix running with ASan by fixing the directory name

### DIFF
--- a/tools/run.py
+++ b/tools/run.py
@@ -64,7 +64,7 @@ def run(args, use_gdb, **kwargs):
 
     # Make sure default log path exists
     if use_asan:
-        log_path = os.path.join(os.sep, "home", "NUbots", "NUbots", "log")
+        log_path = os.path.join(os.sep, "home", "nubots", "NUbots", "log")
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
 
     # Add necessary ASAN environment variables


### PR DESCRIPTION
ngl kinda confused as to when this broke and why this wasn't a problem before (did we rename the user?)

In the docker container, the user is `nubots`, not `NUbots`, so the log_path to save ASan logs to was wrong. 