### PR TITLE
Revert scripttuner bug fix and use on<Always> instead

### DIFF
--- a/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
+++ b/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
@@ -66,19 +66,6 @@ namespace module::purpose {
         on<Configuration>("KeyboardWalk.yaml").then([this](const Configuration& config) {
             // Use configuration here from file KeyboardWalk.yaml
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
-
-            // Set STDIN to non-blocking
-            int flags  = fcntl(STDIN_FILENO, F_GETFL, 0);
-            auto error = fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK);
-            if (error == -1) {
-                log<NUClear::ERROR>("Failed to set STDIN to non-blocking");
-            }
-
-            // Set up our terminal to not require EOF
-            struct termios attr;
-            tcgetattr(STDIN_FILENO, &attr);
-            attr.c_lflag &= ~(ICANON | ECHO);
-            tcsetattr(STDIN_FILENO, TCSANOW, &attr);
         });
 
         // Start the Director graph for the KeyboardWalk.

--- a/module/purpose/ScriptTuner/src/ScriptTuner.cpp
+++ b/module/purpose/ScriptTuner/src/ScriptTuner.cpp
@@ -84,19 +84,6 @@ namespace module::purpose {
         on<Configuration>("ScriptTuner.yaml").then([this](const Configuration& config) {
             // Use configuration here from file KeyboardWalk.yaml
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
-
-            // Set STDIN to non-blocking
-            int flags  = fcntl(STDIN_FILENO, F_GETFL, 0);
-            auto error = fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK);
-            if (error == -1) {
-                log<NUClear::ERROR>("Failed to set STDIN to non-blocking");
-            }
-
-            // Set up our terminal to not require EOF
-            struct termios attr;
-            tcgetattr(STDIN_FILENO, &attr);
-            attr.c_lflag &= ~(ICANON | ECHO);
-            tcsetattr(STDIN_FILENO, TCSANOW, &attr);
         });
 
         on<Startup>().then([this] {
@@ -155,7 +142,7 @@ namespace module::purpose {
         });
 
 
-        on<IO>(STDIN_FILENO, IO::READ).then([this] {
+        on<Always>().then([this] {
             switch (getch()) {
                 case KEY_UP:  // Change selection up
                     selection = selection == 0 ? 19 : selection - 1;

--- a/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.cpp
+++ b/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.cpp
@@ -52,19 +52,6 @@ namespace module::tools {
         on<Configuration>("RoboCupConfiguration.yaml").then([this](const Configuration& config) {
             // Use configuration here from file RoboCupConfiguration.yaml
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
-
-            // Set STDIN to non-blocking
-            int flags  = fcntl(STDIN_FILENO, F_GETFL, 0);
-            auto error = fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK);
-            if (error == -1) {
-                log<NUClear::ERROR>("Failed to set STDIN to non-blocking");
-            }
-
-            // Set up our terminal to not require EOF
-            struct termios attr;
-            tcgetattr(STDIN_FILENO, &attr);
-            attr.c_lflag &= ~(ICANON | ECHO);
-            tcsetattr(STDIN_FILENO, TCSANOW, &attr);
         });
 
         on<Startup>().then([this] {


### PR DESCRIPTION
Recent PR which fixed ncurses freezing has introduced bugs. This PR reverts changes made and just uses ` on<Always>` for scripttuner main thread which fixes the freezing issue.