### PR TITLE
Have root set the frequency update for behaviour providers

### DIFF
--- a/module/planning/PlanLook/src/PlanLook.cpp
+++ b/module/planning/PlanLook/src/PlanLook.cpp
@@ -54,7 +54,7 @@ namespace module::planning {
             }
         });
 
-        on<Provide<LookAround>, Every<30, Per<std::chrono::seconds>>>().then([this] {
+        on<Provide<LookAround>>().then([this] {
             // How long the look has lingered - will move to the next position if long enough
             float time_since_last_search_moved =
                 std::chrono::duration_cast<std::chrono::duration<float>>(NUClear::clock::now() - search_last_moved)

--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -90,7 +90,7 @@ namespace module::purpose {
             emit<Task>(std::make_unique<FallRecovery>(), 2);
         });
 
-        on<Provide<FindPurpose>>().then([this] {
+        on<Provide<FindPurpose>, Every<10, Per<std::chrono::seconds>>>().then([this] {
             // Make task based on configured purpose/soccer position
             switch (cfg.position) {
                 case Position::STRIKER: emit<Task>(std::make_unique<Striker>(cfg.force_playing)); break;

--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -90,7 +90,7 @@ namespace module::purpose {
             emit<Task>(std::make_unique<FallRecovery>(), 2);
         });
 
-        on<Provide<FindPurpose>, Every<10, Per<std::chrono::seconds>>>().then([this] {
+        on<Provide<FindPurpose>, Every<BEHAVIOUR_UPDATE_RATE, Per<std::chrono::seconds>>>().then([this] {
             // Make task based on configured purpose/soccer position
             switch (cfg.position) {
                 case Position::STRIKER: emit<Task>(std::make_unique<Striker>(cfg.force_playing)); break;

--- a/module/purpose/Soccer/src/Soccer.hpp
+++ b/module/purpose/Soccer/src/Soccer.hpp
@@ -69,7 +69,7 @@ namespace module::purpose {
         } cfg;
 
         /// @brief The rate the find purpose provider will run, to drive the rest of the system
-        const int BEHAVIOUR_UPDATE_RATE = 10;
+        static constexpr size_t BEHAVIOUR_UPDATE_RATE = 10;
 
     public:
         /// @brief Called by the powerplant to build and setup the Soccer reactor.

--- a/module/purpose/Soccer/src/Soccer.hpp
+++ b/module/purpose/Soccer/src/Soccer.hpp
@@ -68,6 +68,7 @@ namespace module::purpose {
             Position position{};
         } cfg;
 
+        /// @brief The rate the find purpose provider will run, to drive the rest of the system
         const int BEHAVIOUR_UPDATE_RATE = 10;
 
     public:

--- a/module/purpose/Soccer/src/Soccer.hpp
+++ b/module/purpose/Soccer/src/Soccer.hpp
@@ -68,6 +68,8 @@ namespace module::purpose {
             Position position{};
         } cfg;
 
+        const int BEHAVIOUR_UPDATE_RATE = 10;
+
     public:
         /// @brief Called by the powerplant to build and setup the Soccer reactor.
         explicit Soccer(std::unique_ptr<NUClear::Environment> environment);

--- a/module/purpose/Tester/src/Tester.cpp
+++ b/module/purpose/Tester/src/Tester.cpp
@@ -87,7 +87,7 @@ namespace module::purpose {
             cfg.chatgpt_prompt                  = config["chatgpt_prompt"].as<std::string>();
         });
 
-        on<Startup>().then([this] {
+        on<Every<10, Per<std::chrono::seconds>>>().then([this] {
             // Emit all the tasks with priorities higher than 0
             if (cfg.find_ball_priority > 0) {
                 emit<Task>(std::make_unique<FindBall>(), cfg.find_ball_priority);

--- a/module/purpose/Tester/src/Tester.cpp
+++ b/module/purpose/Tester/src/Tester.cpp
@@ -87,7 +87,7 @@ namespace module::purpose {
             cfg.chatgpt_prompt                  = config["chatgpt_prompt"].as<std::string>();
         });
 
-        on<Every<10, Per<std::chrono::seconds>>>().then([this] {
+        on<Every<BEHAVIOUR_UPDATE_RATE, Per<std::chrono::seconds>>>().then([this] {
             // Emit all the tasks with priorities higher than 0
             if (cfg.find_ball_priority > 0) {
                 emit<Task>(std::make_unique<FindBall>(), cfg.find_ball_priority);

--- a/module/purpose/Tester/src/Tester.hpp
+++ b/module/purpose/Tester/src/Tester.hpp
@@ -72,6 +72,8 @@ namespace module::purpose {
             int audiogpt_listen_duration = 0;
         } cfg;
 
+        const int BEHAVIOUR_UPDATE_RATE = 10;
+
     public:
         /// @brief Called by the powerplant to build and setup the Tester reactor.
         explicit Tester(std::unique_ptr<NUClear::Environment> environment);

--- a/module/purpose/Tester/src/Tester.hpp
+++ b/module/purpose/Tester/src/Tester.hpp
@@ -73,7 +73,7 @@ namespace module::purpose {
         } cfg;
 
         /// @brief The rate the tasks will emit, to drive the rest of the system
-        const int BEHAVIOUR_UPDATE_RATE = 10;
+        static constexpr size_t BEHAVIOUR_UPDATE_RATE = 10;
 
     public:
         /// @brief Called by the powerplant to build and setup the Tester reactor.

--- a/module/purpose/Tester/src/Tester.hpp
+++ b/module/purpose/Tester/src/Tester.hpp
@@ -72,6 +72,7 @@ namespace module::purpose {
             int audiogpt_listen_duration = 0;
         } cfg;
 
+        /// @brief The rate the tasks will emit, to drive the rest of the system
         const int BEHAVIOUR_UPDATE_RATE = 10;
 
     public:

--- a/module/strategy/AlignBallToGoal/src/AlignBallToGoal.cpp
+++ b/module/strategy/AlignBallToGoal/src/AlignBallToGoal.cpp
@@ -59,16 +59,11 @@ namespace module::strategy {
             cfg.angle_threshold         = config["angle_threshold"].as<Expression>();
         });
 
-        on<Provide<AlignBallToGoalTask>,
-           With<Ball>,
-           With<Field>,
-           With<Sensors>,
-           With<FieldDescription>,
-           Every<30, Per<std::chrono::seconds>>>()
-            .then([this](const Ball& ball,
-                         const Field& field,
-                         const Sensors& sensors,
-                         const FieldDescription& field_description) {
+        on<Provide<AlignBallToGoalTask>, With<Ball>, With<Field>, With<Sensors>, With<FieldDescription>>().then(
+            [this](const Ball& ball,
+                   const Field& field,
+                   const Sensors& sensors,
+                   const FieldDescription& field_description) {
                 // If the ball is close, align towards the goal
                 Eigen::Vector3d rBRr    = sensors.Hrw * ball.rBWw;
                 double distance_to_ball = rBRr.head(2).norm();

--- a/module/strategy/KickToGoal/src/KickToGoal.cpp
+++ b/module/strategy/KickToGoal/src/KickToGoal.cpp
@@ -52,12 +52,8 @@ namespace module::strategy {
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
         });
 
-        on<Provide<KickToGoalTask>,
-           With<Field>,
-           With<Sensors>,
-           With<FieldDescription>,
-           Every<30, Per<std::chrono::seconds>>>()
-            .then([this](const Field& field, const Sensors& sensors, const FieldDescription& field_description) {
+        on<Provide<KickToGoalTask>, With<Field>, With<Sensors>, With<FieldDescription>>().then(
+            [this](const Field& field, const Sensors& sensors, const FieldDescription& field_description) {
                 // Get the robot's position (pose) on the field
                 Eigen::Isometry3d Hrf =
                     Eigen::Isometry3d(sensors.Hrw) * Eigen::Isometry3d(field.Hfw.inverse().cast<double>());

--- a/module/strategy/Ready/src/Ready.cpp
+++ b/module/strategy/Ready/src/Ready.cpp
@@ -54,25 +54,23 @@ namespace module::strategy {
             cfg.walk_to_ready_rotation = config["walk_to_ready_rotation"].as<double>();
         });
 
-        on<Provide<ReadyTask>, With<Stability>, Every<30, Per<std::chrono::seconds>>>().then(
-            [this](const RunInfo& info, const Stability& stability) {
-                if (info.run_reason == RunInfo::RunReason::NEW_TASK) {
-                    // Set the timer and emit a walk Task
-                    start_ready_time = NUClear::clock::now();
-                    emit<Task>(std::make_unique<Walk>(Eigen::Vector3d(cfg.walk_to_ready_speed_x,
-                                                                      cfg.walk_to_ready_speed_y,
-                                                                      cfg.walk_to_ready_rotation)));
-                }
-                // If the time has elapsed to walk to ready, then emit the stand still task
-                // Don't emit another stand still task if we already did so
-                else if (NUClear::clock::now() - start_ready_time > cfg.walk_to_ready_time
-                         && stability != Stability::STANDING) {
-                    emit<Task>(std::make_unique<Walk>(Eigen::Vector3d::Zero()));
-                }
-                else {  // Otherwise, emit the idle task to keep walking or standing still
-                    emit<Task>(std::make_unique<Idle>());
-                }
-            });
+        on<Provide<ReadyTask>, With<Stability>>().then([this](const RunInfo& info, const Stability& stability) {
+            if (info.run_reason == RunInfo::RunReason::NEW_TASK) {
+                // Set the timer and emit a walk Task
+                start_ready_time = NUClear::clock::now();
+                emit<Task>(std::make_unique<Walk>(
+                    Eigen::Vector3d(cfg.walk_to_ready_speed_x, cfg.walk_to_ready_speed_y, cfg.walk_to_ready_rotation)));
+            }
+            // If the time has elapsed to walk to ready, then emit the stand still task
+            // Don't emit another stand still task if we already did so
+            else if (NUClear::clock::now() - start_ready_time > cfg.walk_to_ready_time
+                     && stability != Stability::STANDING) {
+                emit<Task>(std::make_unique<Walk>(Eigen::Vector3d::Zero()));
+            }
+            else {  // Otherwise, emit the idle task to keep walking or standing still
+                emit<Task>(std::make_unique<Idle>());
+            }
+        });
     }
 
 }  // namespace module::strategy

--- a/module/strategy/StrategiseLook/src/StrategiseLook.cpp
+++ b/module/strategy/StrategiseLook/src/StrategiseLook.cpp
@@ -62,19 +62,18 @@ namespace module::strategy {
 
         // Trigger on Ball to update readings
         // Uses Every to update time difference so if the ball is not recent, the Look Task will not be emitted
-        on<Provide<LookAtBall>, Trigger<Ball>, With<Sensors>, Every<30, Per<std::chrono::seconds>>>().then(
-            [this](const Ball& ball, const Sensors& sensors) {
-                // If we have a ball and it is recent, look at it
-                if (NUClear::clock::now() - ball.time_of_measurement < cfg.ball_search_timeout) {
-                    Eigen::Vector3d rBCc = ball.Hcw * ball.rBWw;
-                    Eigen::Vector3d rBCt = (sensors.Htw * ball.Hcw.inverse()).rotation() * rBCc;
-                    emit<Task>(std::make_unique<Look>(rBCt, true));
-                }
-            });
+        on<Provide<LookAtBall>, Trigger<Ball>, With<Sensors>>().then([this](const Ball& ball, const Sensors& sensors) {
+            // If we have a ball and it is recent, look at it
+            if (NUClear::clock::now() - ball.time_of_measurement < cfg.ball_search_timeout) {
+                Eigen::Vector3d rBCc = ball.Hcw * ball.rBWw;
+                Eigen::Vector3d rBCt = (sensors.Htw * ball.Hcw.inverse()).rotation() * rBCc;
+                emit<Task>(std::make_unique<Look>(rBCt, true));
+            }
+        });
 
         // Trigger on Goals to update readings
         // Uses Every to update time difference so if the goals are not recent, the Look Task will not be emitted
-        on<Provide<LookAtGoals>, Trigger<Goals>, With<Sensors>, Every<30, Per<std::chrono::seconds>>>().then(
+        on<Provide<LookAtGoals>, Trigger<Goals>, With<Sensors>>().then(
             [this](const Goals& goals, const Sensors& sensors) {
                 // If we have goals, with at least one measurement and the goals are recent, look at the goals
                 if (!goals.goals.empty() && (NUClear::clock::now() - goals.timestamp < cfg.goal_search_timeout)) {

--- a/module/strategy/WalkToBall/src/WalkToBall.cpp
+++ b/module/strategy/WalkToBall/src/WalkToBall.cpp
@@ -55,17 +55,16 @@ namespace module::strategy {
 
         // If the Provider updates on Every and the last Ball was too long ago, it won't emit any Task
         // Otherwise it will emit a Task to walk to the ball
-        on<Provide<WalkToBallTask>, With<Ball>, With<Sensors>, Every<30, Per<std::chrono::seconds>>>().then(
-            [this](const Ball& ball, const Sensors& sensors) {
-                // If we have a ball, walk to it
-                if (NUClear::clock::now() - ball.time_of_measurement < cfg.ball_search_timeout) {
-                    Eigen::Vector3d rBRr = sensors.Hrw * ball.rBWw;
-                    // Add an offset to account for walking with the foot in front of the ball
-                    rBRr.y() += cfg.ball_y_offset;
-                    const double heading = std::atan2(rBRr.y(), rBRr.x());
-                    emit<Task>(std::make_unique<WalkTo>(rBRr, heading));
-                }
-            });
+        on<Provide<WalkToBallTask>, With<Ball>, With<Sensors>>().then([this](const Ball& ball, const Sensors& sensors) {
+            // If we have a ball, walk to it
+            if (NUClear::clock::now() - ball.time_of_measurement < cfg.ball_search_timeout) {
+                Eigen::Vector3d rBRr = sensors.Hrw * ball.rBWw;
+                // Add an offset to account for walking with the foot in front of the ball
+                rBRr.y() += cfg.ball_y_offset;
+                const double heading = std::atan2(rBRr.y(), rBRr.x());
+                emit<Task>(std::make_unique<WalkTo>(rBRr, heading));
+            }
+        });
     }
 
 }  // namespace module::strategy

--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
@@ -55,7 +55,7 @@ namespace module::strategy {
             cfg.resume_tolerance = config["resume_tolerance"].as<double>();
         });
 
-        on<Provide<WalkToFieldPositionTask>, With<Field>, With<Sensors>, Every<30, Per<std::chrono::seconds>>>().then(
+        on<Provide<WalkToFieldPositionTask>, With<Field>, With<Sensors>>().then(
             [this](const WalkToFieldPositionTask& walk_to_field_position, const Field& field, const Sensors& sensors) {
                 // Get the transformation from robot {r} space to field {f} space
                 const Eigen::Isometry3d Hfr = field.Hfw * sensors.Hrw.inverse();


### PR DESCRIPTION
Our behaviour providers need to run at some frequency to check if things change, often time based things. Currently we've been doing this per-Provider but then if a parent and child are both running eg 10 times a second, this will compound for the child if the parent is triggering the child each time. The PR just makes the root update 10 times/second. 

Things wouldn't run if idle'd, but thats only really used lower down. Main motivation is for walk path planner to have reasonable dt for new method.

Tested in webots.