### PR TITLE
Add robot-specific player ID config

### DIFF
--- a/module/support/configuration/GlobalConfig/data/config/nugus2/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/nugus2/GlobalConfig.yaml
@@ -1,0 +1,1 @@
+player_id: 2

--- a/module/support/configuration/GlobalConfig/data/config/nugus3/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/nugus3/GlobalConfig.yaml
@@ -1,0 +1,1 @@
+player_id: 3

--- a/module/support/configuration/GlobalConfig/data/config/nugus4/GlobalConfig.yaml
+++ b/module/support/configuration/GlobalConfig/data/config/nugus4/GlobalConfig.yaml
@@ -1,0 +1,1 @@
+player_id: 4


### PR DESCRIPTION
This means that the robots will have the player ID corresponding to their nuc number automatically.