### PR TITLE
Correct the goal-positions read from the NUSense state with the offsets and the directions.

### DIFF
--- a/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
@@ -171,6 +171,8 @@ namespace module::platform::NUSense {
                 // Add the offsets and switch the direction.
                 servo.present_position *= nugus.servo_direction[val.id - 1];
                 servo.present_position += nugus.servo_offset[val.id - 1];
+                servo.goal_position *= nugus.servo_direction[val.id - 1];
+                servo.goal_position += nugus.servo_offset[val.id - 1];
             }
 
             log<NUClear::TRACE>(


### PR DESCRIPTION
Fixes a small bug where we forgot to add the offsets and switch the directions on the goal-positions received from NUSense. I am not sure whether this bug had a big effect on walking, etc., but it did affect the goal positions plotted on PlotJuggler.

### Pre-PR Checklist:

Have you

- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [x] Added a descriptive title and relevant labels to the PR