### PR TITLE
Remove Idle Stand Still from RoboCup

### DIFF
--- a/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
+++ b/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
@@ -88,14 +88,11 @@ namespace module::purpose {
             emit(std::make_unique<Stability>(Stability::UNKNOWN));
             emit(std::make_unique<WalkState>(WalkState::State::STOPPED));
 
-            // The robot should always try to recover from falling, if applicable, regardless of purpose
-            emit<Task>(std::make_unique<FallRecovery>(), 5);
-
             // Start up safely with low gains
             emit<Task>(std::make_unique<StartSafely>(), 4);
 
-            // Stand Still on startup
-            // emit<Task>(std::make_unique<StandStill>());
+            // The robot should always try to recover from falling, if applicable, regardless of purpose
+            emit<Task>(std::make_unique<FallRecovery>(), 5);
 
             // Ensure UTF-8 is enabled
             std::setlocale(LC_ALL, "en_US.UTF-8");

--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -82,16 +82,14 @@ namespace module::purpose {
             // Without these emits, modules that need a Stability and WalkState messages may not run
             emit(std::make_unique<Stability>(Stability::UNKNOWN));
             emit(std::make_unique<WalkState>(WalkState::State::STOPPED));
-            // Idle stand if not doing anything
-            emit<Task>(std::make_unique<StandStill>());
             // Idle look forward if the head isn't doing anything else
             emit<Task>(std::make_unique<Look>(Eigen::Vector3d::UnitX(), true));
             // This emit starts the tree to play soccer
-            emit<Task>(std::make_unique<FindPurpose>(), 1);
+            emit<Task>(std::make_unique<FindPurpose>(), 0);
             // When starting, we want to safely move to the stand position
-            emit<Task>(std::make_unique<StartSafely>(), 2);
+            emit<Task>(std::make_unique<StartSafely>(), 1);
             // The robot should always try to recover from falling, if applicable, regardless of purpose
-            emit<Task>(std::make_unique<FallRecovery>(), 3);
+            emit<Task>(std::make_unique<FallRecovery>(), 2);
         });
 
         on<Provide<FindPurpose>, Every<BEHAVIOUR_UPDATE_RATE, Per<std::chrono::seconds>>>().then([this] {


### PR DESCRIPTION
and the commented out one in keyboardwalk.

I don't think it makes sense to have stand still and start safely as they are competing functionalities. If either of them run, it makes the other obsolete. The idle stand still in the background is only really useful for the start when nothing is telling the motors to move. After that, the motors are always going to be in some position. Stand still was added because in penalised state, the robot wouldn't stand if the binary was rerun, but start safely will do this instead. 