### PR TITLE
Add unwanted ball collision avoidance

### DIFF
--- a/module/strategy/WalkToBall/data/config/WalkToBall.yaml
+++ b/module/strategy/WalkToBall/data/config/WalkToBall.yaml
@@ -11,7 +11,7 @@ ball_y_offset: 0.0
 goal_target_offset: 0.5
 
 # Distance from ball to walk to if approaching from a "bad" position
-ball_approach_distance: 0.3
+ball_approach_distance: 0.35
 
 # Distance from ball to walk to if approaching from a "good" position
 ball_kick_distance: 0.0

--- a/module/strategy/WalkToBall/data/config/WalkToBall.yaml
+++ b/module/strategy/WalkToBall/data/config/WalkToBall.yaml
@@ -19,4 +19,4 @@ ball_kick_distance: 0.0
 # Maximum angle error which indicates that robot is approaching from a "bad position"
 max_angle_error: 45 * pi / 180
 
-avoid_ball_offset: [0.15, 0.5, 0]
+avoid_ball_offset: [0.25, 0.5, 0]

--- a/module/strategy/WalkToBall/data/config/WalkToBall.yaml
+++ b/module/strategy/WalkToBall/data/config/WalkToBall.yaml
@@ -18,3 +18,5 @@ ball_kick_distance: 0.0
 
 # Maximum angle error which indicates that robot is approaching from a "bad position"
 max_angle_error: 45 * pi / 180
+
+avoid_ball_offset: [0.15, 0.5, 0]

--- a/module/strategy/WalkToBall/data/config/webots/WalkToBall.yaml
+++ b/module/strategy/WalkToBall/data/config/webots/WalkToBall.yaml
@@ -18,3 +18,5 @@ ball_kick_distance: 0.0
 
 # Maximum angle error which indicates that robot is approaching from a "bad position"
 max_angle_error: 45 * pi / 180
+
+avoid_ball_offset: [0.15, 0.5, 0]

--- a/module/strategy/WalkToBall/src/WalkToBall.cpp
+++ b/module/strategy/WalkToBall/src/WalkToBall.cpp
@@ -173,17 +173,7 @@ namespace module::strategy {
 
                 emit<Task>(std::make_unique<WalkToFieldPosition>(Hfk));
             }
-            else {
-                // Move towards kick distance, where ball_approach_distance is scaled by angle error
-                // to ensure robot is facing the desired heading before reaching kick distance
-                rKFf = rBFf - uGBf * cfg.ball_kick_distance
-                       - uGBf * cfg.ball_approach_distance * angle_error_scaling_factor;
-            }
-
-            auto Hfk = pos_rpy_to_transform(rKFf, Eigen::Vector3d(0, 0, desired_heading));
-            emit<Task>(std::make_unique<WalkToFieldPosition>(Hfk));
-            }
-    });
-}
+        });
+    }
 
 }  // namespace module::strategy

--- a/module/strategy/WalkToBall/src/WalkToBall.hpp
+++ b/module/strategy/WalkToBall/src/WalkToBall.hpp
@@ -55,6 +55,10 @@ namespace module::strategy {
 
             /// @brief Maximum angle error to the ball before we need to walk to approach distance point
             double max_angle_error = 0.0;
+
+            /// @brief Offset from ball in field space to walk to when approaching the ball from in "front"
+            Eigen::Vector3d avoid_ball_offset = Eigen::Vector3d::Zero();
+
         } cfg;
 
         /// @brief The position of the goal {g} in field {f} space


### PR DESCRIPTION
This PR adds some additional path planning to `WalkToKickBall` to avoid colliding with ball when approaching from "in front"