### PR TITLE
Fix Walk Engine States - Stuck in STOPPING when non-zero command requested before STOPPED

### DIFF
--- a/shared/utility/skill/WalkGenerator.hpp
+++ b/shared/utility/skill/WalkGenerator.hpp
@@ -209,7 +209,8 @@ namespace utility::skill {
                 // Requested velocity target is zero and we haven't finished taking a step, continue stopping
                 engine_state = WalkState::State::STOPPING;
             }
-            else if (velocity_target.isZero() && t >= p.step_period) {
+            else if (t >= p.step_period
+                     && (velocity_target.isZero() || engine_state.value == WalkState::State::STOPPING)) {
                 // Requested velocity target is zero and we have finished taking a step, remain stopped
                 engine_state = WalkState::State::STOPPED;
             }


### PR DESCRIPTION
The walk engine will get stuck in the STOPPING state if the robot switches between stopping and then getting a new non-zero command. This happens when switching quickly between the WalkTo Task and the TurnOnSpot Task. 

This PR adds to the condition that STOPPED can be achieved if the step is over and the robot is STOPPING. This allows the walk engine to continue to walking again after stopped.