### PR TITLE
fix buttons not working when battery voltage is low

### DIFF
--- a/module/platform/OpenCR/HardwareIO/src/hardwareio/construct_sensors.cpp
+++ b/module/platform/OpenCR/HardwareIO/src/hardwareio/construct_sensors.cpp
@@ -106,9 +106,6 @@ namespace module::platform::OpenCR {
                 // Error code
                 servo.hardware_error = servo_states[i].hardware_error;
 
-                // Accumulate all packet error flags to read at once
-                sensors.subcontroller_error |= servo_states[i].packet_error;
-
                 // Present Data
                 servo.present_position = servo_states[i].present_position;
                 servo.present_velocity = servo_states[i].present_velocity;


### PR DESCRIPTION
Duplicate of #1458 but for `main` instead of `robocup`.


subcontroller_error masked in all dynamixel packet errors from all devices. this was done before masking out the alert bit for battery voltage errors, which meant that we had a nonzero subcontroller_error if the battery was fresh (because servos would report a voltage error).

then button debouncing ignored buttons when we had a subcontroller error, causing the problem.

we now keep the subcontroller error check, but don't consider servo errors as subcontroller errors anymore. which is better.
