### PR TITLE
Update NUSense offsets to current OpenCR offsets

### DIFF
--- a/module/platform/NUSense/HardwareIO/data/config/billie/HardwareIO.yaml
+++ b/module/platform/NUSense/HardwareIO/data/config/billie/HardwareIO.yaml
@@ -1,15 +1,15 @@
 servos:
   - # [0]  R_SHOULDER_PITCH
     direction: -1
-    offset: 0.0
+    offset: pi / 4
     simulated: false
   - # [1]  L_SHOULDER_PITCH
     direction: 1
-    offset: 0.0
+    offset: pi / 4 + 0.113
     simulated: false
   - # [2]  R_SHOULDER_ROLL
     direction: -1
-    offset: -pi / 4
+    offset: -pi / 4 - 0.159
     simulated: false
   - # [3]  L_SHOULDER_ROLL
     direction: -1
@@ -25,11 +25,11 @@ servos:
     simulated: false
   - # [6]  R_HIP_YAW
     direction: -1
-    offset: 0.0
+    offset: 0.0 - 0.046
     simulated: false
   - # [7]  L_HIP_YAW
     direction: -1
-    offset: 0.0
+    offset: 0.0 + 0.020
     simulated: false
   - # [8]  R_HIP_ROLL
     direction: 1
@@ -41,7 +41,7 @@ servos:
     simulated: false
   - # [10] R_HIP_PITCH
     direction: 1
-    offset: 0.0
+    offset: 0.0 + 0.013
     simulated: false
   - # [11] L_HIP_PITCH
     direction: -1
@@ -49,11 +49,11 @@ servos:
     simulated: false
   - # [12] R_KNEE
     direction: -1
-    offset: 0.0
+    offset: pi / 4
     simulated: false
   - # [13] L_KNEE
     direction: 1
-    offset: 0.0
+    offset: pi / 4
     simulated: false
   - # [14] R_ANKLE_PITCH
     direction: -1
@@ -61,7 +61,7 @@ servos:
     simulated: false
   - # [15] L_ANKLE_PITCH
     direction: 1
-    offset: 0.029
+    offset: 0.0
     simulated: false
   - # [16] R_ANKLE_ROLL
     direction: -1
@@ -69,11 +69,11 @@ servos:
     simulated: false
   - # [17] L_ANKLE_ROLL
     direction: -1
-    offset: -0.069
+    offset: 0.0
     simulated: false
   - # [18] HEAD_YAW
     direction: 1
-    offset: 0.2
+    offset: 0.0
     simulated: false
   - # [19] HEAD_PITCH
     direction: 1

--- a/module/platform/NUSense/HardwareIO/data/config/frankie/HardwareIO.yaml
+++ b/module/platform/NUSense/HardwareIO/data/config/frankie/HardwareIO.yaml
@@ -1,7 +1,7 @@
 servos:
   - # [0]  R_SHOULDER_PITCH
     direction: -1
-    offset: pi / 4
+    offset: pi / 4 + 0.162
     simulated: false
   - # [1]  L_SHOULDER_PITCH
     direction: 1
@@ -13,7 +13,7 @@ servos:
     simulated: false
   - # [3]  L_SHOULDER_ROLL
     direction: -1
-    offset: pi / 4
+    offset: pi / 4 - 0.087
     simulated: false
   - # [4]  R_ELBOW
     direction: -1
@@ -41,15 +41,15 @@ servos:
     simulated: false
   - # [10] R_HIP_PITCH
     direction: 1
-    offset: 0.23
+    offset: 0.0
     simulated: false
   - # [11] L_HIP_PITCH
     direction: -1
-    offset: 0.066
+    offset: 0.0
     simulated: false
   - # [12] R_KNEE
     direction: -1
-    offset: pi / 4
+    offset: pi / 4 + pi / 16
     simulated: false
   - # [13] L_KNEE
     direction: 1

--- a/module/platform/NUSense/HardwareIO/data/config/kevin/HardwareIO.yaml
+++ b/module/platform/NUSense/HardwareIO/data/config/kevin/HardwareIO.yaml
@@ -73,7 +73,7 @@ servos:
     simulated: false
   - # [18] HEAD_YAW
     direction: 1
-    offset: -pi / 16
+    offset: 0.0
     simulated: false
   - # [19] HEAD_PITCH
     direction: 1


### PR DESCRIPTION
Noticed when using Billie yesterday that the offsets in the NUSense HardwareIO were wrong (I assume old) and copying over the OpenCR config fixed it. Did the same for the others too.