### PR TITLE
Align servo names in scripttuner for readability

### DIFF
--- a/module/purpose/ScriptTuner/src/ScriptTuner.cpp
+++ b/module/purpose/ScriptTuner/src/ScriptTuner.cpp
@@ -320,23 +320,23 @@ namespace module::purpose {
         const char* MOTOR_NAMES[] = {"Head Pan",
                                      "Head Tilt",
                                      "Right Shoulder Pitch",
-                                     "Left Shoulder Pitch",
+                                     "Left  Shoulder Pitch",
                                      "Right Shoulder Roll",
-                                     "Left Shoulder Roll",
+                                     "Left  Shoulder Roll",
                                      "Right Elbow",
-                                     "Left Elbow",
+                                     "Left  Elbow",
                                      "Right Hip Yaw",
-                                     "Left Hip Yaw",
+                                     "Left  Hip Yaw",
                                      "Right Hip Roll",
-                                     "Left Hip Roll",
+                                     "Left  Hip Roll",
                                      "Right Hip Pitch",
-                                     "Left Hip Pitch",
+                                     "Left  Hip Pitch",
                                      "Right Knee",
-                                     "Left Knee",
+                                     "Left  Knee",
                                      "Right Ankle Pitch",
-                                     "Left Ankle Pitch",
+                                     "Left  Ankle Pitch",
                                      "Right Ankle Roll",
-                                     "Left Ankle Roll"};
+                                     "Left  Ankle Roll"};
 
         // Loop through all our motors
         for (size_t i = 0; i < 20; ++i) {
@@ -1004,7 +1004,7 @@ namespace module::purpose {
                     }  // end KEY_ENTER else
                     mvchgat(YPOSITION[i][j], XPOSITION[i][j], 5, A_STANDOUT, 0, nullptr);
                     break;  // end case KEY_ENTER
-            }               // switch
+            }  // switch
 
         }  // while
 

--- a/module/purpose/ScriptTuner/src/ScriptTuner.cpp
+++ b/module/purpose/ScriptTuner/src/ScriptTuner.cpp
@@ -1004,7 +1004,7 @@ namespace module::purpose {
                     }  // end KEY_ENTER else
                     mvchgat(YPOSITION[i][j], XPOSITION[i][j], 5, A_STANDOUT, 0, nullptr);
                     break;  // end case KEY_ENTER
-            }  // switch
+            }               // switch
 
         }  // while
 


### PR DESCRIPTION
Adds an additional space after `Left` so that left and right servos have their names aligned :)

![image](https://github.com/NUbots/NUbots/assets/15846679/8d1ed2f6-e9b4-46ca-b7f6-30bb04b711d6)
