### PR TITLE
Fix bug in walk engine

### DIFF
--- a/shared/utility/skill/WalkGenerator.hpp
+++ b/shared/utility/skill/WalkGenerator.hpp
@@ -247,7 +247,7 @@ namespace utility::skill {
                     break;
                 case WalkState::State::STOPPED:
                     // We do not update the time here because we want to remain in the stopped state
-                    generate_walking_trajectories(velocity_target);
+                    reset();
                     break;
                 default: NUClear::log<NUClear::WARN>("Unknown state", engine_state.value);
             }


### PR DESCRIPTION
When entering the `STOPPED` state the `Hps` transform is not updated. This breaks the first trajectory generated after leaving the stopped state. This PR fixes this bug by resetting the walk engine when in the stopped state, essentially, setting everything to their default initial state.