### PR TITLE
OpenCR buzzer fixes

### DIFF
--- a/module/platform/OpenCR/HardwareIO/data/config/HardwareIO.yaml
+++ b/module/platform/OpenCR/HardwareIO/data/config/HardwareIO.yaml
@@ -98,4 +98,4 @@ servos:
 alarms:
   temperature:
     level: 60
-    buzzer_frequency: 880 # Hz
+    buzzer_frequency: 2666 # Hz

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -347,8 +347,10 @@ namespace module::platform::OpenCR {
         });
 
         on<Trigger<Buzzer>>().then([this](const Buzzer& buzzer_msg) {
+            log<NUClear::DEBUG>("Received Buzzer message");
             // Fill the necessary field within the opencr_state struct
             opencr_state.buzzer = buzzer_msg.frequency;
+            opencr_state.dirty  = true;
         });
     }
 

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
@@ -164,6 +164,9 @@ namespace module::platform::OpenCR {
         // A servo is defined to be hot if the detected temperature exceeds the maximum tolerance in the configuration
         for (const auto& servo : servo_states) {
             if (servo.temperature > cfg.alarms.temperature.level) {
+                log<NUClear::WARN>("Alarm triggered: Servo ID {} ({}) is hot! (Later servos may also be hot)",
+                                   packet.id,
+                                   nugus.device_name(static_cast<NUgus::ID>(packet.id)));
                 emit(std::make_unique<Buzzer>(cfg.alarms.temperature.buzzer_frequency));
                 break;
             }

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
@@ -170,10 +170,6 @@ namespace module::platform::OpenCR {
             }
         }
 
-        if (!any_servo_hot) {
-            emit(std::make_unique<Buzzer>(0));
-        }
-
         // If this servo has not been initialised yet, set the goal states to the current states
         if (!servo_states[servo_index].initialised) {
             servo_states[servo_index].goal_position = servo_states[servo_index].present_position;

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/process_data.cpp
@@ -159,12 +159,11 @@ namespace module::platform::OpenCR {
         servo_states[servo_index].voltage     = convert::voltage(data.present_voltage);
         servo_states[servo_index].temperature = convert::temperature(data.present_temperature);
 
-        // Buzz if any servo is hot, use the boolean flag to turn the buzzer off once the servo is no longer hot
+        // Buzz if any servo is hot, forever, until power is turned off.
+        // Middle button can be used to disable alarm once no servos are hot, if a power cycle is not desired.
         // A servo is defined to be hot if the detected temperature exceeds the maximum tolerance in the configuration
-        bool any_servo_hot = false;
         for (const auto& servo : servo_states) {
             if (servo.temperature > cfg.alarms.temperature.level) {
-                any_servo_hot = true;
                 emit(std::make_unique<Buzzer>(cfg.alarms.temperature.buzzer_frequency));
                 break;
             }

--- a/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
+++ b/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
@@ -78,7 +78,6 @@ namespace module::purpose {
         on<Trigger<ButtonMiddleDown>, Single>().then([this] {
             emit<Scope::DIRECT>(std::make_unique<ResetFieldLocalisation>());
             emit<Scope::DIRECT>(std::make_unique<Buzzer>(1000));
-            log<NUClear::DEBUG>("Bzzzzzzzzzzz resetting field localisation.");
         });
 
         on<Trigger<ButtonMiddleUp>, Single>().then([this] { emit<Scope::DIRECT>(std::make_unique<Buzzer>(0)); });

--- a/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
+++ b/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
@@ -78,6 +78,7 @@ namespace module::purpose {
         on<Trigger<ButtonMiddleDown>, Single>().then([this] {
             emit<Scope::DIRECT>(std::make_unique<ResetFieldLocalisation>());
             emit<Scope::DIRECT>(std::make_unique<Buzzer>(1000));
+            log<NUClear::DEBUG>("Bzzzzzzzzzzz resetting field localisation.");
         });
 
         on<Trigger<ButtonMiddleUp>, Single>().then([this] { emit<Scope::DIRECT>(std::make_unique<Buzzer>(0)); });


### PR DESCRIPTION
This PR:
 - Fixes issues which were breaking buzzer functionality
   - Not setting the dirty flag on `opencr_state`
   - Emitting `Buzzer` 0's when servos are not hot (which cancelled out with other buzzer emits).
- Makes the temperature alarm frequency more annoying.
- Adds `WARN` logging when temperature alarm is enabled, and `DEBUG` logging for any buzzer message.

These fixes implement the buzzer functionality for #1393 