### PR TITLE
Fix python warnings

### DIFF
--- a/nuclear/b.py
+++ b/nuclear/b.py
@@ -26,7 +26,7 @@
 # SOFTWARE.
 #
 import argparse
-import importlib
+import importlib.util
 import os
 import re
 import subprocess

--- a/nuclear/b.py
+++ b/nuclear/b.py
@@ -26,8 +26,8 @@
 # SOFTWARE.
 #
 import argparse
+import importlib
 import os
-import pkgutil
 import re
 import subprocess
 import sys
@@ -53,7 +53,6 @@ if os.path.isfile("CMakeCache.txt"):
     with open("CMakeCache.txt", "r") as f:
         cmake_cache_text = f.readlines()
 
-
 # Look for a build directory
 else:
     dirs = ["build", os.path.join(os.pardir, "build")]
@@ -76,7 +75,6 @@ else:
 
 # Go and process our lines in our cmake file
 for l in cmake_cache_text:
-
     # Remove whitespace at the ends and start
     l = l.strip()
 
@@ -141,10 +139,11 @@ if __name__ == "__main__":
 
     for components in useable:
         if sys.argv[1 : len(components) + 1] == components:
-            loader = pkgutil.find_loader(".".join(components))
-            if loader:
+            spec = importlib.util.find_spec(".".join(components))
+            if spec:
                 try:
-                    module = loader.load_module()
+                    module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(module)
                     if hasattr(module, "register") and hasattr(module, "run"):
 
                         # Build up the base subcommands to this point
@@ -182,11 +181,11 @@ if __name__ == "__main__":
     tools = {}
     for components in candidates:
         try:
-            loader = pkgutil.find_loader(".".join(components))
-            if loader:
-                module = loader.load_module()
+            spec = importlib.util.find_spec(".".join(components))
+            if spec:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
                 if hasattr(module, "register") and hasattr(module, "run"):
-
                     subcommand = subcommands
                     tool = tools
                     for c in components[:-1]:

--- a/nuclear/dependencies.py
+++ b/nuclear/dependencies.py
@@ -29,7 +29,7 @@ import re
 import subprocess
 import sys
 
-whitespace = re.compile("\s+")
+whitespace = re.compile(r"\s+")
 
 
 def parse_requirements_map(user_tools_path):

--- a/tools/utility/dockerise/run.py
+++ b/tools/utility/dockerise/run.py
@@ -51,7 +51,7 @@ def _is_wsl1():
         return False
 
     kernel_release = subprocess.check_output(["uname", "-r"]).decode("utf-8").strip()
-    search = re.search("^(\d+)\.(\d+)\.\d+", kernel_release)
+    search = re.search(r"^(\d+)\.(\d+)\.\d+", kernel_release)
     major = search.group(1)
     minor = search.group(2)
 


### PR DESCRIPTION
Minor updates to fix warnings raised by python 3.12.
https://docs.python.org/3/whatsnew/3.12.html

1. Replace pkgutil.find_loader() with importlib.util.find_spec()
> pkgutil: pkgutil.find_loader() and pkgutil.get_loader() are deprecated and will be removed in Python 3.14; use importlib.util.find_spec() instead. (Contributed by Nikita Sobolev in gh-97850.)

2. Replace strings with raw string literals when needed 
> A backslash-character pair that is not a valid escape sequence now generates a SyntaxWarning, instead of DeprecationWarning. For example, re.compile("\d+\.\d+") now emits a SyntaxWarning ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, SyntaxError will eventually be raised, instead of SyntaxWarning. (Contributed by Victor Stinner in gh-98401.)
