### PR TITLE
Fix multiple default config running on install

### DIFF
--- a/shared/extension/Configuration.hpp
+++ b/shared/extension/Configuration.hpp
@@ -109,7 +109,7 @@ namespace extension {
             }
 
             // If the same file exists in this robots per-robot config directory then load and merge.
-            if (fs::exists(fs::path("config") / hostname / file_name)) {
+            if ((platform != hostname) && fs::exists(fs::path("config") / hostname / file_name)) {
                 if (loaded) {
                     config = merge_yaml_nodes(config, YAML::LoadFile(fs::path("config") / hostname / file_name));
                 }
@@ -365,7 +365,7 @@ namespace NUClear::dsl {
 
                 // Bind our robot specific config file if it exists
                 const fs::path platform_config = fs::path("config") / platform / file_name;
-                if (fs::exists(platform_config) && !platform.empty()) {
+                if ((platform != hostname) && fs::exists(platform_config) && !platform.empty()) {
                     DSLProxy<::extension::FileWatch>::bind<DSL>(reaction, platform_config, flags);
                 }
 

--- a/shared/extension/Configuration.hpp
+++ b/shared/extension/Configuration.hpp
@@ -353,7 +353,7 @@ namespace NUClear::dsl {
 
                 // Bind our robot name specific config file if it exists
                 const fs::path name_config = fs::path("config") / robot_name / file_name;
-                if (!name_config.empty() && fs::exists(name_config)) {
+                if (!robot_name.empty() && fs::exists(name_config)) {
                     DSLProxy<::extension::FileWatch>::bind<DSL>(reaction, name_config, flags);
                 }
 


### PR DESCRIPTION
Wrong variable used in empty check. If no robot config, don't bind.

Also fixes multiple binding when the platform and hostname are equal, eg 'webots'