### PR TITLE
Vision heuristics with YOLO + VMesh (mostly balls)

### DIFF
--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
@@ -67,11 +67,8 @@ namespace module::localisation {
                     // Position of robot {r} in world {w} space
                     auto rRWw = Hwc * vision_robot.rRCc;
 
-                    // Only consider vision measurements within the green horizon
-                    if (point_in_convex_hull(horizon.horizon, rRWw)) {
-                        // Data association: find tracked robot which is associated with the vision measurement
-                        data_association(rRWw);
-                    }
+                    // Data association: find tracked robot which is associated with the vision measurement
+                    data_association(rRWw);
                 }
             }
 

--- a/module/vision/BallDetector/data/config/BallDetector.yaml
+++ b/module/vision/BallDetector/data/config/BallDetector.yaml
@@ -1,8 +1,8 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-confidence_threshold: 0.6 # Minimum confidence required for a ball point to be a ball point
-cluster_points: 1 # Minimum number of points for a cluster to be a viable ball
+confidence_threshold: 0.7 # Minimum confidence required for a ball point to be a ball point
+cluster_points: 20 # Minimum number of points for a cluster to be a viable ball
 minimum_ball_distance: 2.5 # Minimum distance for a cluster to be a viable ball
 distance_disagreement:
   1.0 # Percentage difference between width and projection based distances. 0.0 means

--- a/module/vision/BallDetector/data/config/BallDetector.yaml
+++ b/module/vision/BallDetector/data/config/BallDetector.yaml
@@ -3,7 +3,7 @@ log_level: INFO
 
 confidence_threshold: 0.6 # Minimum confidence required for a ball point to be a ball point
 cluster_points: 1 # Minimum number of points for a cluster to be a viable ball
-minimum_ball_distance: 0.1 # Minimum distance for a cluster to be a viable ball
+minimum_ball_distance: 2.5 # Minimum distance for a cluster to be a viable ball
 distance_disagreement:
   1.0 # Percentage difference between width and projection based distances. 0.0 means
   # the distance measurements must match perfectly

--- a/module/vision/GreenHorizonDetector/data/config/GreenHorizonDetector.yaml
+++ b/module/vision/GreenHorizonDetector/data/config/GreenHorizonDetector.yaml
@@ -1,4 +1,4 @@
 log_level: INFO
 
-confidence_threshold: 0.95 # How confident do we need to be that this is a green horizon point
+confidence_threshold: 0.9 # How confident do we need to be that this is a green horizon point
 cluster_points: 50 # How many points do we need to claim this cluster is a viable part of the green horizon

--- a/module/vision/GreenHorizonDetector/data/config/GreenHorizonDetector.yaml
+++ b/module/vision/GreenHorizonDetector/data/config/GreenHorizonDetector.yaml
@@ -1,4 +1,8 @@
 log_level: INFO
 
-confidence_threshold: 0.9 # How confident do we need to be that this is a green horizon point
-cluster_points: 50 # How many points do we need to claim this cluster is a viable part of the green horizon
+# How confident do we need to be that this is a green horizon point
+confidence_threshold: 0.9
+# How many points do we need to claim this cluster is a viable part of the green horizon
+cluster_points: 200
+# How close a field cluster needs to be to the robot to be an accepted cluster
+max_distance: 2.0

--- a/module/vision/GreenHorizonDetector/src/GreenHorizonDetector.hpp
+++ b/module/vision/GreenHorizonDetector/src/GreenHorizonDetector.hpp
@@ -43,6 +43,7 @@ namespace module::vision {
         struct {
             double confidence_threshold = 0.0;
             uint cluster_points         = 0;
+            double max_distance         = 0.0;
         } cfg{};
     };
 

