### PR TITLE
Make walk related modules high priority

### DIFF
--- a/module/actuation/FootController/src/FootController.cpp
+++ b/module/actuation/FootController/src/FootController.cpp
@@ -62,7 +62,7 @@ namespace module::actuation {
         });
 
 
-        on<Provide<ControlLeftFoot>, With<Sensors>, Needs<LeftLegIK>>().then(
+        on<Provide<ControlLeftFoot>, With<Sensors>, Needs<LeftLegIK>, Priority::HIGH>().then(
             [this](const ControlLeftFoot& left_foot, const Sensors& sensors) {
                 auto left_leg = std::make_unique<LeftLegIK>();
 
@@ -72,7 +72,7 @@ namespace module::actuation {
                 emit<Task>(left_leg, 0, false, "Control left foot");
             });
 
-        on<Provide<ControlRightFoot>, With<Sensors>, Needs<RightLegIK>>().then(
+        on<Provide<ControlRightFoot>, With<Sensors>, Needs<RightLegIK>, Priority::HIGH>().then(
             [this](const ControlRightFoot& right_foot, const Sensors& sensors) {
                 auto right_leg = std::make_unique<RightLegIK>();
 

--- a/module/actuation/Kinematics/src/Kinematics.cpp
+++ b/module/actuation/Kinematics/src/Kinematics.cpp
@@ -87,7 +87,7 @@ namespace module::actuation {
         });
 
         /// @brief Calculates left leg kinematics and makes a task for the LeftLeg servos
-        on<Provide<LeftLegIK>, With<KinematicsModel>, Needs<LeftLeg>>().then(
+        on<Provide<LeftLegIK>, With<KinematicsModel>, Needs<LeftLeg>, Priority::HIGH>().then(
             [this](const LeftLegIK& leg_ik, const RunInfo& info, const KinematicsModel& kinematics_model) {
                 // If the leg is done moving, then IK is done
                 if (info.run_reason == RunInfo::RunReason::SUBTASK_DONE) {
@@ -129,7 +129,7 @@ namespace module::actuation {
             });
 
         /// @brief Calculates right leg kinematics and makes a task for the RightLeg servos
-        on<Provide<RightLegIK>, With<KinematicsModel>, Needs<RightLeg>>().then(
+        on<Provide<RightLegIK>, With<KinematicsModel>, Needs<RightLeg>, Priority::HIGH>().then(
             [this](const RightLegIK& leg_ik, const RunInfo& info, const KinematicsModel& kinematics_model) {
                 // If the leg is done moving, then IK is done
                 if (info.run_reason == RunInfo::RunReason::SUBTASK_DONE) {

--- a/module/actuation/Servos/src/Servos.hpp
+++ b/module/actuation/Servos/src/Servos.hpp
@@ -51,7 +51,7 @@ namespace module::actuation {
         // TODO(ysims): add capability to be Done when the servo reaches the target position
         template <typename Servo, ServoID::Value ID>
         void add_servo_provider() {
-            on<Provide<Servo>, Every<90, Per<std::chrono::seconds>>>().then(
+            on<Provide<Servo>, Every<90, Per<std::chrono::seconds>>, Priority::HIGH>().then(
                 [this](const Servo& servo, const RunInfo& info) {
                     if (info.run_reason == RunInfo::RunReason::NEW_TASK) {
                         if (log_level <= NUClear::DEBUG) {
@@ -80,7 +80,7 @@ namespace module::actuation {
         /// @tparam Elements is a template pack of Servos that Group uses
         template <typename Group, typename... Elements>
         void add_group_provider() {
-            on<Provide<Group>, Needs<Elements>...>().then(
+            on<Provide<Group>, Needs<Elements>..., Priority::HIGH>().then(
                 [this](const Group& group, const RunInfo& info, const Uses<Elements>... elements) {
                     // Check if any subtask is Done
                     if (info.run_reason == RunInfo::RunReason::SUBTASK_DONE) {
@@ -132,7 +132,7 @@ namespace module::actuation {
             // Make an initial count message
             emit<Scope::DIRECT>(std::make_unique<Count<Sequence>>(0));
 
-            on<Provide<Sequence>, Needs<Group>, With<Count<Sequence>>>().then(
+            on<Provide<Sequence>, Needs<Group>, With<Count<Sequence>>, Priority::HIGH>().then(
                 [this](const Sequence& sequence, const RunInfo& info, const Count<Sequence>& count) {
                     // If the user gave us nothing then we are done
                     if (sequence.frames.empty()) {

--- a/module/skill/Walk/src/Walk.cpp
+++ b/module/skill/Walk/src/Walk.cpp
@@ -132,7 +132,8 @@ namespace module::skill {
            Needs<LeftLegIK>,
            Needs<RightLegIK>,
            Every<UPDATE_FREQUENCY, Per<std::chrono::seconds>>,
-           Single>()
+           Single,
+           Priority::HIGH>()
             .then([this](const WalkTask& walk_task, const Sensors& sensors, const Stability& stability) {
                 // Compute time since the last update
                 auto time_delta =


### PR DESCRIPTION
This PR updates all providers which are related to the walk engine to be high priority. The aim of this is to ensure that the walk engine always runs despite any computational conflict. 