### PR TITLE
Add stop at target functionality to WalkToFieldPosition

### DIFF
--- a/module/purpose/AllRounder/src/AllRounder.cpp
+++ b/module/purpose/AllRounder/src/AllRounder.cpp
@@ -117,7 +117,8 @@ namespace module::purpose {
             // If we are stable, walk to the ready field position
             emit<Task>(std::make_unique<WalkToFieldPosition>(
                 pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                     Eigen::Vector3d(0, 0, cfg.ready_position.z()))));
+                                     Eigen::Vector3d(0, 0, cfg.ready_position.z())),
+                true));
         });
 
         // Normal PLAYING state

--- a/module/purpose/AllRounder/src/AllRounder.cpp
+++ b/module/purpose/AllRounder/src/AllRounder.cpp
@@ -79,8 +79,10 @@ namespace module::purpose {
 
         on<Configuration>("AllRounder.yaml").then([this](const Configuration& config) {
             // Use configuration here from file AllRounder.yaml
-            this->log_level    = config["log_level"].as<NUClear::LogLevel>();
-            cfg.ready_position = config["ready_position"].as<Expression>();
+            this->log_level                = config["log_level"].as<NUClear::LogLevel>();
+            Eigen::Vector3d ready_position = config["ready_position"].as<Expression>();
+            cfg.Hfr = pos_rpy_to_transform(Eigen::Vector3d(ready_position.x(), ready_position.y(), 0),
+                                           Eigen::Vector3d(0, 0, ready_position.z()));
         });
 
         on<Provide<AllRounderTask>, Optional<Trigger<GameState>>>().then(
@@ -115,10 +117,7 @@ namespace module::purpose {
         // Normal READY state
         on<Provide<NormalAllRounder>, When<Phase, std::equal_to, Phase::READY>>().then([this] {
             // If we are stable, walk to the ready field position
-            emit<Task>(std::make_unique<WalkToFieldPosition>(
-                pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                     Eigen::Vector3d(0, 0, cfg.ready_position.z())),
-                true));
+            emit<Task>(std::make_unique<WalkToFieldPosition>(cfg.Hfr, true));
         });
 
         // Normal PLAYING state

--- a/module/purpose/AllRounder/src/AllRounder.hpp
+++ b/module/purpose/AllRounder/src/AllRounder.hpp
@@ -29,6 +29,7 @@
 
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <nuclear>
 
 #include "extension/Behaviour.hpp"
@@ -42,8 +43,8 @@ namespace module::purpose {
 
         /// @brief Stores configuration values
         struct Config {
-            /// @brief Ready position to walk to (x, y, theta)
-            Eigen::Vector3f ready_position = Eigen::Vector3f::Zero();
+            /// @brief Ready position to walk to
+            Eigen::Isometry3d Hfr = Eigen::Isometry3d::Identity();
         } cfg;
 
 

--- a/module/purpose/Defender/src/Defender.cpp
+++ b/module/purpose/Defender/src/Defender.cpp
@@ -134,7 +134,8 @@ namespace module::purpose {
             log<NUClear::DEBUG>("READY");
             emit<Task>(std::make_unique<WalkToFieldPosition>(
                 pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                     Eigen::Vector3d(0, 0, cfg.ready_position.z()))));
+                                     Eigen::Vector3d(0, 0, cfg.ready_position.z())),
+                true));
         });
 
         // Normal PLAYING state

