### PR TITLE
Set default NLopt field localisation config to start on EITHER side of the field

### DIFF
--- a/module/localisation/FieldLocalisationNLopt/data/config/FieldLocalisationNLopt.yaml
+++ b/module/localisation/FieldLocalisationNLopt/data/config/FieldLocalisationNLopt.yaml
@@ -5,7 +5,7 @@ log_level: DEBUG
 grid_size: 1e-2
 
 # Starting side of the field looking towards own goal from centre of field (LEFT, RIGHT, EITHER or CUSTOM)
-starting_side: LEFT
+starting_side: EITHER
 
 # Our initial guess of where the robot starts on the field (Used if starting_side is selected as CUSTOM)
 initial_state: [0.0, 0.0, 0.0]


### PR DESCRIPTION
When I was running in the lab,it wasn't localising until I set this to either. It worked with either and makes sense to have it as either.