### PR TITLE
Make FindBall only look if it can't see the ball

### DIFF
--- a/module/strategy/FindObject/data/config/FindObject.yaml
+++ b/module/strategy/FindObject/data/config/FindObject.yaml
@@ -1,2 +1,5 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
+
+# How long to wait until the ball is lost and we should look for it
+ball_search_timeout: 2

--- a/module/strategy/FindObject/src/FindObject.hpp
+++ b/module/strategy/FindObject/src/FindObject.hpp
@@ -35,6 +35,13 @@ namespace module::strategy {
 
     class FindObject : public ::extension::behaviour::BehaviourReactor {
 
+    private:
+        /// @brief Stores configuration values
+        struct Config {
+            /// @brief Length of time before the ball detection is too old and we should search for the ball
+            NUClear::clock::duration ball_search_timeout{};
+        } cfg;
+
     public:
         /// @brief Called by the powerplant to build and setup the FindObject reactor.
         explicit FindObject(std::unique_ptr<NUClear::Environment> environment);


### PR DESCRIPTION
It was originally made without this check because the idea was it was running at the lowest priority and would take over if the walk to ball/look at ball couldn't run. But this makes it unnecessarily request Tasks and it is a problem if we want to stand still sometimes when we can see the ball (ie goalie and defender).