--- a/module/purpose/Defender/src/Defender.cpp
+++ b/module/purpose/Defender/src/Defender.cpp
@@ -76,8 +76,10 @@ namespace module::purpose {
     Defender::Defender(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
         on<Configuration>("Defender.yaml").then([this](const Configuration& config) {
             // Use configuration here from file Defender.yaml
-            this->log_level    = config["log_level"].as<NUClear::LogLevel>();
-            cfg.ready_position = config["ready_position"].as<Expression>();
+            this->log_level                = config["log_level"].as<NUClear::LogLevel>();
+            Eigen::Vector3d ready_position = config["ready_position"].as<Expression>();
+            cfg.Hfr = pos_rpy_to_transform(Eigen::Vector3d(ready_position.x(), ready_position.y(), 0),
+                                           Eigen::Vector3d(0, 0, ready_position.z()));
 
             cfg.bounded_region_x_min = config["bounded_region_x_min"].as<Expression>();
             cfg.bounded_region_x_max = config["bounded_region_x_max"].as<Expression>();
@@ -91,13 +93,11 @@ namespace module::purpose {
             cfg.bounded_region_y_min = new_bounding_box.y_min;
             cfg.bounded_region_y_max = new_bounding_box.y_max;
             // Debugging
-            emit(std::make_unique<WalkInsideBoundedBox>(
-                cfg.bounded_region_x_min,
-                cfg.bounded_region_x_max,
-                cfg.bounded_region_y_min,
-                cfg.bounded_region_y_max,
-                pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                     Eigen::Vector3d(0, 0, cfg.ready_position.z()))));
+            emit(std::make_unique<WalkInsideBoundedBox>(cfg.bounded_region_x_min,
+                                                        cfg.bounded_region_x_max,
+                                                        cfg.bounded_region_y_min,
+                                                        cfg.bounded_region_y_max,
+                                                        cfg.Hfr));
         });
 
         on<Provide<DefenderTask>, Optional<Trigger<GameState>>>().then(
@@ -132,10 +132,7 @@ namespace module::purpose {
         on<Provide<NormalDefender>, When<Phase, std::equal_to, Phase::READY>>().then([this] {
             // If we are stable, walk to the ready field position
             log<NUClear::DEBUG>("READY");
-            emit<Task>(std::make_unique<WalkToFieldPosition>(
-                pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                     Eigen::Vector3d(0, 0, cfg.ready_position.z())),
-                true));
+            emit<Task>(std::make_unique<WalkToFieldPosition>(cfg.Hfr, true));
         });
 
         // Normal PLAYING state
@@ -176,13 +173,11 @@ namespace module::purpose {
         emit<Task>(std::make_unique<FindBall>(), 1);    // if the look/walk to ball tasks are not running, find the ball
         emit<Task>(std::make_unique<LookAtBall>(), 2);  // try to track the ball
         emit<Task>(std::make_unique<WalkToKickBall>(), 3);  // try to walk to the ball and align towards opponents goal
-        emit<Task>(std::make_unique<WalkInsideBoundedBox>(
-                       cfg.bounded_region_x_min,
-                       cfg.bounded_region_x_max,
-                       cfg.bounded_region_y_min,
-                       cfg.bounded_region_y_max,
-                       pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                            Eigen::Vector3d(0, 0, cfg.ready_position.z()))),
+        emit<Task>(std::make_unique<WalkInsideBoundedBox>(cfg.bounded_region_x_min,
+                                                          cfg.bounded_region_x_max,
+                                                          cfg.bounded_region_y_min,
+                                                          cfg.bounded_region_y_max,
+                                                          cfg.Hfr),
                    4);  // Patrol bounded box region
     }
 

--- a/module/purpose/Defender/src/Defender.hpp
+++ b/module/purpose/Defender/src/Defender.hpp
@@ -29,6 +29,7 @@
 
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <nuclear>
 
 #include "extension/Behaviour.hpp"
@@ -42,8 +43,8 @@ namespace module::purpose {
 
         /// @brief Stores configuration values
         struct Config {
-            /// @brief Ready position to walk to (x, y, theta)
-            Eigen::Vector3d ready_position = Eigen::Vector3d::Zero();
+            /// @brief Ready position to walk to
+            Eigen::Isometry3d Hfr = Eigen::Isometry3d::Identity();
             /// @brief x minimum bound on field to walk within
             double bounded_region_x_min = 0.0;
             /// @brief x maximum bound on field to walk within

--- a/module/purpose/Goalie/src/Goalie.cpp
+++ b/module/purpose/Goalie/src/Goalie.cpp
@@ -74,8 +74,10 @@ namespace module::purpose {
 
         on<Configuration>("Goalie.yaml").then([this](const Configuration& config) {
             // Use configuration here from file Goalie.yaml
-            this->log_level    = config["log_level"].as<NUClear::LogLevel>();
-            cfg.ready_position = config["ready_position"].as<Expression>();
+            this->log_level                = config["log_level"].as<NUClear::LogLevel>();
+            Eigen::Vector3d ready_position = config["ready_position"].as<Expression>();
+            cfg.Hfr = pos_rpy_to_transform(Eigen::Vector3d(ready_position.x(), ready_position.y(), 0),
+                                           Eigen::Vector3d(0, 0, ready_position.z()));
 
             cfg.bounded_region_x_min = config["bounded_region_x_min"].as<Expression>();
             cfg.bounded_region_x_max = config["bounded_region_x_max"].as<Expression>();
@@ -109,12 +111,8 @@ namespace module::purpose {
             });
 
         // Normal READY state
-        on<Provide<NormalGoalie>, When<Phase, std::equal_to, Phase::READY>>().then([this] {
-            emit<Task>(std::make_unique<WalkToFieldPosition>(
-                pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                     Eigen::Vector3d(0, 0, cfg.ready_position.z())),
-                true));
-        });
+        on<Provide<NormalGoalie>, When<Phase, std::equal_to, Phase::READY>>().then(
+            [this] { emit<Task>(std::make_unique<WalkToFieldPosition>(cfg.Hfr, true)); });
 
         // Normal PLAYING state
         on<Provide<NormalGoalie>, When<Phase, std::equal_to, Phase::PLAYING>>().then([this] { play(); });
@@ -161,13 +159,11 @@ namespace module::purpose {
         emit<Task>(std::make_unique<FindBall>(), 1);    // if the look/walk to ball tasks are not running, find the ball
         emit<Task>(std::make_unique<LookAtBall>(), 2);  // try to track the ball
         emit<Task>(std::make_unique<WalkToKickBall>(), 3);  // try to walk to the ball and align towards opponents goal
-        emit<Task>(std::make_unique<WalkInsideBoundedBox>(
-                       cfg.bounded_region_x_min,
-                       cfg.bounded_region_x_max,
-                       cfg.bounded_region_y_min,
-                       cfg.bounded_region_y_max,
-                       pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                            Eigen::Vector3d(0, 0, cfg.ready_position.z()))),
+        emit<Task>(std::make_unique<WalkInsideBoundedBox>(cfg.bounded_region_x_min,
+                                                          cfg.bounded_region_x_max,
+                                                          cfg.bounded_region_y_min,
+                                                          cfg.bounded_region_y_max,
+                                                          cfg.Hfr),
                    4);  // Patrol bounded box region
     }
 

--- a/module/purpose/Goalie/src/Goalie.cpp
+++ b/module/purpose/Goalie/src/Goalie.cpp
@@ -112,7 +112,8 @@ namespace module::purpose {
         on<Provide<NormalGoalie>, When<Phase, std::equal_to, Phase::READY>>().then([this] {
             emit<Task>(std::make_unique<WalkToFieldPosition>(
                 pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                     Eigen::Vector3d(0, 0, cfg.ready_position.z()))));
+                                     Eigen::Vector3d(0, 0, cfg.ready_position.z())),
+                true));
         });
 
         // Normal PLAYING state

--- a/module/purpose/Goalie/src/Goalie.hpp
+++ b/module/purpose/Goalie/src/Goalie.hpp
@@ -28,6 +28,7 @@
 #define MODULE_PURPOSE_GOALIE_HPP
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <nuclear>
 
 #include "extension/Behaviour.hpp"
@@ -41,8 +42,8 @@ namespace module::purpose {
 
         /// @brief Stores configuration values
         struct Config {
-            /// @brief Ready position to walk to (x, y, theta)
-            Eigen::Vector3f ready_position = Eigen::Vector3f::Zero();
+            /// @brief Ready position to walk to
+            Eigen::Isometry3d Hfr = Eigen::Isometry3d::Identity();
             /// @brief x minimum bound on field to walk within
             double bounded_region_x_min = 0.0;
             /// @brief x maximum bound on field to walk within

--- a/module/purpose/Striker/src/Striker.cpp
+++ b/module/purpose/Striker/src/Striker.cpp
@@ -168,7 +168,8 @@ namespace module::purpose {
                     // Walk to ready so we are ready to play when kickoff finishes
                     emit<Task>(std::make_unique<WalkToFieldPosition>(
                         pos_rpy_to_transform(Eigen::Vector3d(cfg.ready_position.x(), cfg.ready_position.y(), 0),
-                                             Eigen::Vector3d(0, 0, cfg.ready_position.z()))));
+                                             Eigen::Vector3d(0, 0, cfg.ready_position.z())),
+                        true));
                     return;
                 }
                 play();

--- a/module/purpose/Striker/src/Striker.hpp
+++ b/module/purpose/Striker/src/Striker.hpp
@@ -29,6 +29,7 @@
 
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <nuclear>
 
 #include "extension/Behaviour.hpp"
@@ -42,8 +43,8 @@ namespace module::purpose {
 
         /// @brief Stores configuration values
         struct Config {
-            /// @brief Ready position to walk to (x, y, theta)
-            Eigen::Vector3f ready_position = Eigen::Vector3f::Zero();
+            /// @brief Ready position to walk to
+            Eigen::Isometry3d Hfr = Eigen::Isometry3d::Identity();
             /// @brief How far (m) the ball can be away from the centre of the field for it to be deemed as
             /// moved/touched by the other team during kickoff so we can start playing
             double ball_kickoff_outside_radius = 0.0;

--- a/module/purpose/Tester/src/Tester.cpp
+++ b/module/purpose/Tester/src/Tester.cpp
@@ -135,11 +135,12 @@ namespace module::purpose {
                     emit<Task>(std::make_unique<KickToGoal>(), cfg.kick_to_goal_priority);
                 }
                 if (cfg.walk_to_field_position_priority > 0) {
-                    emit<Task>(std::make_unique<WalkToFieldPosition>(pos_rpy_to_transform(
-                                   Eigen::Vector3d(cfg.walk_to_field_position_position.x(),
-                                                   cfg.walk_to_field_position_position.y(),
-                                                   0),
-                                   Eigen::Vector3d(0, 0, cfg.walk_to_field_position_position.z()))),
+                    emit<Task>(std::make_unique<WalkToFieldPosition>(
+                                   pos_rpy_to_transform(Eigen::Vector3d(cfg.walk_to_field_position_position.x(),
+                                                                        cfg.walk_to_field_position_position.y(),
+                                                                        0),
+                                                        Eigen::Vector3d(0, 0, cfg.walk_to_field_position_position.z())),
+                                   true),
                                cfg.walk_to_field_position_priority);
                 }
                 if (cfg.walk_inside_bounded_box_priority > 0) {

--- a/module/strategy/WalkInsideBoundedBox/src/WalkInsideBoundedBox.cpp
+++ b/module/strategy/WalkInsideBoundedBox/src/WalkInsideBoundedBox.cpp
@@ -71,7 +71,7 @@ namespace module::strategy {
 
                 if (ball == nullptr || NUClear::clock::now() - ball->time_of_measurement > cfg.ball_search_timeout) {
                     log<NUClear::DEBUG>("Ball timeout. Returning to default position");
-                    emit<Task>(std::make_unique<WalkToFieldPosition>(box.Hfd));
+                    emit<Task>(std::make_unique<WalkToFieldPosition>(box.Hfd, true));
                     return;
                 }
 

--- a/module/strategy/WalkToBall/src/WalkToBall.cpp
+++ b/module/strategy/WalkToBall/src/WalkToBall.cpp
@@ -171,7 +171,7 @@ namespace module::strategy {
                 }
 
 
-                emit<Task>(std::make_unique<WalkToFieldPosition>(Hfk, true));
+                emit<Task>(std::make_unique<WalkToFieldPosition>(Hfk, false));
             }
         });
     }

--- a/module/strategy/WalkToBall/src/WalkToBall.cpp
+++ b/module/strategy/WalkToBall/src/WalkToBall.cpp
@@ -171,7 +171,7 @@ namespace module::strategy {
                 }
 
 
-                emit<Task>(std::make_unique<WalkToFieldPosition>(Hfk));
+                emit<Task>(std::make_unique<WalkToFieldPosition>(Hfk, true));
             }
         });
     }

