### PR TITLE
Path planning rework with Director `When`

### DIFF
--- a/module/planning/PlanWalkPath/data/config/PlanWalkPath.yaml
+++ b/module/planning/PlanWalkPath/data/config/PlanWalkPath.yaml
@@ -1,6 +1,16 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
+# Threshold values
+enter_rotate_to_target: 0.3
+exit_rotate_to_target: 0.05
+
+enter_walk_to_target: 0.1
+exit_walk_to_target: 0.05
+
+enter_rotate_to_heading: 0.2
+exit_rotate_to_heading: 0.05
+
 # General playing tuning values for approaching ball
 max_translational_velocity_magnitude: 0.15
 min_translational_velocity_magnitude: 0.05

--- a/module/planning/PlanWalkPath/data/config/webots/PlanWalkPath.yaml
+++ b/module/planning/PlanWalkPath/data/config/webots/PlanWalkPath.yaml
@@ -1,6 +1,16 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
+# Threshold values
+enter_rotate_to_target: 0.5
+exit_rotate_to_target: 0.1
+
+enter_walk_to_target: 0.5
+exit_walk_to_target: 0.1
+
+enter_rotate_to_heading: 0.5
+exit_rotate_to_heading: 0.1
+
 # General playing tuning values for approaching ball
 max_translational_velocity_magnitude: 0.4
 min_translational_velocity_magnitude: 0.1

--- a/module/planning/PlanWalkPath/data/config/webots/PlanWalkPath.yaml
+++ b/module/planning/PlanWalkPath/data/config/webots/PlanWalkPath.yaml
@@ -1,15 +1,15 @@
 # Controls the minimum log level that NUClear log will display
-log_level: INFO
+log_level: DEBUG
 
 # Threshold values
-enter_rotate_to_target: 0.5
-exit_rotate_to_target: 0.1
+enter_rotate_to_target: 0.3
+exit_rotate_to_target: 0.05
 
-enter_walk_to_target: 0.5
-exit_walk_to_target: 0.1
+enter_walk_to_target: 0.1
+exit_walk_to_target: 0.05
 
-enter_rotate_to_heading: 0.5
-exit_rotate_to_heading: 0.1
+enter_rotate_to_heading: 0.2
+exit_rotate_to_heading: 0.05
 
 # General playing tuning values for approaching ball
 max_translational_velocity_magnitude: 0.4

