### PR TITLE
Fix bug where ncurses menu can freeze

### DIFF
--- a/module/purpose/ScriptTuner/src/ScriptTuner.cpp
+++ b/module/purpose/ScriptTuner/src/ScriptTuner.cpp
@@ -141,7 +141,7 @@ namespace module::purpose {
 
 
         // Trigger when stdin has something to read
-        on<IO>(STDIN_FILENO, IO::READ).then([this] {
+        on<Always>().then([this] {
             // Get the character the user has typed
             switch (getch()) {
                 case KEY_UP:  // Change selection up

--- a/module/purpose/ScriptTuner/src/ScriptTuner.cpp
+++ b/module/purpose/ScriptTuner/src/ScriptTuner.cpp
@@ -33,7 +33,9 @@ extern "C" {
 }
 
 #include <cstdio>
+#include <fcntl.h>
 #include <sstream>
+#include <termios.h>
 
 #include "extension/Behaviour.hpp"
 #include "extension/Configuration.hpp"
@@ -82,6 +84,19 @@ namespace module::purpose {
         on<Configuration>("ScriptTuner.yaml").then([this](const Configuration& config) {
             // Use configuration here from file KeyboardWalk.yaml
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
+
+            // Set STDIN to non-blocking
+            int flags  = fcntl(STDIN_FILENO, F_GETFL, 0);
+            auto error = fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK);
+            if (error == -1) {
+                log<NUClear::ERROR>("Failed to set STDIN to non-blocking");
+            }
+
+            // Set up our terminal to not require EOF
+            struct termios attr;
+            tcgetattr(STDIN_FILENO, &attr);
+            attr.c_lflag &= ~(ICANON | ECHO);
+            tcsetattr(STDIN_FILENO, TCSANOW, &attr);
         });
 
         on<Startup>().then([this] {
@@ -140,9 +155,7 @@ namespace module::purpose {
         });
 
 
-        // Trigger when stdin has something to read
-        on<Always>().then([this] {
-            // Get the character the user has typed
+        on<IO>(STDIN_FILENO, IO::READ).then([this] {
             switch (getch()) {
                 case KEY_UP:  // Change selection up
                     selection = selection == 0 ? 19 : selection - 1;
@@ -203,7 +216,6 @@ namespace module::purpose {
                     powerplant.shutdown();
                     break;
             }
-
             // Update whatever visual changes we made
             refresh_view();
         });

--- a/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.cpp
+++ b/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <ranges>
 #include <sstream>
+#include <termios.h>
 
 #include "extension/Configuration.hpp"
 
@@ -51,6 +52,19 @@ namespace module::tools {
         on<Configuration>("RoboCupConfiguration.yaml").then([this](const Configuration& config) {
             // Use configuration here from file RoboCupConfiguration.yaml
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
+
+            // Set STDIN to non-blocking
+            int flags  = fcntl(STDIN_FILENO, F_GETFL, 0);
+            auto error = fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK);
+            if (error == -1) {
+                log<NUClear::ERROR>("Failed to set STDIN to non-blocking");
+            }
+
+            // Set up our terminal to not require EOF
+            struct termios attr;
+            tcgetattr(STDIN_FILENO, &attr);
+            attr.c_lflag &= ~(ICANON | ECHO);
+            tcsetattr(STDIN_FILENO, TCSANOW, &attr);
         });
 
         on<Startup>().then([this] {


### PR DESCRIPTION
This PR fixes a bug where ncurses menu freezes. The issue is something related to using `getch()` in combination with `on<IO>`. Setting up `STDIN` to non-blocking and not requiring an EOF  fixes the issue.