### PR TITLE
Fix R2R seg fault by checking if GameState is null first

### DIFF
--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -138,6 +138,7 @@ namespace module::network {
                 msg->timestamp = NUClear::clock::now();
 
                 // State
+                // If there is game state information, then process 
                 if (game_state) {
                     int penalty_reason = game_state->data.self.penalty_reason;
                     switch (penalty_reason) {

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -138,7 +138,7 @@ namespace module::network {
                 msg->timestamp = NUClear::clock::now();
 
                 // State
-                // If there is game state information, then process 
+                // If there is game state information, then process
                 if (game_state) {
                     int penalty_reason = game_state->data.self.penalty_reason;
                     switch (penalty_reason) {

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -138,11 +138,13 @@ namespace module::network {
                 msg->timestamp = NUClear::clock::now();
 
                 // State
-                int penalty_reason = game_state->data.self.penalty_reason;
-                switch (penalty_reason) {
-                    case 0: msg->state = 0; break;
-                    case 1: msg->state = 1; break;
-                    default: msg->state = 2; break;
+                if (game_state) {
+                    int penalty_reason = game_state->data.self.penalty_reason;
+                    switch (penalty_reason) {
+                        case 0: msg->state = 0; break;
+                        case 1: msg->state = 1; break;
+                        default: msg->state = 2; break;
+                    }
                 }
 
                 // Current pose (Position, orientation, and covariance of the player on the field)


### PR DESCRIPTION
Noticed when GameController didn't exist but RobotComms did, it seg faults. Optional GameState is used without checking for nullptr first. Fixed up so there's a check.