### PR TITLE
Add STARTING state to walk generator

### DIFF
--- a/module/skill/Walk/data/config/kevin/Walk.yaml
+++ b/module/skill/Walk/data/config/kevin/Walk.yaml
@@ -9,9 +9,9 @@ walk:
     # Maximum step limits in x and y (in meters), and theta (in radians).
     limits: [0.5, 0.2, 0.4]
     # Step height (in meters)
-    height: 0.075
+    height: 0.085
     # Lateral distance in meters between feet (how spread apart the feet should be)
-    width: 0.235
+    width: 0.225
     # Ratio of the step_period where the foot should be at its highest point, between [0 1].
     apex_ratio: 0.4
   torso:
@@ -22,7 +22,7 @@ walk:
     # Torso constant position offset
     position_offset: [0.01, 0, 0]
     # Torso offset from the planted foot [x,y,z] (in meters), at time = torso_sway_ratio*step_period
-    sway_offset: [0, 0.05, 0]
+    sway_offset: [0, 0.08, 0]
     # Ratio of the step_period where the torso should be at its maximum sway, between [0 1]
     sway_ratio: 0.5
     # Determines where to position the torso at the end of the step using a ratio of the next step placement.

--- a/module/skill/Walk/data/config/webots/Walk.yaml
+++ b/module/skill/Walk/data/config/webots/Walk.yaml
@@ -2,7 +2,7 @@ log_level: INFO
 
 walk:
   # Time for one complete step (in seconds).
-  period: 0.5
+  period: 0.39
   # Bool to indicate whether or not to only switch if the next foot is planted
   only_switch_when_planted: true
   step:
@@ -22,7 +22,7 @@ walk:
     # Torso constant position offset
     position_offset: [0.0, 0, 0]
     # Torso offset from the planted foot [x,y,z] (in meters), at time = torso_sway_ratio*step_period
-    sway_offset: [0, 0.0, 0]
+    sway_offset: [0, 0.08, 0]
     # Ratio of the step_period where the torso should be at its maximum sway, between [0 1]
     sway_ratio: 0.5
     # Determines where to position the torso at the end of the step using a ratio of the next step placement.

