### PR TITLE
Shuffle around docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -371,7 +371,7 @@ RUN install-from-source https://github.com/Tom0Brien/tinyrobotics/archive/refs/t
     -DBUILD_TESTS=OFF
 
 # lame
-RUN install-package lame
+RUN install-from-source https://downloads.sourceforge.net/lame/lame-3.100.tar.gz
 
 #######################################
 ### ADD NEW PROGRAMS/LIBRARIES HERE ###

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -216,6 +216,24 @@ RUN install-from-source https://github.com/KhronosGroup/OpenCL-Headers/archive/r
 RUN install-package ruby
 RUN install-from-source https://github.com/OCL-dev/ocl-icd/archive/refs/tags/v2.3.1.tar.gz
 
+# Eigen3
+RUN install-from-source https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+
+# tcmalloc
+RUN install-from-source https://github.com/gperftools/gperftools/releases/download/gperftools-2.10/gperftools-2.10.tar.gz \
+    --build-system autotools \
+    --with-tcmalloc-pagesize=64 \
+    --enable-minimal
+
+# Protobuf
+RUN install-package protobuf && \
+    install-from-source https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-cpp-3.21.4.tar.gz \
+    --patch https://github.com/protocolbuffers/protobuf/commit/735221ff3a1b8e5ca1a7b38a1884043e25864f31.patch \
+    -DWITH_PROTOC="/usr/sbin/protoc" \
+    -Dprotobuf_BUILD_TESTS=OFF \
+    -Dprotobuf_BUILD_LIBPROTOC=ON \
+    -DBUILD_SHARED_LIBS=OFF
+
 # OpenCV
 RUN install-from-source https://github.com/opencv/opencv/archive/refs/tags/4.9.0.tar.gz
 
@@ -248,24 +266,6 @@ RUN git clone https://github.com/openvinotoolkit/openvino.git --branch 2023.0.1 
 
 # Move OpenVino libraries to our library path
 RUN sudo cp /usr/local/runtime/lib/intel64/* /usr/local/lib/ -r && sudo cp /usr/local/runtime/3rdparty/tbb/lib/* /usr/local/lib/ -r
-
-# Eigen3
-RUN install-from-source https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
-
-# tcmalloc
-RUN install-from-source https://github.com/gperftools/gperftools/releases/download/gperftools-2.10/gperftools-2.10.tar.gz \
-    --build-system autotools \
-    --with-tcmalloc-pagesize=64 \
-    --enable-minimal
-
-# Protobuf
-RUN install-package protobuf && \
-    install-from-source https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-cpp-3.21.4.tar.gz \
-    --patch https://github.com/protocolbuffers/protobuf/commit/735221ff3a1b8e5ca1a7b38a1884043e25864f31.patch \
-    -DWITH_PROTOC="/usr/sbin/protoc" \
-    -Dprotobuf_BUILD_TESTS=OFF \
-    -Dprotobuf_BUILD_LIBPROTOC=ON \
-    -DBUILD_SHARED_LIBS=OFF
 
 # Libjpeg
 RUN install-package yasm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -216,6 +216,39 @@ RUN install-from-source https://github.com/KhronosGroup/OpenCL-Headers/archive/r
 RUN install-package ruby
 RUN install-from-source https://github.com/OCL-dev/ocl-icd/archive/refs/tags/v2.3.1.tar.gz
 
+# OpenCV
+RUN install-from-source https://github.com/opencv/opencv/archive/refs/tags/4.9.0.tar.gz
+
+# OpenVino - Dependencies
+RUN install-package opencl-clhpp && \
+    install-package opencl-headers && \
+    install-package ocl-icd
+
+# OpenVino
+RUN git clone https://github.com/openvinotoolkit/openvino.git --branch 2023.0.1 && \
+    cd openvino &&  \
+    git submodule update --init --recursive && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBUILD_TESTING:BOOL='OFF' \
+            -DCMAKE_BUILD_TYPE:STRING='Release' \
+            -DENABLE_AVX512F:BOOL='OFF' \
+            -DENABLE_PYTHON:BOOL='OFF' \
+            -DENABLE_CLANG_FORMAT:BOOL='OFF' \
+            -DENABLE_NCC_STYLE:BOOL='OFF' \
+            -DENABLE_SYSTEM_PUGIXML:BOOL='ON' \
+            -DENABLE_SYSTEM_TBB:BOOL='ON' \
+            -DENABLE_SYSTEM_OPENCL:BOOL='ON' \
+            -DENABLE_SYSTEM_PROTOBUF:BOOL='ON' \
+            -DENABLE_SYSTEM_FLATBUFFERS:BOOL='OFF' \
+            -Wno-dev && \
+    make -j$(nproc) && \
+    make install && \
+    /usr/local/setupvars.sh
+
+# Move OpenVino libraries to our library path
+RUN sudo cp /usr/local/runtime/lib/intel64/* /usr/local/lib/ -r && sudo cp /usr/local/runtime/3rdparty/tbb/lib/* /usr/local/lib/ -r
+
 # Eigen3
 RUN install-from-source https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
 
@@ -336,42 +369,9 @@ RUN install-from-source https://github.com/stevengj/nlopt/archive/refs/tags/v2.7
 # tinyrobotics
 RUN install-from-source https://github.com/Tom0Brien/tinyrobotics/archive/refs/tags/0.0.1.tar.gz \
     -DBUILD_TESTS=OFF
-    
+
 # lame
 RUN install-package lame
-
-# OpenCV
-RUN install-from-source https://github.com/opencv/opencv/archive/refs/tags/4.9.0.tar.gz
-
-# OpenVino - Dependencies
-RUN install-package opencl-clhpp && \
-    install-package opencl-headers && \
-    install-package ocl-icd
-
-# OpenVino
-RUN git clone https://github.com/openvinotoolkit/openvino.git --branch 2023.0.1 && \
-    cd openvino &&  \
-    git submodule update --init --recursive && \
-    mkdir build && \
-    cd build && \
-    cmake .. -DBUILD_TESTING:BOOL='OFF' \
-            -DCMAKE_BUILD_TYPE:STRING='Release' \
-            -DENABLE_AVX512F:BOOL='OFF' \
-            -DENABLE_PYTHON:BOOL='OFF' \
-            -DENABLE_CLANG_FORMAT:BOOL='OFF' \
-            -DENABLE_NCC_STYLE:BOOL='OFF' \
-            -DENABLE_SYSTEM_PUGIXML:BOOL='ON' \
-            -DENABLE_SYSTEM_TBB:BOOL='ON' \
-            -DENABLE_SYSTEM_OPENCL:BOOL='ON' \
-            -DENABLE_SYSTEM_PROTOBUF:BOOL='ON' \
-            -DENABLE_SYSTEM_FLATBUFFERS:BOOL='OFF' \
-            -Wno-dev && \
-    make -j$(nproc) && \
-    make install && \
-    /usr/local/setupvars.sh
-
-# Move OpenVino libraries to our library path
-RUN sudo cp /usr/local/runtime/lib/intel64/* /usr/local/lib/ -r && sudo cp /usr/local/runtime/3rdparty/tbb/lib/* /usr/local/lib/ -r
 
 #######################################
 ### ADD NEW PROGRAMS/LIBRARIES HERE ###


### PR DESCRIPTION
OpenVino and OpenCV take quite a while to build from source so tthis PR moves them to earlier in the Dockerfile to help with caching and build times.

Additionally, the library `lame` is built from source now so installing to the robot correctly moves across the required libraries. 