### PR TITLE
Clear spline kick waypoints on configuration

### DIFF
--- a/module/skill/SplineKick/src/SplineKick.cpp
+++ b/module/skill/SplineKick/src/SplineKick.cpp
@@ -64,6 +64,7 @@ namespace module::skill {
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
 
             // Add kick motion waypoints
+            kick_generator.clear_waypoints();
             for (const auto& foot_waypoint : config["foot_waypoints"].config) {
                 Waypoint<double> waypoint;
                 Eigen::Vector4d frame = foot_waypoint.as<Expression>();

--- a/shared/utility/skill/KickGenerator.hpp
+++ b/shared/utility/skill/KickGenerator.hpp
@@ -173,6 +173,14 @@ namespace utility::skill {
             torso_waypoints.push_back(waypoint);
         }
 
+        /**
+         * @brief Clear all waypoints from the foot and torso trajectories.
+         */
+        void clear_waypoints() {
+            foot_waypoints.clear();
+            torso_waypoints.clear();
+        }
+
     private:
         // ******************************** State ********************************
 


### PR DESCRIPTION
This PR updates spline kick configuration to clear waypoints on configuration. This fixes the bug where if configuration ever runs multiple times timing between waypoints in broken. 

Improvement: We should also look at sorting waypoints in the trajectory class by time to allow waypoints to be added out of order.