### PR TITLE
Add logic for whether to approach ball in kickoff 

### DIFF
--- a/module/purpose/Striker/data/config/Striker.yaml
+++ b/module/purpose/Striker/data/config/Striker.yaml
@@ -3,3 +3,7 @@ log_level: INFO
 
 # Position on field to walk to (x,y,theta)
 ready_position: [1.5, 0, -3.14]
+
+# How far (m) the ball can be away from the centre of the field for it to be deemed as
+# .moved/touched by the other team during kickoff so we can start playing
+ball_kickoff_outside_radius: 1.0

--- a/module/purpose/Striker/src/Striker.cpp
+++ b/module/purpose/Striker/src/Striker.cpp
@@ -142,14 +142,12 @@ namespace module::purpose {
                         play();
                         return;
                     }
-                    log<NUClear::INFO>("Waiting for kickoff.");
                     // Walk to ready so we are ready to play when kickoff finishes
                     emit<Task>(std::make_unique<WalkToFieldPosition>(
                         pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
                                              Eigen::Vector3d(0, 0, cfg.ready_position.z()))));
                     return;
                 }
-                log<NUClear::INFO>("Playing.");
                 play();
             });
 

--- a/module/purpose/Striker/src/Striker.cpp
+++ b/module/purpose/Striker/src/Striker.cpp
@@ -118,7 +118,20 @@ namespace module::purpose {
         });
 
         // Normal PLAYING state
-        on<Provide<NormalStriker>, When<Phase, std::equal_to, Phase::PLAYING>>().then([this] { play(); });
+        on<Provide<NormalStriker>, When<Phase, std::equal_to, Phase::PLAYING>, With<GameState>>().then(
+            [this](const GameState& game_state) {
+                // If it's not our kickoff and timer is going, stand still
+                // The secondary timer will only happen for kickoff here
+                log<NUClear::INFO>(game_state.data.our_kick_off,
+                                   (game_state.data.secondary_time - NUClear::clock::now()).count());
+                if (!game_state.data.our_kick_off
+                    && (game_state.data.secondary_time - NUClear::clock::now()).count() > 0) {
+                    emit<Task>(std::make_unique<StandStill>());
+                }
+                else {
+                    play();
+                }
+            });
 
         // Normal UNKNOWN state
         on<Provide<NormalStriker>, When<Phase, std::equal_to, Phase::UNKNOWN_PHASE>>().then(

--- a/module/purpose/Striker/src/Striker.cpp
+++ b/module/purpose/Striker/src/Striker.cpp
@@ -138,7 +138,6 @@ namespace module::purpose {
                     // Check if the ball has moved, if so start playing
                     if (ball != nullptr && field != nullptr
                         && (field->Hfw * ball->rBWw).norm() > cfg.ball_kickoff_outside_radius) {
-                        log<NUClear::INFO>("Ball has moved, starting to play.");
                         play();
                         return;
                     }

--- a/module/purpose/Striker/src/Striker.cpp
+++ b/module/purpose/Striker/src/Striker.cpp
@@ -30,6 +30,8 @@
 #include "extension/Configuration.hpp"
 
 #include "message/input/GameState.hpp"
+#include "message/localisation/Ball.hpp"
+#include "message/localisation/Field.hpp"
 #include "message/planning/KickTo.hpp"
 #include "message/purpose/Striker.hpp"
 #include "message/strategy/AlignBallToGoal.hpp"
@@ -50,6 +52,8 @@ namespace module::purpose {
     using Phase    = message::input::GameState::Data::Phase;
     using GameMode = message::input::GameState::Data::Mode;
     using message::input::GameState;
+    using message::localisation::Ball;
+    using message::localisation::Field;
     using message::planning::KickTo;
     using message::purpose::CornerKickStriker;
     using message::purpose::DirectFreeKickStriker;
@@ -78,8 +82,9 @@ namespace module::purpose {
 
         on<Configuration>("Striker.yaml").then([this](const Configuration& config) {
             // Use configuration here from file Striker.yaml
-            this->log_level    = config["log_level"].as<NUClear::LogLevel>();
-            cfg.ready_position = config["ready_position"].as<Expression>();
+            this->log_level                 = config["log_level"].as<NUClear::LogLevel>();
+            cfg.ready_position              = config["ready_position"].as<Expression>();
+            cfg.ball_kickoff_outside_radius = config["ball_kickoff_outside_radius"].as<double>();
         });
 
         on<Provide<StrikerTask>, Optional<Trigger<GameState>>>().then(
@@ -118,19 +123,34 @@ namespace module::purpose {
         });
 
         // Normal PLAYING state
-        on<Provide<NormalStriker>, When<Phase, std::equal_to, Phase::PLAYING>, With<GameState>>().then(
-            [this](const GameState& game_state) {
+        on<Provide<NormalStriker>,
+           When<Phase, std::equal_to, Phase::PLAYING>,
+           With<GameState>,
+           Optional<With<Ball>>,
+           Optional<With<Field>>>()
+            .then([this](const GameState& game_state,
+                         const std::shared_ptr<const Ball>& ball,
+                         const std::shared_ptr<const Field>& field) {
                 // If it's not our kickoff and timer is going, stand still
                 // The secondary timer will only happen for kickoff here
-                log<NUClear::INFO>(game_state.data.our_kick_off,
-                                   (game_state.data.secondary_time - NUClear::clock::now()).count());
                 if (!game_state.data.our_kick_off
                     && (game_state.data.secondary_time - NUClear::clock::now()).count() > 0) {
-                    emit<Task>(std::make_unique<StandStill>());
+                    // Check if the ball has moved, if so start playing
+                    if (ball != nullptr && field != nullptr
+                        && (field->Hfw * ball->rBWw).norm() > cfg.ball_kickoff_outside_radius) {
+                        log<NUClear::INFO>("Ball has moved, starting to play.");
+                        play();
+                        return;
+                    }
+                    log<NUClear::INFO>("Waiting for kickoff.");
+                    // Walk to ready so we are ready to play when kickoff finishes
+                    emit<Task>(std::make_unique<WalkToFieldPosition>(
+                        pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
+                                             Eigen::Vector3d(0, 0, cfg.ready_position.z()))));
+                    return;
                 }
-                else {
-                    play();
-                }
+                log<NUClear::INFO>("Playing.");
+                play();
             });
 
         // Normal UNKNOWN state

--- a/module/purpose/Striker/src/Striker.hpp
+++ b/module/purpose/Striker/src/Striker.hpp
@@ -44,6 +44,9 @@ namespace module::purpose {
         struct Config {
             /// @brief Ready position to walk to (x, y, theta)
             Eigen::Vector3f ready_position = Eigen::Vector3f::Zero();
+            /// @brief How far (m) the ball can be away from the centre of the field for it to be deemed as
+            /// moved/touched by the other team during kickoff so we can start playing
+            double ball_kickoff_outside_radius = 0.0;
         } cfg;
 
 


### PR DESCRIPTION
In kickoff, we now keep walking to the ready position if it's the opponent's kickoff. If the ball moves enough away from the center of the field, we assume they have touched the ball and we can play.

Secondary time is used to determine if kickoff time is finished as this time shouldn't be used for anything else unless it's in a mode like direct free kick etc, but in that case we'd be in a different Provider and it wouldn't matter. 

Kickoff applies not just to the start of a half, but also whenever a robot scores a goal. These cases were all tested in Webots. 

The distance for the ball to move to assume kickoff is over seems to be large in webots so hopefully is okay even if localisation has a bit of error.

Only applies to Striker as the others wouldn't attempt to touch the ball in this position.