--- a/module/strategy/WalkToFieldPosition/data/config/WalkToFieldPosition.yaml
+++ b/module/strategy/WalkToFieldPosition/data/config/WalkToFieldPosition.yaml
@@ -1,2 +1,5 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
+
+stop_threshold: 0.2
+stopped_threshold: 0.4

--- a/module/strategy/WalkToFieldPosition/data/config/webots/WalkToFieldPosition.yaml
+++ b/module/strategy/WalkToFieldPosition/data/config/webots/WalkToFieldPosition.yaml
@@ -1,2 +1,5 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
+
+stop_threshold: 0.2
+stopped_threshold: 0.4

--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
@@ -72,9 +72,11 @@ namespace module::strategy {
                 // Normalize the angle error to be within the range [-pi, pi]
                 angle_error = std::atan2(std::sin(angle_error), std::cos(angle_error));
 
+                // If the robot is close enough to the target and the angle error is small enough, stop the robot
                 if (translational_error < current_threshold && std::abs(angle_error) < current_threshold
                     && !walk_to_field_position.dont_stop_at_target) {
                     emit<Task>(std::make_unique<Walk>(Eigen::Vector3d::Zero()));
+                    // Increase the threshold to the stopped threshold to prevent oscillations
                     current_threshold = cfg.stopped_threshold;
                     log<NUClear::DEBUG>("Stopped at field position");
                 }

--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
@@ -74,7 +74,7 @@ namespace module::strategy {
 
                 // If the robot is close enough to the target and the angle error is small enough, stop the robot
                 if (translational_error < current_threshold && std::abs(angle_error) < current_threshold
-                    && !walk_to_field_position.dont_stop_at_target) {
+                    && walk_to_field_position.stop_at_target) {
                     emit<Task>(std::make_unique<Walk>(Eigen::Vector3d::Zero()));
                     // Increase the threshold to the stopped threshold to prevent oscillations
                     current_threshold = cfg.stopped_threshold;

--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.cpp
@@ -32,6 +32,7 @@
 #include "message/input/Sensors.hpp"
 #include "message/localisation/Field.hpp"
 #include "message/planning/WalkPath.hpp"
+#include "message/skill/Walk.hpp"
 #include "message/strategy/WalkToFieldPosition.hpp"
 
 namespace module::strategy {
@@ -40,6 +41,7 @@ namespace module::strategy {
     using message::input::Sensors;
     using message::localisation::Field;
     using message::planning::WalkTo;
+    using message::skill::Walk;
     using WalkToFieldPositionTask = message::strategy::WalkToFieldPosition;
 
     WalkToFieldPosition::WalkToFieldPosition(std::unique_ptr<NUClear::Environment> environment)
@@ -47,14 +49,39 @@ namespace module::strategy {
 
         on<Configuration>("WalkToFieldPosition.yaml").then([this](const Configuration& config) {
             // Use configuration here from file WalkToFieldPosition.yaml
-            this->log_level = config["log_level"].as<NUClear::LogLevel>();
+            this->log_level       = config["log_level"].as<NUClear::LogLevel>();
+            cfg.stop_threshold    = config["stop_threshold"].as<double>();
+            cfg.stopped_threshold = config["stopped_threshold"].as<double>();
         });
+
+        on<Start<WalkToFieldPositionTask>>().then([this] { current_threshold = cfg.stop_threshold; });
 
         on<Provide<WalkToFieldPositionTask>, With<Field>, With<Sensors>>().then(
             [this](const WalkToFieldPositionTask& walk_to_field_position, const Field& field, const Sensors& sensors) {
                 // Transform from desired field position into robot space
-                Eigen::Isometry3d Hrd = sensors.Hrw * field.Hfw.inverse() * walk_to_field_position.Hfd;
-                emit<Task>(std::make_unique<WalkTo>(Hrd));
+                Eigen::Isometry3d Hrd      = sensors.Hrw * field.Hfw.inverse() * walk_to_field_position.Hfd;
+                double translational_error = Hrd.translation().norm();
+
+                // Compute the error between the desired heading and the measured heading
+                Eigen::Isometry3d Hfr          = field.Hfw * sensors.Hrw.inverse();
+                Eigen::Vector3d desired_unit_x = walk_to_field_position.Hfd.linear().col(0);
+                double desired_heading         = std::atan2(desired_unit_x.y(), desired_unit_x.x());
+                double measured_heading        = std::atan2(Hfr.linear().col(0).y(), Hfr.linear().col(0).x());
+
+                double angle_error = std::abs(desired_heading - measured_heading);
+                // Normalize the angle error to be within the range [-pi, pi]
+                angle_error = std::atan2(std::sin(angle_error), std::cos(angle_error));
+
+                if (translational_error < current_threshold && std::abs(angle_error) < current_threshold
+                    && !walk_to_field_position.dont_stop_at_target) {
+                    emit<Task>(std::make_unique<Walk>(Eigen::Vector3d::Zero()));
+                    current_threshold = cfg.stopped_threshold;
+                    log<NUClear::DEBUG>("Stopped at field position");
+                }
+                else {
+                    log<NUClear::DEBUG>("Walking to field position");
+                    emit<Task>(std::make_unique<WalkTo>(Hrd));
+                }
             });
     }
 

--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.hpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.hpp
@@ -36,10 +36,13 @@ namespace module::strategy {
     class WalkToFieldPosition : public ::extension::behaviour::BehaviourReactor {
     private:
         struct Config {
-            double stop_threshold    = 0.0;
+            /// @brief Error threshold for stopping the robot.
+            double stop_threshold = 0.0;
+            /// @brief Error threshold for resuming walking.
             double stopped_threshold = 0.0;
         } cfg;
 
+        /// @brief The current threshold to use for stopping the robot.
         double current_threshold = 0.0;
 
     public:

--- a/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.hpp
+++ b/module/strategy/WalkToFieldPosition/src/WalkToFieldPosition.hpp
@@ -34,6 +34,14 @@
 namespace module::strategy {
 
     class WalkToFieldPosition : public ::extension::behaviour::BehaviourReactor {
+    private:
+        struct Config {
+            double stop_threshold    = 0.0;
+            double stopped_threshold = 0.0;
+        } cfg;
+
+        double current_threshold = 0.0;
+
     public:
         /// @brief Called by the powerplant to build and setup the WalkToFieldPosition reactor.
         explicit WalkToFieldPosition(std::unique_ptr<NUClear::Environment> environment);

--- a/shared/message/strategy/WalkToFieldPosition.proto
+++ b/shared/message/strategy/WalkToFieldPosition.proto
@@ -34,5 +34,5 @@ message WalkToFieldPosition {
     /// Transform from desired robot pose {d} to field {f} space
     iso3 Hfd = 1;
     /// Whether to stop at the target position
-    bool dont_stop_at_target = 2;
+    bool stop_at_target = 2;
 }

--- a/shared/message/strategy/WalkToFieldPosition.proto
+++ b/shared/message/strategy/WalkToFieldPosition.proto
@@ -33,4 +33,6 @@ import "Transform.proto";
 message WalkToFieldPosition {
     /// Transform from desired robot pose {d} to field {f} space
     iso3 Hfd = 1;
+    /// Whether to stop at the target position
+    bool dont_stop_at_target = 2;
 }


### PR DESCRIPTION
This PR adds functionality to `WalkToFieldPosition` where robot will stop once reaching the target position on the field. Additionally, a flag is added to the `WalkToFieldPosition` message to toggle this feature off, which is useful when walking to ball for dribbling. 