### PR TITLE
Update RoboCup Field SSIDs

### DIFF
--- a/module/tools/RoboCupConfiguration/data/config/RoboCupConfiguration.yaml
+++ b/module/tools/RoboCupConfiguration/data/config/RoboCupConfiguration.yaml
@@ -3,9 +3,9 @@ log_level: INFO
 
 # Map of ssid and passwords that are possible
 wifi_networks:
-  A_HUMANOID: "rc2024humanoid"
-  B_HUMANOID: "rc2024humanoid"
-  C_HUMANOID: "rc2024humanoid"
-  D_HUMANOID: "rc2024humanoid"
+  Humanoid_A: "rc2024humanoid"
+  Humanoid_B: "rc2024humanoid"
+  Humanoid_C: "rc2024humanoid"
+  Humanoid_D: "rc2024humanoid"
 
 common_ips: ["10.1.1.X", "192.168.1.X", "192.168.31.X", "192.168.32.X"]


### PR DESCRIPTION
They ended up using a different one to the one we were told. This fixes the config so it has the right SSIDs for the RroboCup fields.