### PR TITLE
Remove Single to fix buttons when running robocup

### DIFF
--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -124,7 +124,7 @@ namespace module::input {
                 emit(std::move(sensors));
             });
 
-        on<Last<20, Trigger<RawSensors>>, Single>().then(
+        on<Last<20, Trigger<RawSensors>>>().then(
             [this](const std::list<std::shared_ptr<const RawSensors>>& raw_sensors) {
                 // Detect wether a button has been pressed or not in the last 20 messages
                 detect_button_press(raw_sensors);

--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -130,16 +130,16 @@ namespace module::purpose {
         });
 
         // Left button pauses the soccer scenario
-        on<Trigger<ButtonLeftDown>, Single>().then([this] {
+        on<Trigger<ButtonLeftDown>>().then([this] {
             emit<Scope::DIRECT>(std::make_unique<ResetFieldLocalisation>());
             emit<Scope::DIRECT>(std::make_unique<EnableIdle>());
             emit<Scope::DIRECT>(std::make_unique<Buzzer>(1000));
             idle = true;
         });
 
-        on<Trigger<ButtonLeftUp>, Single>().then([this] { emit<Scope::DIRECT>(std::make_unique<Buzzer>(0)); });
+        on<Trigger<ButtonLeftUp>>().then([this] { emit<Scope::DIRECT>(std::make_unique<Buzzer>(0)); });
 
-        on<Trigger<EnableIdle>, Single>().then([this] {
+        on<Trigger<EnableIdle>>().then([this] {
             // Stop all tasks and stand still
             emit<Task>(std::unique_ptr<FindPurpose>(nullptr));
             emit(std::make_unique<Stability>(Stability::UNKNOWN));
@@ -148,7 +148,7 @@ namespace module::purpose {
         });
 
         // Middle button resumes the soccer scenario
-        on<Trigger<ButtonMiddleDown>, Single>().then([this] {
+        on<Trigger<ButtonMiddleDown>>().then([this] {
             emit<Scope::DIRECT>(std::make_unique<ResetFieldLocalisation>());
             // Restart the Director graph for the soccer scenario after a delay
             emit<Scope::DELAY>(std::make_unique<DisableIdle>(), std::chrono::seconds(cfg.disable_idle_delay));
@@ -156,7 +156,7 @@ namespace module::purpose {
             idle = false;
         });
 
-        on<Trigger<ButtonMiddleUp>, Single>().then([this] { emit<Scope::DIRECT>(std::make_unique<Buzzer>(0)); });
+        on<Trigger<ButtonMiddleUp>>().then([this] { emit<Scope::DIRECT>(std::make_unique<Buzzer>(0)); });
 
         on<Trigger<DisableIdle>, Single>().then([this] {
             // If the robot is not idle, restart the Director graph for the soccer scenario!


### PR DESCRIPTION
Button presses were getting skipped due to Single in each button trigger. Removing single seems to have fixed the issue.