### PR TITLE
Remove reseting mahony filter when resetting localisation

### DIFF
--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -131,9 +131,6 @@ namespace module::input {
             });
 
         on<Trigger<ResetFieldLocalisation>>().then([this] {
-            // Reset the mahony filter
-            mahony_filter.set_state(cfg.initial_Rwt);
-
             // Reset anchor frame
             Hwp                   = Eigen::Isometry3d::Identity();
             Hwp.translation().y() = tinyrobotics::forward_kinematics<double, n_servos>(nugus_model,


### PR DESCRIPTION
This PR removes resetting the mahony filter when resetting localisation so roll and pitch are still accurate.