### PR TITLE
[NUsight] Remove disposeOnUnmount usages

### DIFF
--- a/nusight2/src/client/components/localisation/view.tsx
+++ b/nusight2/src/client/components/localisation/view.tsx
@@ -89,7 +89,6 @@ export class LocalisationView extends React.Component<LocalisationViewProps> {
   private dispose?: () => void;
 
   componentDidMount(): void {
-    this.dispose?.();
     this.dispose = compose([
       addDocListener("pointerlockchange", this.onPointerLockChange, false),
       addDocListener("mousemove", this.onMouseMove, false),

--- a/nusight2/src/client/components/localisation/view.tsx
+++ b/nusight2/src/client/components/localisation/view.tsx
@@ -3,6 +3,7 @@ import { reaction } from "mobx";
 import { observer } from "mobx-react";
 import { now } from "mobx-utils";
 
+import { compose } from "../../../shared/base/compose";
 import { Button } from "../button/button";
 import { dropdownContainer } from "../dropdown_container/view";
 import { Icon } from "../icon/view";
@@ -24,7 +25,6 @@ import { SkyboxView } from "./r3f_components/skybox/view";
 import { WalkPathGoal } from "./r3f_components/walk_path_goal/view";
 import { WalkPathVisualiser } from "./r3f_components/walk_path_visualiser/view";
 import { LocalisationRobotModel } from "./robot_model";
-import { compose } from "../../../shared/base/compose";
 
 type LocalisationViewProps = {
   controller: LocalisationController;

--- a/nusight2/src/client/components/localisation/view.tsx
+++ b/nusight2/src/client/components/localisation/view.tsx
@@ -77,12 +77,10 @@ export class FieldDimensionSelector extends React.Component<FieldDimensionSelect
 const EnhancedDropdown = dropdownContainer();
 
 const addDocListener = <K extends keyof DocumentEventMap>(
-  type: K,
-  listener: (this: Document, ev: DocumentEventMap[K]) => any,
-  options?: boolean | AddEventListenerOptions,
+  ...args: Parameters<typeof document.addEventListener<K>>
 ): (() => void) => {
-  document.addEventListener(type, listener, options);
-  return () => document.removeEventListener(type, listener, options);
+  document.addEventListener(...args);
+  return () => document.removeEventListener(...args);
 };
 
 @observer

--- a/nusight2/src/client/components/localisation/view.tsx
+++ b/nusight2/src/client/components/localisation/view.tsx
@@ -76,12 +76,11 @@ export class FieldDimensionSelector extends React.Component<FieldDimensionSelect
 
 const EnhancedDropdown = dropdownContainer();
 
-
 const addDocListener = <K extends keyof DocumentEventMap>(
   type: K,
   listener: (this: Document, ev: DocumentEventMap[K]) => any,
-  options?: boolean | AddEventListenerOptions
-): () => void => {
+  options?: boolean | AddEventListenerOptions,
+): (() => void) => {
   document.addEventListener(type, listener, options);
   return () => document.removeEventListener(type, listener, options);
 };

--- a/nusight2/src/client/components/odometry/odometry_visualizer/stories/robot_odometry.stories.tsx
+++ b/nusight2/src/client/components/odometry/odometry_visualizer/stories/robot_odometry.stories.tsx
@@ -36,14 +36,16 @@ class OdometryVisualizerHarness extends React.Component<{ animate?: boolean }> {
 
   componentDidMount() {
     this.dispose?.();
-    this.dispose = this.props.animate ? reaction(
+    this.dispose = this.props.animate
+      ? reaction(
           () => now("frame") / 1000,
           (t) => {
             this.model.Hwt = Matrix4.fromThree(
               new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(Math.cos(t) / 5, 0, t)).setPosition(0, 0, 1),
             );
           },
-      ) : undefined;
+        )
+      : undefined;
   }
 
   componentWillUnmount() {

--- a/nusight2/src/client/components/odometry/odometry_visualizer/stories/robot_odometry.stories.tsx
+++ b/nusight2/src/client/components/odometry/odometry_visualizer/stories/robot_odometry.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import { reaction } from "mobx";
-import { disposeOnUnmount } from "mobx-react";
 import { now } from "mobx-utils";
 import * as THREE from "three";
 
@@ -28,24 +27,28 @@ export const Animated: StoryObj<StoryProps> = {
 };
 
 class OdometryVisualizerHarness extends React.Component<{ animate?: boolean }> {
+  private dispose?: () => void;
+
   private model = OdometryVisualizerModel.of({
     Hwt: Matrix4.fromThree(new THREE.Matrix4().makeTranslation(0, 0, 1)),
     accelerometer: new Vector3(0, 0, -9.8),
   });
 
   componentDidMount() {
-    this.props.animate &&
-      disposeOnUnmount(
-        this,
-        reaction(
+    this.dispose?.();
+    this.dispose = this.props.animate ? reaction(
           () => now("frame") / 1000,
           (t) => {
             this.model.Hwt = Matrix4.fromThree(
               new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(Math.cos(t) / 5, 0, t)).setPosition(0, 0, 1),
             );
           },
-        ),
-      );
+      ) : undefined;
+  }
+
+  componentWillUnmount() {
+    this.dispose?.();
+    this.dispose = undefined;
   }
 
   render() {

--- a/nusight2/src/client/components/odometry/odometry_visualizer/stories/robot_odometry.stories.tsx
+++ b/nusight2/src/client/components/odometry/odometry_visualizer/stories/robot_odometry.stories.tsx
@@ -35,7 +35,6 @@ class OdometryVisualizerHarness extends React.Component<{ animate?: boolean }> {
   });
 
   componentDidMount() {
-    this.dispose?.();
     this.dispose = this.props.animate
       ? reaction(
           () => now("frame") / 1000,

--- a/nusight2/src/client/components/robot_selector/stories/robot_selector.stories.tsx
+++ b/nusight2/src/client/components/robot_selector/stories/robot_selector.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { action } from "@storybook/addon-actions";
 import { Meta, StoryObj } from "@storybook/react";
 import { action as mobxAction, observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import { now } from "mobx-utils";
 
 import { SeededRandom } from "../../../../shared/base/random/seeded_random";
@@ -99,6 +99,8 @@ const random = SeededRandom.of("random-stats");
 
 @observer
 export class UpdatingStatsStory extends React.Component<{ robots: RobotModel[] }> {
+  private dispose?: () => void;
+
   render() {
     const { robots } = this.props;
 
@@ -121,9 +123,12 @@ export class UpdatingStatsStory extends React.Component<{ robots: RobotModel[] }
   };
 
   componentDidMount() {
-    disposeOnUnmount(
-      this,
-      reaction(() => now("frame"), this.updateStats, { fireImmediately: true }),
-    );
+    this.dispose?.();
+    this.dispose = reaction(() => now("frame"), this.updateStats, { fireImmediately: true });
+  }
+
+  componentWillUnmount() {
+    this.dispose?.();
+    this.dispose = undefined;
   }
 }

--- a/nusight2/src/client/components/robot_selector/stories/robot_selector.stories.tsx
+++ b/nusight2/src/client/components/robot_selector/stories/robot_selector.stories.tsx
@@ -123,7 +123,6 @@ export class UpdatingStatsStory extends React.Component<{ robots: RobotModel[] }
   };
 
   componentDidMount() {
-    this.dispose?.();
     this.dispose = reaction(() => now("frame"), this.updateStats, { fireImmediately: true });
   }
 

--- a/nusight2/src/client/components/three/stories/render_targets.stories.tsx
+++ b/nusight2/src/client/components/three/stories/render_targets.stories.tsx
@@ -4,7 +4,6 @@ import { action } from "mobx";
 import { reaction } from "mobx";
 import { computed } from "mobx";
 import { observable } from "mobx";
-import { disposeOnUnmount } from "mobx-react";
 import { now } from "mobx-utils";
 import { WebGLRenderTarget } from "three";
 import { TextureLoader } from "three";
@@ -60,6 +59,8 @@ export const AnimatedSceneWithRenderTargets: StoryObj<StoryComponent> = {
 type Model = { time: number };
 
 class RenderTargetHarness extends React.Component<{ animate?: boolean }> {
+  private dispose?: () => void;
+
   @observable
   private readonly model: Model = {
     time: 0,
@@ -67,11 +68,13 @@ class RenderTargetHarness extends React.Component<{ animate?: boolean }> {
 
   componentDidMount() {
     this.update(0);
-    this.props.animate &&
-      disposeOnUnmount(
-        this,
-        reaction(() => now("frame"), this.update),
-      );
+    this.dispose?.();
+    this.dispose = this.props.animate ? reaction(() => now("frame"), this.update) : undefined;
+  }
+
+  componentWillUnmount() {
+    this.dispose?.();
+    this.dispose = undefined;
   }
 
   render() {

--- a/nusight2/src/client/components/three/stories/render_targets.stories.tsx
+++ b/nusight2/src/client/components/three/stories/render_targets.stories.tsx
@@ -68,7 +68,6 @@ class RenderTargetHarness extends React.Component<{ animate?: boolean }> {
 
   componentDidMount() {
     this.update(0);
-    this.dispose?.();
     this.dispose = this.props.animate ? reaction(() => now("frame"), this.update) : undefined;
   }
 

--- a/nusight2/src/client/components/three/stories/three.stories.tsx
+++ b/nusight2/src/client/components/three/stories/three.stories.tsx
@@ -5,7 +5,6 @@ import { action } from "mobx";
 import { computed } from "mobx";
 import { reaction } from "mobx";
 import { observable } from "mobx";
-import { disposeOnUnmount } from "mobx-react";
 import { createTransformer } from "mobx-utils";
 import { now } from "mobx-utils";
 import { Color } from "three";
@@ -54,6 +53,8 @@ type Model = { boxes: BoxModel[] };
 type BoxModel = { color: string; size: number; position: Vector3; rotation: Vector3 };
 
 class BoxVisualiser extends Component<{ animate?: boolean }> {
+  private dispose?: () => void;
+
   @observable
   private readonly model = {
     boxes: [
@@ -65,11 +66,13 @@ class BoxVisualiser extends Component<{ animate?: boolean }> {
 
   componentDidMount() {
     this.update(0);
-    this.props.animate &&
-      disposeOnUnmount(
-        this,
-        reaction(() => now("frame"), this.update),
-      );
+    this.dispose?.();
+    this.dispose = this.props.animate ? reaction(() => now("frame"), this.update) : undefined;
+  }
+
+  componentWillUnmount() {
+    this.dispose?.();
+    this.dispose = undefined;
   }
 
   render() {

--- a/nusight2/src/client/components/three/stories/three.stories.tsx
+++ b/nusight2/src/client/components/three/stories/three.stories.tsx
@@ -66,7 +66,6 @@ class BoxVisualiser extends Component<{ animate?: boolean }> {
 
   componentDidMount() {
     this.update(0);
-    this.dispose?.();
     this.dispose = this.props.animate ? reaction(() => now("frame"), this.update) : undefined;
   }
 

--- a/nusight2/src/client/components/three/three.tsx
+++ b/nusight2/src/client/components/three/three.tsx
@@ -52,7 +52,6 @@ export class Three extends Component<{
     this.props.clearColor && this.renderer.setClearColor(this.props.clearColor);
     const stages = this.props.stage!(this.canvas);
     // TODO (Annable): Extract this and add unit tests.
-    this.dispose?.();
     this.dispose = compose([
       reaction(
         () => stages.get(),

--- a/nusight2/src/client/components/three/three.tsx
+++ b/nusight2/src/client/components/three/three.tsx
@@ -7,7 +7,6 @@ import { IComputedValue } from "mobx";
 import { observable } from "mobx";
 import { action } from "mobx";
 import { autorun } from "mobx";
-import { disposeOnUnmount } from "mobx-react";
 import { observer } from "mobx-react";
 import { ContentRect } from "react-measure";
 import Measure from "react-measure";
@@ -37,6 +36,8 @@ export class Three extends Component<{
   onWheel?(deltaY: number, preventDefault: () => void): void;
   renderScheduler?: (callback: () => void) => any;
 }> {
+  private dispose?: () => void;
+  private disposeStages?: () => void;
   @observable private containerSize = { width: 0, height: 0 };
   @observable private canvas: Canvas = { width: 0, height: 0 };
   private ref: HTMLCanvasElement | null = null;
@@ -51,15 +52,15 @@ export class Three extends Component<{
     this.props.clearColor && this.renderer.setClearColor(this.props.clearColor);
     const stages = this.props.stage!(this.canvas);
     // TODO (Annable): Extract this and add unit tests.
-    let dispose: () => void = () => undefined;
-    disposeOnUnmount(this, [
+    this.dispose?.();
+    this.dispose = compose([
       reaction(
         () => stages.get(),
         (stages) => {
-          dispose();
+          this.disposeStages?.();
           if (stages instanceof Array) {
             // Create individual reactions for each stage, so they may react and re-render independently.
-            dispose = compose(
+            this.disposeStages = compose(
               stages.map((stage) =>
                 autorun(() => this.renderStage(stage()), {
                   scheduler: this.props.renderScheduler ?? requestAnimationFrame,
@@ -67,11 +68,10 @@ export class Three extends Component<{
               ),
             );
           } else {
-            dispose = autorun(() => this.renderStage(stages), {
+            this.disposeStages = autorun(() => this.renderStage(stages), {
               scheduler: this.props.renderScheduler ?? requestAnimationFrame,
             });
           }
-          disposeOnUnmount(this, dispose);
         },
         { fireImmediately: true },
       ),
@@ -93,6 +93,10 @@ export class Three extends Component<{
     this.renderer?.forceContextLoss();
     this.renderer?.dispose();
     delete this.renderer;
+    this.dispose?.();
+    this.dispose = undefined;
+    this.disposeStages?.();
+    this.disposeStages = undefined;
   }
 
   render() {


### PR DESCRIPTION
The `disposeOnUnmount` function is deprecated in MobX 6 and its invocation will throw an error. This PR replaces all usages with a manual dispose method to prepare for such a day (#1503).

Converting classes to functional components would likely be a cleaner solution, but would come with a much greater scope of work.