--- a/module/planning/PlanWalkPath/src/PlanWalkPath.hpp
+++ b/module/planning/PlanWalkPath/src/PlanWalkPath.hpp
@@ -37,6 +37,12 @@ namespace module::planning {
     private:
         /// @brief Stores configuration values
         struct Config {
+            double enter_rotate_to_target  = 0.0;
+            double exit_rotate_to_target   = 0.0;
+            double enter_walk_to_target    = 0.0;
+            double exit_walk_to_target     = 0.0;
+            double enter_rotate_to_heading = 0.0;
+            double exit_rotate_to_heading  = 0.0;
             /// @brief Maximum walk command velocity magnitude for walking to ball
             double max_translational_velocity_magnitude = 0;
             /// @brief Minimum walk command velocity for walking to ball
@@ -62,6 +68,25 @@ namespace module::planning {
             /// @brief Pivot ball side velocity
             double pivot_ball_velocity_y = 0;
         } cfg;
+
+        struct State {
+            enum Value {
+                /// @brief The beginning of the planner, where we determine what state the robot is in
+                STOP,
+                /// @brief The robot is rotating to face the position it needs to walk to
+                /// This is to prevent attempts to strafe and walk backwards to reach the position target
+                ROTATE_TO_TARGET,
+                /// @brief The robot is walking to the target from a distance
+                /// The robot should slow down as it approaches the target
+                WALK_TO_TARGET,
+                /// @brief The robot is rotating on the spot to face the requested heading
+                ROTATE_TO_HEADING,
+            } value;
+            State(const Value& v) : value(v) {}
+            operator int() const {
+                return value;
+            }
+        };
 
         /// @brief Current magnitude of the translational velocity of the walk command
         double velocity_magnitude = 0;

--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -81,7 +81,7 @@ namespace module::purpose {
             emit(std::make_unique<Stability>(Stability::UNKNOWN));
             emit(std::make_unique<WalkState>(WalkState::State::STOPPED));
             // Idle stand if not doing anything
-            emit<Task>(std::make_unique<StandStill>());
+            // emit<Task>(std::make_unique<StandStill>());
             // Idle look forward if the head isn't doing anything else
             emit<Task>(std::make_unique<Look>(Eigen::Vector3d::UnitX(), true));
             // This emit starts the tree to play soccer

--- a/module/strategy/WalkToBall/src/WalkToBall.cpp
+++ b/module/strategy/WalkToBall/src/WalkToBall.cpp
@@ -80,8 +80,8 @@ namespace module::strategy {
                     const Eigen::Vector3d rGFf(field_desc.dimensions.field_length / 2.0, 0.0, 0.0);
 
                     // Get heading toward goals
-                    Eigen::Vector3d rGRr = (sensors.Hrw * field.Hfw.inverse()) * rGFf;
-                    double heading       = std::atan2(rGRr.y(), rGRr.x());
+                    const Eigen::Vector3d rGRr = (sensors.Hrw * field.Hfw.inverse()) * rGFf;
+                    const double heading       = std::atan2(rGRr.y(), rGRr.x());
 
                     emit<Task>(std::make_unique<WalkTo>(rBRr, heading));
                 }

--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
@@ -68,44 +68,12 @@ namespace module::strategy {
                                            std::sin(walk_to_field_position.heading),
                                            0.0);
 
-                // Transform the field position from field {f} space to robot {r} space
+                // Transform the field position and heading from field {f} space to robot {r} space
                 const Eigen::Vector3d rPRr(Hfr.inverse() * rPFf);
+                const Eigen::Vector3d uHRr(Hfr.inverse() * uHFf);
+                const double heading = std::atan2(uHRr.y(), uHRr.x());
 
-                // Compute the current position error and heading error in field {f} space
-                const double position_error = (Hfr.translation().head(2) - rPFf.head(2)).norm();
-                Eigen::Vector2d uXRf        = Hfr.rotation().col(0).head<2>();
-                const double heading_error  = std::acos(std::max(-1.0, std::min(1.0, uXRf.dot(uHFf.head<2>()))));
-
-                // If we have stopped and our position and heading error is below resume tolerance, then remain stopped
-                if (stopped && position_error < cfg.resume_tolerance && heading_error < cfg.resume_tolerance) {
-                    emit<Task>(std::make_unique<StandStill>());
-                    stopped = true;
-                    return;
-                }
-
-                // If the error in the desired field position and heading is low enough, stand still
-                if (!stopped && position_error < cfg.stop_tolerance && heading_error < cfg.stop_tolerance) {
-                    emit<Task>(std::make_unique<StandStill>());
-                    stopped = true;
-                    return;
-                }
-
-                // If we are getting close to the field position begin to align with the desired heading in field space
-                if (position_error < cfg.align_radius) {
-                    // Rotate the desired heading in field {f} space to robot space
-                    const Eigen::Vector3d uHRr(Hfr.inverse().linear() * uHFf);
-                    const double desired_heading = std::atan2(uHRr.y(), uHRr.x());
-                    emit<Task>(std::make_unique<WalkTo>(rPRr, desired_heading));
-                }
-                // Otherwise, walk directly to the field position
-                else {
-                    const double desired_heading = std::atan2(rPRr.y(), rPRr.x());
-                    emit<Task>(std::make_unique<WalkTo>(rPRr, desired_heading));
-                }
-
-                if (log_level <= NUClear::DEBUG) {
-                    log<NUClear::DEBUG>("Position error: ", position_error, " Heading error: ", heading_error);
-                }
+                emit<Task>(std::make_unique<WalkTo>(rPRr, heading));
             });
     }
 

--- a/roles/webots/robocup.role
+++ b/roles/webots/robocup.role
@@ -24,6 +24,7 @@ nuclear_role(
   platform::Webots
   # Vision
   vision::VisualMesh
+  vision::Yolo
   vision::GreenHorizonDetector
   vision::BallDetector
   vision::FieldLineDetector

--- a/shared/message/planning/WalkPath.proto
+++ b/shared/message/planning/WalkPath.proto
@@ -37,6 +37,14 @@ message WalkTo {
     double heading = 2;
 }
 
+/// Walk straight to the target (main walk path)
+message WalkDirect {
+    /// Point {P} to walk to from robot {R} in robot {r} space
+    vec3 rPRr = 1;
+    /// Desired heading in robot {r} space (radians)
+    double heading = 2;
+}
+
 /// Turn on the spot in the given direction
 message TurnOnSpot {
     /// Direction to turn


### PR DESCRIPTION
This PR utilises the Director's `When` functionality in path planning. There is a state struct/message local to the module that we use to transition between path phases. WalkToFieldPosition no longer has its own path planning and instead calls the main walk path planner. 

Specifically, this implementation has

- Rotate to face the target (note this isn't the end heading, it's just so the robot is facing where it's walking to, to try to prevent strafing and walking backwards). 
- Walk direct to the target (as before)
- Rotate to the heading (walk to ball as been modified so the middle of the opponent's goal is the heading)
- Stop when at target and facing heading

The phases have enter and exit thresholds. This is to create an overlap so that the robot doesn't oscillate between phases. The exit threshold is fine, so the robot won't leave the state until it's fairly well positioned. The enter threshold is larger, so it is harder to enter a state.

### Pre-PR Checklist:

- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [x] Added a descriptive title and relevant labels to the PR

### To Do

- [ ] This is meant to implement Tom's "walk behind the target then rotate" but I still need the "walk behind" part
- [ ] Real robot testing

and any other changes to the overall path planning method
also Director bugs exist - add back in idle standstill and the robot will do initial standstill->rotate to target->freezes
instead of freezing, it should walk direct, but it just stands still. this is also to fix.