--- a/module/vision/Yolo/README.md
+++ b/module/vision/Yolo/README.md
@@ -17,6 +17,8 @@ Inference can be ran on either the CPU or GPU using OpenVino (https://github.com
 
 Include this module to detect balls, goals, robots and field line intersections in images.
 
+If the GreenHorizon is included in the program, balls, field line intersections and robots outside of the GreenHorizon will be discarded.
+
 To run with GPU device in docker you need to include the following flags `./b run {binary} --gpus all`
 
 ## Consumes

--- a/module/vision/Yolo/data/config/Yolo.yaml
+++ b/module/vision/Yolo/data/config/Yolo.yaml
@@ -5,7 +5,7 @@ log_level: INFO
 model_path: "yolo.onnx"
 
 # Minimum confidence required for a ball detection to be accepted
-ball_confidence_threshold: 0.5
+ball_confidence_threshold: 0.3
 
 # Minimum confidence required for a goal detection to be accepted
 goalpost_confidence_threshold: 0.2

--- a/module/vision/Yolo/src/Yolo.cpp
+++ b/module/vision/Yolo/src/Yolo.cpp
@@ -12,6 +12,7 @@
 #include "message/vision/BoundingBoxes.hpp"
 #include "message/vision/FieldIntersections.hpp"
 #include "message/vision/Goal.hpp"
+#include "message/vision/GreenHorizon.hpp"
 #include "message/vision/Robot.hpp"
 
 #include "utility/math/coordinates.hpp"
@@ -19,6 +20,7 @@
 #include "utility/vision/Vision.hpp"
 #include "utility/vision/fourcc.hpp"
 #include "utility/vision/projection.hpp"
+#include "utility/vision/visualmesh/VisualMesh.hpp"
 
 namespace module::vision {
 
@@ -33,11 +35,13 @@ namespace module::vision {
     using message::vision::FieldIntersections;
     using message::vision::Goal;
     using message::vision::Goals;
+    using message::vision::GreenHorizon;
     using message::vision::Robot;
     using message::vision::Robots;
 
     using utility::math::coordinates::cartesianToReciprocalSpherical;
     using utility::math::coordinates::cartesianToSpherical;
+    using utility::math::geometry::point_in_convex_hull;
     using utility::support::Expression;
     using utility::vision::unproject;
 
@@ -61,217 +65,229 @@ namespace module::vision {
             infer_request = compiled_model.create_infer_request();
         });
 
-        on<Trigger<Image>, Single>().then("Yolo Main Loop", [this](const Image& img) {
-            // Start timer for benchmarking
-            auto start = std::chrono::high_resolution_clock::now();
+        on<Trigger<Image>, Optional<With<GreenHorizon>>, Single>().then(
+            "Yolo Main Loop",
+            [this](const Image& img, const std::shared_ptr<const GreenHorizon>& horizon) {
+                // Start timer for benchmarking
+                auto start = std::chrono::high_resolution_clock::now();
 
-            // -------- Convert image to cv::Mat -------
-            const int width  = img.dimensions.x();
-            const int height = img.dimensions.y();
-            cv::Mat img_cv;
-            switch (img.format) {
-                case utility::vision::fourcc("BGR3"):  // BGR3 not available in utility::vision::FOURCC.
-                    img_cv = cv::Mat(height, width, CV_8UC3, const_cast<uint8_t*>(img.data.data()));
-                    break;
-                case utility::vision::FOURCC::RGGB:
-                    img_cv = cv::Mat(height, width, CV_8UC1, const_cast<uint8_t*>(img.data.data()));
-                    cv::cvtColor(img_cv, img_cv, cv::COLOR_BayerRG2RGB);
-                    break;
-                default:
-                    log<NUClear::WARN>("Image format not supported: ", utility::vision::fourcc(img.format));
-                    return;
-            }
-
-            // -------- Preprocess the image -------
-            int max               = MAX(width, height);
-            cv::Mat letterbox_img = cv::Mat::zeros(max, max, CV_8UC3);
-            img_cv.copyTo(letterbox_img(cv::Rect(0, 0, width, height)));
-            cv::Mat blob = cv::dnn::blobFromImage(letterbox_img, 1.0 / 255.0, cv::Size(640, 640), cv::Scalar(), true);
-
-            // -------- Feed the blob into the input node of the Model -------
-            // Get input port for model with one input
-            auto input_port = compiled_model.input();
-            // Create tensor from external memory
-            ov::Tensor input_tensor(input_port.get_element_type(), input_port.get_shape(), blob.ptr(0));
-            // Set input tensor for model with one input
-            infer_request.set_input_tensor(input_tensor);
-
-            // -------- Perform Inference --------
-            infer_request.infer();
-            auto output = infer_request.get_output_tensor(0);
-
-            // -------- Postprocess the result --------
-            float* data = output.data<float>();
-            cv::Mat output_buffer(output.get_shape()[1], output.get_shape()[2], CV_32F, data);
-            transpose(output_buffer, output_buffer);  //[8400,84]
-            std::vector<int> class_ids;
-            std::vector<float> class_confidences;
-            std::vector<cv::Rect> boxes;
-            float scale = letterbox_img.size[0] / 640.0;
-
-            // Figure out the bbox, class_id and class_score
-            for (int i = 0; i < output_buffer.rows; i++) {
-                cv::Mat objects_scores = output_buffer.row(i).colRange(4, 10);
-                cv::Point class_id;
-                double confidence;
-                cv::minMaxLoc(objects_scores, 0, &confidence, 0, &class_id);
-
-                // Filter out the objects with confidence below the class threshold
-                if (confidence > objects[class_id.x].confidence_threshold) {
-                    class_confidences.push_back(confidence);
-                    class_ids.push_back(class_id.x);
-                    float cx = output_buffer.at<float>(i, 0);
-                    float cy = output_buffer.at<float>(i, 1);
-                    float w  = output_buffer.at<float>(i, 2);
-                    float h  = output_buffer.at<float>(i, 3);
-
-                    // Scale the bbox to the original image dimensions
-                    int left   = int((cx - 0.5 * w) * scale);
-                    int top    = int((cy - 0.5 * h) * scale);
-                    int width  = int(w * scale);
-                    int height = int(h * scale);
-                    boxes.push_back(cv::Rect(left, top, width, height));
-                }
-            }
-
-            // Perform NMS (non maximum suppression) to remove overlapping boxes
-            std::vector<int> indices;
-            cv::dnn::NMSBoxes(boxes, class_confidences, cfg.nms_score_threshold, cfg.nms_threshold, indices);
-
-            // -------- Emit Detections --------
-            const Eigen::Isometry3d& Hwc = img.Hcw.inverse();
-
-            auto balls               = std::make_unique<Balls>();
-            auto robots              = std::make_unique<Robots>();
-            auto goals               = std::make_unique<Goals>();
-            auto field_intersections = std::make_unique<FieldIntersections>();
-            auto bounding_boxes      = std::make_unique<BoundingBoxes>();
-
-            // Common message fields
-            balls->id = robots->id = goals->id = field_intersections->id = bounding_boxes->id = img.id;
-            balls->timestamp = robots->timestamp = goals->timestamp = field_intersections->timestamp =
-                bounding_boxes->timestamp                           = img.timestamp;
-            balls->Hcw = robots->Hcw = goals->Hcw = field_intersections->Hcw = bounding_boxes->Hcw = img.Hcw;
-
-            // Helper function to simplify unprojection calls
-            auto pix_to_ray = [&](double x, double y) {
-                // Normalize the pixel coordinates to the image width normalized dimensions
-                Eigen::Vector2d norm_dim = Eigen::Vector2d(img.dimensions.x(), img.dimensions.y()) / img.dimensions.x();
-                return unproject(Eigen::Matrix<double, 2, 1>(x / img.dimensions.x(), y / img.dimensions.x()),
-                                 img.lens,
-                                 norm_dim);
-            };
-
-            // Helper function to simplify projecting rays onto the field plane then transforming into camera space
-            auto ray_to_camera_space = [&](const Eigen::Matrix<double, 3, 1>& ray) {
-                Eigen::Vector3d uBCw = Hwc.rotation() * ray;
-                Eigen::Vector3d rPWw = uBCw * std::abs(Hwc.translation().z() / uBCw.z()) + Hwc.translation();
-                return Hwc.inverse() * rPWw;
-            };
-
-            for (size_t i = 0; i < indices.size(); i++) {
-                // Get the index of the detected object from list of indices
-                int idx = indices[i];
-                // Get the class id associated with the detected object
-                int class_id = class_ids[idx];
-
-                // Convert the bounding box points to unit vectors (rays) in the camera {c} space
-                Eigen::Vector3d top_left_ray  = pix_to_ray(boxes[idx].x, boxes[idx].y);
-                Eigen::Vector3d top_right_ray = pix_to_ray(boxes[idx].x + boxes[idx].width, boxes[idx].y);
-                Eigen::Vector3d bottom_right_ray =
-                    pix_to_ray(boxes[idx].x + boxes[idx].width, boxes[idx].y + boxes[idx].height);
-                Eigen::Vector3d bottom_left_ray = pix_to_ray(boxes[idx].x, boxes[idx].y + boxes[idx].height);
-                Eigen::Vector3d centre_ray =
-                    pix_to_ray(boxes[idx].x + boxes[idx].width / 2.0, boxes[idx].y + boxes[idx].height / 2.0);
-                Eigen::Vector3d bottom_centre_ray =
-                    pix_to_ray(boxes[idx].x + boxes[idx].width / 2.0, boxes[idx].y + boxes[idx].height);
-                Eigen::Vector3d top_centre_ray = pix_to_ray(boxes[idx].x + boxes[idx].width / 2.0, boxes[idx].y);
-
-                auto bbox        = std::make_unique<BoundingBox>();
-                bbox->name       = objects[class_id].name;
-                bbox->confidence = class_confidences[idx];
-                bbox->corners.push_back(top_left_ray);
-                bbox->corners.push_back(top_right_ray);
-                bbox->corners.push_back(bottom_right_ray);
-                bbox->corners.push_back(bottom_left_ray);
-
-
-                if (objects[class_id].name == "ball") {
-                    Ball b;
-                    b.uBCc = ray_to_camera_space(centre_ray).normalized();
-                    b.measurements.emplace_back();
-                    b.measurements.back().type = Ball::MeasurementType::PROJECTION;
-                    b.measurements.back().rBCc = ray_to_camera_space(centre_ray);
-                    // Calculate the angular radius of the ball in camera space
-                    b.radius = bottom_centre_ray.dot(bottom_left_ray);
-                    b.colour.fill(1.0);
-                    balls->balls.push_back(b);
-                    bbox->colour = objects[class_id].colour;
-                    bounding_boxes->bounding_boxes.push_back(*bbox);
+                // -------- Convert image to cv::Mat -------
+                const int width  = img.dimensions.x();
+                const int height = img.dimensions.y();
+                cv::Mat img_cv;
+                switch (img.format) {
+                    case utility::vision::fourcc("BGR3"):  // BGR3 not available in utility::vision::FOURCC.
+                        img_cv = cv::Mat(height, width, CV_8UC3, const_cast<uint8_t*>(img.data.data()));
+                        break;
+                    case utility::vision::FOURCC::RGGB:
+                        img_cv = cv::Mat(height, width, CV_8UC1, const_cast<uint8_t*>(img.data.data()));
+                        cv::cvtColor(img_cv, img_cv, cv::COLOR_BayerRG2RGB);
+                        break;
+                    default:
+                        log<NUClear::WARN>("Image format not supported: ", utility::vision::fourcc(img.format));
+                        return;
                 }
 
-                if (objects[class_id].name == "goal post") {
-                    Goal g;
-                    g.measurements.emplace_back();
-                    g.measurements.back().type = Goal::MeasurementType::CENTRE;
-                    g.measurements.back().rGCc = ray_to_camera_space(bottom_centre_ray);
-                    g.post.top                 = top_centre_ray;
-                    g.post.bottom              = bottom_centre_ray;
-                    g.post.distance            = ray_to_camera_space(bottom_centre_ray).norm();
-                    g.side                     = Goal::Side::UNKNOWN_SIDE;
-                    g.screen_angular           = cartesianToSpherical(g.post.bottom).tail<2>();
-                    goals->goals.push_back(std::move(g));
-                    bbox->colour = objects[class_id].colour;
-                    bounding_boxes->bounding_boxes.push_back(*bbox);
-                }
+                // -------- Preprocess the image -------
+                int max               = MAX(width, height);
+                cv::Mat letterbox_img = cv::Mat::zeros(max, max, CV_8UC3);
+                img_cv.copyTo(letterbox_img(cv::Rect(0, 0, width, height)));
+                cv::Mat blob =
+                    cv::dnn::blobFromImage(letterbox_img, 1.0 / 255.0, cv::Size(640, 640), cv::Scalar(), true);
 
-                if (objects[class_id].name == "robot") {
-                    Robot r;
-                    r.rRCc   = ray_to_camera_space(bottom_centre_ray);
-                    r.radius = bottom_centre_ray.dot(bottom_left_ray);
-                    robots->robots.push_back(r);
-                    bbox->colour = objects[class_id].colour;
-                    bounding_boxes->bounding_boxes.push_back(*bbox);
-                }
+                // -------- Feed the blob into the input node of the Model -------
+                // Get input port for model with one input
+                auto input_port = compiled_model.input();
+                // Create tensor from external memory
+                ov::Tensor input_tensor(input_port.get_element_type(), input_port.get_shape(), blob.ptr(0));
+                // Set input tensor for model with one input
+                infer_request.set_input_tensor(input_tensor);
 
-                if (objects[class_id].name == "L-intersection" || objects[class_id].name == "T-intersection"
-                    || objects[class_id].name == "X-intersection") {
-                    FieldIntersection i;
-                    // Project the centre ray onto the ground plane in world {w} space
-                    Eigen::Vector3d uICw = Hwc.rotation() * centre_ray;
-                    Eigen::Vector3d rIWw = uICw * std::abs(Hwc.translation().z() / uICw.z()) + Hwc.translation();
-                    i.rIWw               = rIWw;
-                    if (objects[class_id].name == "L-intersection") {
-                        i.type       = FieldIntersection::IntersectionType::L_INTERSECTION;
-                        bbox->colour = objects[class_id].colour;
+                // -------- Perform Inference --------
+                infer_request.infer();
+                auto output = infer_request.get_output_tensor(0);
+
+                // -------- Postprocess the result --------
+                float* data = output.data<float>();
+                cv::Mat output_buffer(output.get_shape()[1], output.get_shape()[2], CV_32F, data);
+                transpose(output_buffer, output_buffer);  //[8400,84]
+                std::vector<int> class_ids;
+                std::vector<float> class_confidences;
+                std::vector<cv::Rect> boxes;
+                float scale = letterbox_img.size[0] / 640.0;
+
+                // Figure out the bbox, class_id and class_score
+                for (int i = 0; i < output_buffer.rows; i++) {
+                    cv::Mat objects_scores = output_buffer.row(i).colRange(4, 10);
+                    cv::Point class_id;
+                    double confidence;
+                    cv::minMaxLoc(objects_scores, 0, &confidence, 0, &class_id);
+
+                    // Filter out the objects with confidence below the class threshold
+                    if (confidence > objects[class_id.x].confidence_threshold) {
+                        class_confidences.push_back(confidence);
+                        class_ids.push_back(class_id.x);
+                        float cx = output_buffer.at<float>(i, 0);
+                        float cy = output_buffer.at<float>(i, 1);
+                        float w  = output_buffer.at<float>(i, 2);
+                        float h  = output_buffer.at<float>(i, 3);
+
+                        // Scale the bbox to the original image dimensions
+                        int left   = int((cx - 0.5 * w) * scale);
+                        int top    = int((cy - 0.5 * h) * scale);
+                        int width  = int(w * scale);
+                        int height = int(h * scale);
+                        boxes.push_back(cv::Rect(left, top, width, height));
                     }
-                    else if (objects[class_id].name == "T-intersection") {
-                        i.type       = FieldIntersection::IntersectionType::T_INTERSECTION;
-                        bbox->colour = objects[class_id].colour;
-                    }
-                    else if (objects[class_id].name == "X-intersection") {
-                        i.type       = FieldIntersection::IntersectionType::X_INTERSECTION;
-                        bbox->colour = objects[class_id].colour;
-                    }
-                    field_intersections->intersections.push_back(std::move(i));
-                    bounding_boxes->bounding_boxes.push_back(*bbox);
                 }
-            }
 
-            emit(std::move(balls));
-            emit(std::move(robots));
-            emit(std::move(goals));
-            emit(std::move(field_intersections));
-            emit(std::move(bounding_boxes));
+                // Perform NMS (non maximum suppression) to remove overlapping boxes
+                std::vector<int> indices;
+                cv::dnn::NMSBoxes(boxes, class_confidences, cfg.nms_score_threshold, cfg.nms_threshold, indices);
 
-            // -------- Benchmark --------
-            if (log_level <= NUClear::DEBUG) {
-                auto end      = std::chrono::high_resolution_clock::now();
-                auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-                log<NUClear::DEBUG>("Yolo took: ", duration, "ms");
-                log<NUClear::DEBUG>("FPS: ", 1000.0 / duration);
-            }
-        });
+                // -------- Emit Detections --------
+                const Eigen::Isometry3d& Hwc = img.Hcw.inverse();
+
+                auto balls               = std::make_unique<Balls>();
+                auto robots              = std::make_unique<Robots>();
+                auto goals               = std::make_unique<Goals>();
+                auto field_intersections = std::make_unique<FieldIntersections>();
+                auto bounding_boxes      = std::make_unique<BoundingBoxes>();
+
+                // Common message fields
+                balls->id = robots->id = goals->id = field_intersections->id = bounding_boxes->id = img.id;
+                balls->timestamp = robots->timestamp = goals->timestamp = field_intersections->timestamp =
+                    bounding_boxes->timestamp                           = img.timestamp;
+                balls->Hcw = robots->Hcw = goals->Hcw = field_intersections->Hcw = bounding_boxes->Hcw = img.Hcw;
+
+                // Helper function to simplify unprojection calls
+                auto pix_to_ray = [&](double x, double y) {
+                    // Normalize the pixel coordinates to the image width normalized dimensions
+                    Eigen::Vector2d norm_dim =
+                        Eigen::Vector2d(img.dimensions.x(), img.dimensions.y()) / img.dimensions.x();
+                    return unproject(Eigen::Matrix<double, 2, 1>(x / img.dimensions.x(), y / img.dimensions.x()),
+                                     img.lens,
+                                     norm_dim);
+                };
+
+                // Helper function to simplify projecting rays onto the field plane then transforming into camera space
+                auto ray_to_camera_space = [&](const Eigen::Matrix<double, 3, 1>& ray) {
+                    Eigen::Vector3d uBCw = Hwc.rotation() * ray;
+                    Eigen::Vector3d rPWw = uBCw * std::abs(Hwc.translation().z() / uBCw.z()) + Hwc.translation();
+                    return Hwc.inverse() * rPWw;
+                };
+
+                for (size_t i = 0; i < indices.size(); i++) {
+                    // Get the index of the detected object from list of indices
+                    int idx = indices[i];
+                    // Get the class id associated with the detected object
+                    int class_id = class_ids[idx];
+
+                    // Convert the bounding box points to unit vectors (rays) in the camera {c} space
+                    Eigen::Vector3d top_left_ray  = pix_to_ray(boxes[idx].x, boxes[idx].y);
+                    Eigen::Vector3d top_right_ray = pix_to_ray(boxes[idx].x + boxes[idx].width, boxes[idx].y);
+                    Eigen::Vector3d bottom_right_ray =
+                        pix_to_ray(boxes[idx].x + boxes[idx].width, boxes[idx].y + boxes[idx].height);
+                    Eigen::Vector3d bottom_left_ray = pix_to_ray(boxes[idx].x, boxes[idx].y + boxes[idx].height);
+                    Eigen::Vector3d centre_ray =
+                        pix_to_ray(boxes[idx].x + boxes[idx].width / 2.0, boxes[idx].y + boxes[idx].height / 2.0);
+                    Eigen::Vector3d bottom_centre_ray =
+                        pix_to_ray(boxes[idx].x + boxes[idx].width / 2.0, boxes[idx].y + boxes[idx].height);
+                    Eigen::Vector3d top_centre_ray = pix_to_ray(boxes[idx].x + boxes[idx].width / 2.0, boxes[idx].y);
+
+                    auto bbox        = std::make_unique<BoundingBox>();
+                    bbox->name       = objects[class_id].name;
+                    bbox->confidence = class_confidences[idx];
+                    bbox->corners.push_back(top_left_ray);
+                    bbox->corners.push_back(top_right_ray);
+                    bbox->corners.push_back(bottom_right_ray);
+                    bbox->corners.push_back(bottom_left_ray);
+
+
+                    if (objects[class_id].name == "ball") {
+                        Ball b;
+                        b.uBCc = ray_to_camera_space(centre_ray).normalized();
+
+                        // Get the vector in world space to check if it is in the field
+                        Eigen::Vector3d rBWw = img.Hcw.inverse() * ray_to_camera_space(centre_ray);
+                        // Only consider vision measurements within the green horizon, if it exists
+                        if (horizon != nullptr && !point_in_convex_hull(horizon->horizon, rBWw)) {
+                            continue;  // skip this run of the loop and continue the for loop
+                        }
+
+                        b.measurements.emplace_back();
+                        b.measurements.back().type = Ball::MeasurementType::PROJECTION;
+                        b.measurements.back().rBCc = ray_to_camera_space(centre_ray);
+                        // Calculate the angular radius of the ball in camera space
+                        b.radius = bottom_centre_ray.dot(bottom_left_ray);
+                        b.colour.fill(1.0);
+                        balls->balls.push_back(b);
+                        bbox->colour = objects[class_id].colour;
+                        bounding_boxes->bounding_boxes.push_back(*bbox);
+                    }
+
+                    if (objects[class_id].name == "goal post") {
+                        Goal g;
+                        g.measurements.emplace_back();
+                        g.measurements.back().type = Goal::MeasurementType::CENTRE;
+                        g.measurements.back().rGCc = ray_to_camera_space(bottom_centre_ray);
+                        g.post.top                 = top_centre_ray;
+                        g.post.bottom              = bottom_centre_ray;
+                        g.post.distance            = ray_to_camera_space(bottom_centre_ray).norm();
+                        g.side                     = Goal::Side::UNKNOWN_SIDE;
+                        g.screen_angular           = cartesianToSpherical(g.post.bottom).tail<2>();
+                        goals->goals.push_back(std::move(g));
+                        bbox->colour = objects[class_id].colour;
+                        bounding_boxes->bounding_boxes.push_back(*bbox);
+                    }
+
+                    if (objects[class_id].name == "robot") {
+                        Robot r;
+                        r.rRCc   = ray_to_camera_space(bottom_centre_ray);
+                        r.radius = bottom_centre_ray.dot(bottom_left_ray);
+                        robots->robots.push_back(r);
+                        bbox->colour = objects[class_id].colour;
+                        bounding_boxes->bounding_boxes.push_back(*bbox);
+                    }
+
+                    if (objects[class_id].name == "L-intersection" || objects[class_id].name == "T-intersection"
+                        || objects[class_id].name == "X-intersection") {
+                        FieldIntersection i;
+                        // Project the centre ray onto the ground plane in world {w} space
+                        Eigen::Vector3d uICw = Hwc.rotation() * centre_ray;
+                        Eigen::Vector3d rIWw = uICw * std::abs(Hwc.translation().z() / uICw.z()) + Hwc.translation();
+                        i.rIWw               = rIWw;
+                        if (objects[class_id].name == "L-intersection") {
+                            i.type       = FieldIntersection::IntersectionType::L_INTERSECTION;
+                            bbox->colour = objects[class_id].colour;
+                        }
+                        else if (objects[class_id].name == "T-intersection") {
+                            i.type       = FieldIntersection::IntersectionType::T_INTERSECTION;
+                            bbox->colour = objects[class_id].colour;
+                        }
+                        else if (objects[class_id].name == "X-intersection") {
+                            i.type       = FieldIntersection::IntersectionType::X_INTERSECTION;
+                            bbox->colour = objects[class_id].colour;
+                        }
+                        field_intersections->intersections.push_back(std::move(i));
+                        bounding_boxes->bounding_boxes.push_back(*bbox);
+                    }
+                }
+
+                emit(std::move(balls));
+                emit(std::move(robots));
+                emit(std::move(goals));
+                emit(std::move(field_intersections));
+                emit(std::move(bounding_boxes));
+
+                // -------- Benchmark --------
+                if (log_level <= NUClear::DEBUG) {
+                    auto end      = std::chrono::high_resolution_clock::now();
+                    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+                    log<NUClear::DEBUG>("Yolo took: ", duration, "ms");
+                    log<NUClear::DEBUG>("FPS: ", 1000.0 / duration);
+                }
+            });
     }
 
 }  // namespace module::vision


### PR DESCRIPTION
- Tune the VMesh Ball Detector to focus more on seeing balls further away. Upped the min distance so it ignores balls close by. Upped the cluster size so small 'balls' don't get through, as small balls are thought to be far away.
- Tune the YOLO detector to allow through balls at a much lower confidence (this helped with balls on field lines and paler balls)
- Added in heuristic to YOLO detector to not allow balls, robots and field intersections if they are outside of the green horizon. 
- Tuned the green horizon to allow lower confidence field points, as it was not covering the whole field sometimes. Helped a lot.
- Removed the check for if the robot is in the green horizon in the RobotLocalisation module as this is already done in the Yolo module. Had to keep in one check and the horizon message as it is used in the logic for if robots go out of view. A new method for this, ie based on fov and image size as per todo comment, will allow us to remove the greenhorizon here entirely.
- Updated GreenHorizonDetector to not just take the closest cluster. Instead it merges clusters if they are close enough to the robot. We try to set this value quite low, as any viable cluster is going to have its closest point very close to the robot. The field is unlikely to be split up horizontally, but more so vertically, therefore the base of the field cluster should be at the bottom of the camera. Tested also with looking as far up as the robot can look, and it still keeps the clusters. There are some strong green patches in the mesh around the field and these stay excluded. Tested with some chairs in the way to vertically split up the field as if robots were there, and it created a good convex hull over the field. 