--- a/module/skill/Walk/src/Walk.cpp
+++ b/module/skill/Walk/src/Walk.cpp
@@ -145,6 +145,7 @@ namespace module::skill {
                 if (stability >= Stability::DYNAMIC) {
                     switch (walk_generator.update(time_delta, walk_task.velocity_target, sensors.planted_foot_phase)
                                 .value) {
+                        case WalkState::State::STARTING:
                         case WalkState::State::WALKING:
                         case WalkState::State::STOPPING: emit(std::make_unique<Stability>(Stability::DYNAMIC)); break;
                         case WalkState::State::STOPPED: emit(std::make_unique<Stability>(Stability::STANDING)); break;

--- a/shared/message/behaviour/state/WalkState.proto
+++ b/shared/message/behaviour/state/WalkState.proto
@@ -32,9 +32,10 @@ import "Vector.proto";
 message WalkState {
     enum State {
         UNKNOWN  = 0;
-        WALKING  = 1;
-        STOPPING = 2;
-        STOPPED  = 3;
+        STARTING = 1;
+        WALKING  = 2;
+        STOPPING = 3;
+        STOPPED  = 4;
     }
 
     enum Phase {

--- a/shared/utility/skill/WalkGenerator.hpp
+++ b/shared/utility/skill/WalkGenerator.hpp
@@ -182,7 +182,7 @@ namespace utility::skill {
             Hps_start.linear().setIdentity();
 
             // Initialize torso pose
-            Hpt_start.translation() = p.torso_sway_offset + p.torso_position_offset;
+            Hpt_start.translation() = p.torso_position_offset + Vec3(0.0, get_foot_width_offset() / 2, p.torso_height);
             Hpt_start.linear()      = Eigen::AngleAxis<Scalar>(p.torso_pitch, Vec3::UnitY()).toRotationMatrix();
 
             // Start time at end of step period to avoid taking a step when starting.
@@ -213,34 +213,44 @@ namespace utility::skill {
                 // Requested velocity target is zero and we have finished taking a step, remain stopped
                 engine_state = WalkState::State::STOPPED;
             }
-            else {
-                // Requested velocity target is non-zero, walk
-                engine_state = WalkState::State::WALKING;
+            else if (!velocity_target.isZero() && engine_state.value == WalkState::State::STOPPED) {
+                // Requested velocity target is non-zero and we are stopped, start walking
+                engine_state = WalkState::State::STARTING;
+                t            = 0;
             }
 
             // If the sensors have detected either double support or next foot planted, allow switching the planted foot
             bool can_switch = sensors_planted_foot_phase != phase || !p.only_switch_when_planted;
-
             switch (engine_state.value) {
+                case WalkState::State::STARTING:
+                    update_time(dt);
+                    // Generate starting trajectories for the torso and swing foot
+                    generate_starting_trajectories();
+                    if (t >= p.step_period) {
+                        engine_state = WalkState::State::WALKING;
+                        t            = 0;
+                    }
+                    break;
                 case WalkState::State::WALKING:
                     update_time(dt);
                     // If we are at the end of the step and can switch feet, switch the planted foot and reset time
                     if (t >= p.step_period && can_switch) {
                         switch_planted_foot();
                     }
+                    generate_walking_trajectories(velocity_target);
                     break;
                 case WalkState::State::STOPPING:
                     update_time(dt);
-                    // We do not switch the planted foot here because we want to transition to the standing state
+                    generate_walking_trajectories(velocity_target);
+                    // We do not switch the planted foot here because we want to transition to the stopped state
                     break;
                 case WalkState::State::STOPPED:
-                    // We do not update the time here because we want to remain in the standing state
+                    // We do not update the time here because we want to remain in the stopped state
+                    generate_walking_trajectories(velocity_target);
                     break;
-                default: NUClear::log<NUClear::WARN>("Unknown state"); break;
+                default: NUClear::log<NUClear::WARN>("Unknown state", engine_state.value);
             }
 
-            // Generate the torso and swing foot trajectories to reach the next foot step location
-            generate_walking_trajectories(velocity_target);
 
             return engine_state;
         }
@@ -321,7 +331,7 @@ namespace utility::skill {
             // ******************************** Torso Trajectory ********************************
             torso_trajectory.clear();
 
-            // Start waypoint: Start from the current torso position at time = 0
+            // Start waypoint: Current torso position
             wp.time_point       = 0.0;
             wp.position         = Hpt_start.translation();
             wp.velocity         = Vec3::Zero();
@@ -329,7 +339,7 @@ namespace utility::skill {
             wp.angular_velocity = Vec3::Zero();
             torso_trajectory.add_waypoint(wp);
 
-            // Middle waypoint: Shift torso to the p.torso_sway_offset at time = p.torso_sway_ratio * p.step_period
+            // Middle waypoint: Shift torso over planted foot
             wp.time_point         = p.torso_sway_ratio * p.step_period;
             Scalar torso_offset_y = phase == LEFT ? -p.torso_sway_offset.y() : p.torso_sway_offset.y();
             wp.position = Vec3(p.torso_sway_offset.x(), torso_offset_y, p.torso_height + p.torso_sway_offset.z())
@@ -339,7 +349,7 @@ namespace utility::skill {
             wp.angular_velocity = Vec3(0.0, 0.0, velocity_target.z());
             torso_trajectory.add_waypoint(wp);
 
-            // End waypoint: Shift torso back to the final torso position at time = p.step_period
+            // End waypoint: Final torso position, ratio of the next step position
             wp.time_point = p.step_period;
             wp.position   = Vec3(p.torso_final_position_ratio.x() * step.x(),
                                get_foot_width_offset() / 2 + p.torso_final_position_ratio.y() * step.y(),
@@ -363,7 +373,7 @@ namespace utility::skill {
             // ******************************** Swing Foot Trajectory ********************************
             swing_foot_trajectory.clear();
 
-            // Start waypoint: Start from the current swing foot position at time = 0
+            // Start waypoint: Current swing foot position
             wp.time_point       = 0.0;
             wp.position         = Hps_start.translation();
             wp.velocity         = Vec3::Zero();
@@ -371,7 +381,7 @@ namespace utility::skill {
             wp.angular_velocity = Vec3::Zero();
             swing_foot_trajectory.add_waypoint(wp);
 
-            // Middle waypoint: Raise foot to step height at time = p.step_apex_ratio * p.step_period
+            // Middle waypoint: Raise foot to step height
             wp.time_point       = p.step_apex_ratio * p.step_period;
             wp.position         = Vec3(0, get_foot_width_offset(), p.step_height);
             wp.velocity         = Vec3(velocity_target.x(), velocity_target.y(), 0);
@@ -379,7 +389,7 @@ namespace utility::skill {
             wp.angular_velocity = Vec3(0.0, 0.0, velocity_target.z());
             swing_foot_trajectory.add_waypoint(wp);
 
-            // End waypoint: End at next foot placement on ground at time = p.step_period
+            // End waypoint: Next foot placement on ground
             wp.time_point       = p.step_period;
             wp.position         = Vec3(step.x(), get_foot_width_offset() + step.y(), 0);
             wp.velocity         = Vec3::Zero();
@@ -404,6 +414,54 @@ namespace utility::skill {
 
             // Generate swing foot trajectory
             generate_swing_foot_trajectory(step, velocity_target);
+        }
+
+        /**
+         * @brief Generate starting trajectories for the torso and swing foot.
+         */
+        void generate_starting_trajectories() {
+            // Create a waypoint variable to use for all waypoints
+            Waypoint<Scalar> wp;
+
+            // ******************************** Swing Foot Trajectory ********************************
+            swing_foot_trajectory.clear();
+
+            // Start waypoint: Start from the current swing foot position
+            wp.time_point       = 0.0;
+            wp.position         = Hps_start.translation();
+            wp.velocity         = Vec3::Zero();
+            wp.orientation      = mat_to_rpy_intrinsic(Hps_start.rotation());
+            wp.angular_velocity = Vec3::Zero();
+            swing_foot_trajectory.add_waypoint(wp);
+
+            // Start waypoint: End at the current swing foot position
+            wp.time_point       = p.step_period;
+            wp.position         = Hps_start.translation();
+            wp.velocity         = Vec3::Zero();
+            wp.orientation      = mat_to_rpy_intrinsic(Hps_start.rotation());
+            wp.angular_velocity = Vec3::Zero();
+            swing_foot_trajectory.add_waypoint(wp);
+
+            // ******************************** Torso Trajectory ********************************
+            torso_trajectory.clear();
+
+            // Start waypoint: Start from the current torso position
+            wp.time_point       = 0.0;
+            wp.position         = Hpt_start.translation();
+            wp.velocity         = Vec3::Zero();
+            wp.orientation      = mat_to_rpy_intrinsic(Hpt_start.rotation());
+            wp.angular_velocity = Vec3::Zero();
+            torso_trajectory.add_waypoint(wp);
+
+            // Middle waypoint: Shift torso over planted foot
+            wp.time_point         = p.step_period;
+            Scalar torso_offset_y = phase == LEFT ? -p.torso_sway_offset.y() : p.torso_sway_offset.y();
+            wp.position = Vec3(p.torso_sway_offset.x(), torso_offset_y, p.torso_height + p.torso_sway_offset.z())
+                          + p.torso_position_offset;
+            wp.velocity         = Vec3(0, 0, 0);
+            wp.orientation      = Vec3(0.0, p.torso_pitch, 0);
+            wp.angular_velocity = Vec3(0.0, 0.0, 0);
+            torso_trajectory.add_waypoint(wp);
         }
 
         /**
@@ -441,7 +499,7 @@ namespace utility::skill {
                 return;
             }
 
-            // Update the phase
+            // Update the time
             t += dt;
 
             // Clamp time to step period


### PR DESCRIPTION
This PR adds a STARTING state to the walk generator. The state is entered when first starting to try walk and shifts the torso above the planted foot before taking a step. This improves the reliability of starting a walking motion.

Also, tunes kevins walk.