### PR TITLE
Temporary fix for robot crashing on startup

### DIFF
--- a/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
+++ b/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
@@ -95,7 +95,7 @@ namespace module::purpose {
             emit<Task>(std::make_unique<StartSafely>(), 4);
 
             // Stand Still on startup
-            emit<Task>(std::make_unique<StandStill>());
+            // emit<Task>(std::make_unique<StandStill>());
 
             // Ensure UTF-8 is enabled
             std::setlocale(LC_ALL, "en_US.UTF-8");


### PR DESCRIPTION
Emitting stand still on startup can cause seg fault which leads to robot falling over. Temporarily fix is provided by commenting this out