### PR TITLE
Add IP, SSID and password toggles to the RoboCup configuration tool

### DIFF
--- a/module/tools/RoboCupConfiguration/README.md
+++ b/module/tools/RoboCupConfiguration/README.md
@@ -39,4 +39,4 @@ N/A
 
 ## Dependencies
 
-N/A
+- ncurses

--- a/module/tools/RoboCupConfiguration/data/config/RoboCupConfiguration.yaml
+++ b/module/tools/RoboCupConfiguration/data/config/RoboCupConfiguration.yaml
@@ -1,2 +1,16 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
+
+# Map of possible ssid and passwords
+wifi_networks:
+  Humanoid_A: "rc2024humanoid"
+  Humanoid_B: "rc2024humanoid"
+  Humanoid_C: "rc2024humanoid"
+  Humanoid_D: "rc2024humanoid"
+
+common_ips: [
+    "10.1.1.X", # Typical ethernet/lab IP
+    "192.168.1.X", # RoboCup NUbots IP
+    "192.168.31.X", # RoboCup Drop-In Team A IP
+    "192.168.32.X", # RoboCup Drop-In Team B IP
+  ]

--- a/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.cpp
+++ b/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.cpp
@@ -52,6 +52,9 @@ namespace module::tools {
         on<Configuration>("RoboCupConfiguration.yaml").then([this](const Configuration& config) {
             // Use configuration here from file RoboCupConfiguration.yaml
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
+
+            cfg.wifi_networks = config["wifi_networks"].as<std::map<std::string, std::string>>();
+            cfg.common_ips    = config["common_ips"].as<std::vector<std::string>>();
         });
 
         on<Startup>().then([this] {
@@ -313,6 +316,43 @@ namespace module::tools {
     void RoboCupConfiguration::toggle_selection() {
         // Networking configuration column
         if (display.column_selection == 0) {
+            if (display.row_selection == int(Display::Column1::SSID) && !cfg.wifi_networks.empty()) {
+                // See if the current SSID is in the cfg.wifi_networks map
+                auto it = cfg.wifi_networks.find(ssid);
+                if (it != cfg.wifi_networks.end()) {
+                    // If it is, set the SSID and password to the next value in the map
+                    auto next = std::next(it);
+                    ssid      = next == cfg.wifi_networks.end() ? cfg.wifi_networks.begin()->first : next->first;
+                    password  = next == cfg.wifi_networks.end() ? cfg.wifi_networks.begin()->second : next->second;
+                }
+                else {
+                    // If it isn't, set the SSID and password to the first value in the map
+                    ssid     = cfg.wifi_networks.begin()->first;
+                    password = cfg.wifi_networks.begin()->second;
+                }
+            }
+
+            if (display.row_selection == int(Display::Column1::IP_ADDRESS) && !cfg.common_ips.empty()) {
+                // Change the IPs to use the player_id in the "X" position
+                std::vector<std::string> player_ips{};
+                for (const auto& ip : cfg.common_ips) {
+                    std::string player_ip = ip;
+                    player_ip.replace(player_ip.find("X"), 1, std::to_string(player_id));
+                    player_ips.push_back(player_ip);
+                }
+
+                // See if the current IP address is in the player_ips vector
+                auto it = std::find(player_ips.begin(), player_ips.end(), ip_address);
+                if (it != player_ips.end()) {
+                    // If it is, set the IP address to the next value in the vector
+                    auto next  = std::next(it);
+                    ip_address = next == player_ips.end() ? player_ips.front() : *next;
+                }
+                else {
+                    // If it isn't, set the IP address to the first value in the vector
+                    ip_address = player_ips.front();
+                }
+            }
             return;
         }
         // Game configuration column

--- a/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.hpp
+++ b/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.hpp
@@ -35,6 +35,13 @@ namespace module::tools {
 
     class RoboCupConfiguration : public NUClear::Reactor {
     private:
+        struct Config {
+            /// @brief Map of ssid and passwords that are possible
+            std::map<std::string, std::string> wifi_networks{};
+            /// @brief Common IPs to toggle
+            std::vector<std::string> common_ips{};
+        } cfg;
+
         /// @brief The hostname of the robot
         std::string hostname = "";
         /// @brief The name of the robot


### PR DESCRIPTION
This PR aims to make it simpler to change IPs and networks by toggling in the robocup configuration tool. This is mostly useful at RoboCup. The IPs in the config shouldn't need changing, but the SSID and passwords of the fields may change next year. I'll keep the ones from this year in as placeholders.

The toggle for IP will look for any X placeholder and replace it with the current player ID for ease. 