### PR TITLE
Add Yolo module into the Webots RoboCup role

### DIFF
--- a/roles/webots/robocup.role
+++ b/roles/webots/robocup.role
@@ -24,6 +24,7 @@ nuclear_role(
   platform::Webots
   # Vision
   vision::VisualMesh
+  vision::Yolo
   vision::GreenHorizonDetector
   vision::BallDetector
   vision::FieldLineDetector


### PR DESCRIPTION
Field localisation needs field intersection points, which comes from yolo. Without yolo localisation won't run and some behaviour modules wont run either.