### PR TITLE
Add error and fault handling for NUSense.

### DIFF
--- a/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
@@ -119,6 +119,7 @@ namespace module::platform::NUSense {
             // Battery data
             sensors->battery = 0;  // not yet implemented
 
+            // Log the latest dispatch from NUSense; only very rare exceptions should be dispatched.
             log<NUClear::WARN>("Dispatch from NUSense: " + std::string(data.dispatch.data(), 5) + " £££££££\n");
 
             // Servo data
@@ -148,6 +149,7 @@ namespace module::platform::NUSense {
                 servo.profile_acceleration  = 0;  // not present in NUSense message
                 servo.profile_velocity      = 0;  // not present in NUSense message
 
+                // Log any errors and timeouts from the servo.
                 if (val.num_errors != 0) {
                     log<NUClear::WARN>(fmt::format("{} packet-error(s) from ID {} ({})",
                                                    val.num_errors,
@@ -155,6 +157,8 @@ namespace module::platform::NUSense {
                                                    nugus.device_name(static_cast<NUgus::ID>(val.id))));
                 }
                 if (val.num_crc_errors != 0) {
+                    // For now, the CRC is set to debug until terminating-resistors are gotten since there are many when
+                    // the robot is walking.
                     log<NUClear::DEBUG>(fmt::format("{} CRC-error(s) from ID {} ({})",
                                                     val.num_crc_errors,
                                                     val.id,

--- a/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
@@ -120,7 +120,7 @@ namespace module::platform::NUSense {
             sensors->battery = 0;  // not yet implemented
 
             // Log the latest dispatch from NUSense; only very rare exceptions should be dispatched.
-            log<NUClear::WARN>("Dispatch from NUSense: " + std::string(data.dispatch.data(), 5) + " £££££££\n");
+            log<NUClear::WARN>("Dispatch from NUSense: " + data.dispatch);
 
             // Servo data
             for (const auto& [key, val] : data.servo_map) {

--- a/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
@@ -120,7 +120,9 @@ namespace module::platform::NUSense {
             sensors->battery = 0;  // not yet implemented
 
             // Log the latest dispatch from NUSense; only very rare exceptions should be dispatched.
-            log<NUClear::WARN>("Dispatch from NUSense: " + data.dispatch);
+            if (data.dispatch.size() > 3) {
+                log<NUClear::WARN>("Dispatch from NUSense: " + data.dispatch);
+            }
 
             // Servo data
             for (const auto& [key, val] : data.servo_map) {

--- a/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
@@ -119,6 +119,8 @@ namespace module::platform::NUSense {
             // Battery data
             sensors->battery = 0;  // not yet implemented
 
+            log<NUClear::WARN>("Dispatch from NUSense: " + std::string(data.dispatch.data(), 5) + " £££££££\n");
+
             // Servo data
             for (const auto& [key, val] : data.servo_map) {
                 // Get a reference to the servo we are populating
@@ -145,6 +147,25 @@ namespace module::platform::NUSense {
                 servo.temperature           = val.temperature;
                 servo.profile_acceleration  = 0;  // not present in NUSense message
                 servo.profile_velocity      = 0;  // not present in NUSense message
+
+                if (val.num_errors != 0) {
+                    log<NUClear::WARN>(fmt::format("{} packet-error(s) from ID {} ({})",
+                                                   val.num_errors,
+                                                   val.id,
+                                                   nugus.device_name(static_cast<NUgus::ID>(val.id))));
+                }
+                if (val.num_crc_errors != 0) {
+                    log<NUClear::DEBUG>(fmt::format("{} CRC-error(s) from ID {} ({})",
+                                                    val.num_crc_errors,
+                                                    val.id,
+                                                    nugus.device_name(static_cast<NUgus::ID>(val.id))));
+                }
+                if (val.num_timeouts != 0) {
+                    log<NUClear::WARN>(fmt::format("{} dropped packet(s) from ID {} ({})",
+                                                   val.num_timeouts,
+                                                   val.id,
+                                                   nugus.device_name(static_cast<NUgus::ID>(val.id))));
+                }
 
                 // Add the offsets and switch the direction.
                 servo.present_position *= nugus.servo_direction[val.id - 1];

--- a/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
@@ -119,11 +119,6 @@ namespace module::platform::NUSense {
             // Battery data
             sensors->battery = 0;  // not yet implemented
 
-            // Log the latest dispatch from NUSense; only very rare exceptions should be dispatched.
-            if (data.dispatch.size() > 3) {
-                log<NUClear::WARN>("Dispatch from NUSense: " + data.dispatch);
-            }
-
             // Servo data
             for (const auto& [key, val] : data.servo_map) {
                 // Get a reference to the servo we are populating
@@ -152,23 +147,23 @@ namespace module::platform::NUSense {
                 servo.profile_velocity      = 0;  // not present in NUSense message
 
                 // Log any errors and timeouts from the servo.
-                if (val.num_errors != 0) {
+                if (val.packet_counts.errors != 0) {
                     log<NUClear::WARN>(fmt::format("{} packet-error(s) from ID {} ({})",
-                                                   val.num_errors,
+                                                   val.packet_counts.errors,
                                                    val.id,
                                                    nugus.device_name(static_cast<NUgus::ID>(val.id))));
                 }
-                if (val.num_crc_errors != 0) {
+                if (val.packet_counts.crc_errors != 0) {
                     // For now, the CRC is set to debug until terminating-resistors are gotten since there are many when
                     // the robot is walking.
                     log<NUClear::DEBUG>(fmt::format("{} CRC-error(s) from ID {} ({})",
-                                                    val.num_crc_errors,
+                                                    val.packet_counts.crc_errors,
                                                     val.id,
                                                     nugus.device_name(static_cast<NUgus::ID>(val.id))));
                 }
-                if (val.num_timeouts != 0) {
+                if (val.packet_counts.timeouts != 0) {
                     log<NUClear::WARN>(fmt::format("{} dropped packet(s) from ID {} ({})",
-                                                   val.num_timeouts,
+                                                   val.packet_counts.timeouts,
                                                    val.id,
                                                    nugus.device_name(static_cast<NUgus::ID>(val.id))));
                 }

--- a/shared/message/platform/NUSenseData.proto
+++ b/shared/message/platform/NUSenseData.proto
@@ -76,7 +76,6 @@ message Servo {
     float temperature = 13;
     /// The windowed counts of the dynamixel packets since the last NUSense message
     PacketCounts packet_counts = 14;
-
 }
 
 message IMU {

--- a/shared/message/platform/NUSenseData.proto
+++ b/shared/message/platform/NUSenseData.proto
@@ -43,7 +43,7 @@ message Servo {
         /// The number of CRC-errors.
         uint32 crc_errors = 3;
         /// The number of packet-errors.
-        uint32 errors = 4;
+        uint32 packet_errors = 4;
     }
 
     /// The ID of the servo

--- a/shared/message/platform/NUSenseData.proto
+++ b/shared/message/platform/NUSenseData.proto
@@ -34,6 +34,18 @@ package message.platform;
 // Message mainly for NUSense <-> NUC communication. NUSense will encode this message via nanopb after it queries all
 // servo states and send it to the NUC.
 message Servo {
+
+    message PacketCounts {
+        /// The number of successes.
+        uint32 total = 1;
+        /// The number of timeouts.
+        uint32 timeouts = 2;
+        /// The number of CRC-errors.
+        uint32 crc_errors = 3;
+        /// The number of packet-errors.
+        uint32 errors = 4;
+    }
+
     /// The ID of the servo
     uint32 id = 1;
     /// Current error state of the servo
@@ -62,14 +74,9 @@ message Servo {
     float voltage = 12;
     /// The last read temperature of the servo
     float temperature = 13;
-    /// The number of successes.
-    uint32 num_successes = 14;
-    /// The number of timeouts.
-    uint32 num_timeouts = 15;
-    /// The number of CRC-errors.
-    uint32 num_crc_errors = 16;
-    /// The number of packet-errors.
-    uint32 num_errors = 17;
+    /// The windowed counts of the dynamixel packets since the last NUSense message
+    PacketCounts packet_counts = 14;
+
 }
 
 message IMU {
@@ -110,6 +117,4 @@ message NUSense {
      */
     map<uint32, Servo> servo_map = 1;
     IMU                imu       = 2;
-    // A generic string-based message for uncommon errors, exceptions, etc.
-    string             dispatch  = 3;
 }

--- a/shared/message/platform/NUSenseData.proto
+++ b/shared/message/platform/NUSenseData.proto
@@ -62,6 +62,14 @@ message Servo {
     float voltage = 12;
     /// The last read temperature of the servo
     float temperature = 13;
+    /// The number of successes.
+    uint32 num_successes = 14;
+    /// The number of timeouts.
+    uint32 num_timeouts = 15;
+    /// The number of CRC-errors.
+    uint32 num_crc_errors = 16;
+    /// The number of packet-errors.
+    uint32 num_errors = 17;
 }
 
 message IMU {
@@ -102,4 +110,5 @@ message NUSense {
      */
     map<uint32, Servo> servo_map = 1;
     IMU                imu       = 2;
+    string             dispatch  = 3;
 }

--- a/shared/message/platform/NUSenseData.proto
+++ b/shared/message/platform/NUSenseData.proto
@@ -36,7 +36,7 @@ package message.platform;
 message Servo {
 
     message PacketCounts {
-        /// The number of successes.
+        /// The total number of packets received.
         uint32 total = 1;
         /// The number of timeouts.
         uint32 timeouts = 2;

--- a/shared/message/platform/NUSenseData.proto
+++ b/shared/message/platform/NUSenseData.proto
@@ -110,5 +110,6 @@ message NUSense {
      */
     map<uint32, Servo> servo_map = 1;
     IMU                imu       = 2;
+    // A generic string-based message for uncommon errors, exceptions, etc.
     string             dispatch  = 3;
 }


### PR DESCRIPTION
Adds some more tailored handling and raising of errors for NUSense.

- Logs the count of packet-errors, CRC-errors, and timeouts.
- Logs a dispatch as a message from NUSense for fleeting errors; this is a generic error-field.

### Pre-PR Checklist:

Have you

- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [x] Added a descriptive title and relevant labels to the PR

### Reviewers, Note

Work in progress.

### Things left to do

- [x] Fix the null-terminator in the string.
