### PR TITLE
Cleanup watchdog creation into functions

### DIFF
--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.cpp
@@ -56,79 +56,7 @@ namespace module::platform::OpenCR {
     HardwareIO::HardwareIO(std::unique_ptr<NUClear::Environment> environment)
         : Reactor(std::move(environment)), opencr(), nugus(), byte_wait(0), packet_wait(0), packet_queue() {
 
-
-        packet_watchdog =
-            on<Watchdog<PacketWatchdog, 20, std::chrono::milliseconds>, Sync<PacketWatchdog>>()
-                .then([this] {
-                    // This is a hacky fix because the watchdog is not disabled quickly enough at the beginning. This
-                    // may be related to the out of order packets with Sync within NUClear. This should be fixed in a
-                    // later version of NUClear.
-                    if (model_watchdog.enabled()) {
-                        log<NUClear::WARN>(
-                            "Packet watchdog cannot be enabled while model watchdog is enabled. You may see this "
-                            "warning at the start of the program. This is expected as the watchdog reaction may still "
-                            "be disabling.");
-                        packet_watchdog.disable();
-                        return;
-                    }
-
-                    // Check what the hangup was
-
-                    int num_packets_dropped        = 0;                 // keep track of how many we dropped
-                    NUgus::ID first_dropped_packet = NUgus::ID::NO_ID;  // keep track in case we have a chain
-
-                    // The result of the assignment is 0 (NUgus::ID::NO_ID) if we aren't waiting on
-                    // any packets, otherwise is the nonzero ID of the timed out device
-                    for (NUgus::ID dropout_id; (dropout_id = queue_item_waiting()) != NUgus::ID::NO_ID;) {
-
-                        // Delete the packet we're waiting on
-                        packet_queue[dropout_id].erase(packet_queue[dropout_id].begin());
-
-                        // notify with ID and servo name
-                        log<NUClear::WARN>(fmt::format("Dropped packet from ID {} ({})",
-                                                       int(dropout_id),
-                                                       nugus.device_name(dropout_id)));
-
-                        // if this is the first packet, set our flag
-                        if (num_packets_dropped == 0) {
-                            first_dropped_packet = dropout_id;
-                        }
-
-                        // increment our counter
-                        num_packets_dropped++;
-                    }
-
-                    // if this is the first packet then send a warning
-                    if (num_packets_dropped > 1) {
-                        log<NUClear::WARN>(
-                            fmt::format("NOTE: A dropped response packet by a dynamixel device in a SYNC READ/WRITE "
-                                        "chain will cause all later packets (of higher ID) to be dropped. Consider "
-                                        "checking cables for ID {} ({})",
-                                        int(first_dropped_packet),
-                                        nugus.device_name(first_dropped_packet)));
-                    }
-
-                    // Send a request for all servo packets, only if there were packets dropped
-                    // In case the system stops for some other reason, we don't want the watchdog
-                    // to make it automatically restart
-                    if (num_packets_dropped > 0) {
-                        log<NUClear::WARN>("Requesting servo packets to restart system");
-                        send_servo_request();
-                    }
-                })
-                .disable();
-
-        model_watchdog =
-            on<Watchdog<ModelWatchdog, 500, std::chrono::milliseconds>, Sync<ModelWatchdog>>()
-                .then([this] {
-                    log<NUClear::WARN>(fmt::format("OpenCR model information not received, restarting system"));
-                    // Clear all packet queues just in case
-                    queue_clear_all();
-                    // Restart the system and exit the watchdog
-                    startup();
-                    return;
-                })
-                .enable();
+        model_watchdog = create_model_watchdog();
 
         on<Configuration>("HardwareIO.yaml").then([this](const Configuration& config) {
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
@@ -169,7 +97,6 @@ namespace module::platform::OpenCR {
             // The model watchdog is started, which has a longer time than the packet watchdog
             // The packet watchdog is disabled until we start the main loop
             model_watchdog.enable();
-            packet_watchdog.disable();
 
             // The startup function sets up the subcontroller state
             startup();
@@ -284,7 +211,10 @@ namespace module::platform::OpenCR {
                         // Start the packet watchdog since the main loop is now starting
                         model_watchdog.disable();
                         model_watchdog.unbind();
-                        log<NUClear::WARN>("Packet watchdog enabled");
+
+                        log<NUClear::INFO>("Packet watchdog enabled");
+
+                        packet_watchdog = create_packet_watchdog();
                         packet_watchdog.enable();
 
                         // At the start, we want to query the motors so we can store their state internally

--- a/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
+++ b/module/platform/OpenCR/HardwareIO/src/HardwareIO.hpp
@@ -241,6 +241,14 @@ namespace module::platform::OpenCR {
         /// @returns the number of packets cleared
         int queue_clear_all();
 
+        /// @brief Creates the model watchdog thread
+        /// @return NUClear::threading::ReactionHandle object
+        ReactionHandle create_model_watchdog();
+
+        /// @brief Creates the packet watchdog thread
+        /// @return NUClear::threading::ReactionHandle object
+        ReactionHandle create_packet_watchdog();
+
         struct PacketWatchdog {};
         struct ModelWatchdog {};
 

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/create_watchdogs.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/create_watchdogs.cpp
@@ -1,0 +1,102 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "HardwareIO.hpp"
+#include <fmt/format.h>
+
+namespace module::platform::OpenCR {
+
+    NUClear::threading::ReactionHandle HardwareIO::create_model_watchdog() {
+        return on<Watchdog<ModelWatchdog, 500, std::chrono::milliseconds>, Sync<ModelWatchdog>>().then([this] {
+            log<NUClear::WARN>(fmt::format("OpenCR model information not received, restarting system"));
+            // Clear all packet queues just in case
+            queue_clear_all();
+            // Restart the system and exit the watchdog
+            startup();
+            return;
+        });
+    }
+
+    NUClear::threading::ReactionHandle HardwareIO::create_packet_watchdog() {
+        return on<Watchdog<PacketWatchdog, 20, std::chrono::milliseconds>, Sync<PacketWatchdog>>().then([this] {
+            // This is a hacky fix because the watchdog is not disabled quickly enough at the beginning.
+            // This may be related to the out of order packets with Sync within NUClear. This should be
+            // fixed in a later version of NUClear.
+            if (model_watchdog.enabled()) {
+                log<NUClear::WARN>(
+                    "Packet watchdog cannot be enabled while model watchdog is enabled. You may see this "
+                    "warning at the start of the program. This is expected as the watchdog reaction may "
+                    "still be disabling.");
+                packet_watchdog.disable();
+                return;
+            }
+
+            // Check what the hangup was
+
+            int num_packets_dropped        = 0;                 // keep track of how many we dropped
+            NUgus::ID first_dropped_packet = NUgus::ID::NO_ID;  // keep track in case we have a chain
+
+            // The result of the assignment is 0 (NUgus::ID::NO_ID) if we aren't waiting on
+            // any packets, otherwise is the nonzero ID of the timed out device
+            for (NUgus::ID dropout_id; (dropout_id = queue_item_waiting()) != NUgus::ID::NO_ID;) {
+
+                // Delete the packet we're waiting on
+                packet_queue[dropout_id].erase(packet_queue[dropout_id].begin());
+
+                // notify with ID and servo name
+                log<NUClear::WARN>(
+                    fmt::format("Dropped packet from ID {} ({})", int(dropout_id), nugus.device_name(dropout_id)));
+
+                // if this is the first packet, set our flag
+                if (num_packets_dropped == 0) {
+                    first_dropped_packet = dropout_id;
+                }
+
+                // increment our counter
+                num_packets_dropped++;
+            }
+
+            // if this is the first packet then send a warning
+            if (num_packets_dropped > 1) {
+                log<NUClear::WARN>(
+                    fmt::format("NOTE: A dropped response packet by a dynamixel device in a SYNC READ/WRITE "
+                                "chain will cause all later packets (of higher ID) to be dropped. Consider "
+                                "checking cables for ID {} ({})",
+                                int(first_dropped_packet),
+                                nugus.device_name(first_dropped_packet)));
+            }
+
+            // Send a request for all servo packets, only if there were packets dropped
+            // In case the system stops for some other reason, we don't want the watchdog
+            // to make it automatically restart
+            if (num_packets_dropped > 0) {
+                log<NUClear::WARN>("Requesting servo packets to restart system");
+                send_servo_request();
+            }
+        });
+    }
+
+}  // namespace module::platform::OpenCR

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/create_watchdogs.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/create_watchdogs.cpp
@@ -24,8 +24,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "HardwareIO.hpp"
 #include <fmt/format.h>
+
+#include "HardwareIO.hpp"
 
 namespace module::platform::OpenCR {
 

--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/startup.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/startup.cpp
@@ -29,9 +29,6 @@
 namespace module::platform::OpenCR {
 
     void HardwareIO::startup() {
-        // first, disable the packet watchdog as we haven't sent anything yet and don't want it to trigger
-        packet_watchdog.disable();
-
         // Set the OpenCR to not return a status packet when written to (to allow consecutive writes)
         opencr.write(dynamixel::v2::WriteCommand<uint8_t>(uint8_t(NUgus::ID::OPENCR),
                                                           uint16_t(OpenCR::Address::STATUS_RETURN_LEVEL),
@@ -166,9 +163,6 @@ namespace module::platform::OpenCR {
         for (auto& servo_state : servo_states) {
             servo_state.initialised = false;
         }
-
-        // Now, enable the packet watchdog before we send anything.
-        packet_watchdog.enable();
 
         // Find OpenCR firmware and model versions
         // This has to be called last, as we need to wait for the response packet before starting


### PR DESCRIPTION
Splits out watchdog refactors (not incl uart flush) from #1441 