### PR TITLE
Skip Continues in the Behaviour extension rather than the Director

### DIFF
--- a/module/extension/Director/src/director/run_task_pack.cpp
+++ b/module/extension/Director/src/director/run_task_pack.cpp
@@ -169,18 +169,6 @@ namespace module::extension {
             return;
         }
 
-        // See if a Idle command was emitted
-        for (const auto& t : requested_tasks) {
-            if (t->type == typeid(::extension::behaviour::Continue)) {
-                if (requested_tasks.size() > 1) {
-                    log<WARN>("Idle task was emitted with other tasks, the other tasks will be ignored");
-                }
-
-                // We don't do anything else on idle
-                return;
-            }
-        }
-
         // See if a done command was emitted
         for (const auto& t : requested_tasks) {
             if (t->type == typeid(::extension::behaviour::Done)) {

--- a/shared/extension/Behaviour.hpp
+++ b/shared/extension/Behaviour.hpp
@@ -38,7 +38,7 @@
 #include "behaviour/RunReason.hpp"
 #include "behaviour/TaskData.hpp"
 #include "behaviour/commands.hpp"
-#include "behaviour/unique_tasks.hpp"
+#include "behaviour/task_types.hpp"
 
 namespace extension::behaviour {
 

--- a/shared/extension/Behaviour.hpp
+++ b/shared/extension/Behaviour.hpp
@@ -38,6 +38,7 @@
 #include "behaviour/RunReason.hpp"
 #include "behaviour/TaskData.hpp"
 #include "behaviour/commands.hpp"
+#include "behaviour/unique_tasks.hpp"
 
 namespace extension::behaviour {
 
@@ -400,45 +401,6 @@ namespace extension::behaviour {
             /// Emit using the provider scope as it will know how to handle the task
             ProviderScope::emit<T>(powerplant, data, priority, optional, name);
         }
-    };
-
-    /**
-     * This is a special task that should be emitted when a Provider finishes the task it was given.
-     * When this is emitted the director will re-execute the Provider which caused this task to run.
-     *
-     * ```
-     * emit<Task>(std::make_unique<Done>());
-     * ```
-     */
-    struct Done {};
-
-    /**
-     * This is a special task that should be emitted when a Provider doesn't want to change what it is doing.
-     * When this is emitted the director will just continue with whatever was previously emitted by this provider.
-     *
-     * ```
-     * emit<Task>(std::make_unique<Continue>());
-     * ```
-     */
-    struct Continue {};
-
-    /**
-     * This is a special task that can be emitted to trigger the Provider to run again at a given time.
-     *
-     * ```
-     * emit<Task>(std::make_unique<Wait>(NUClear::clock::now() + std::chrono::milliseconds(100)));
-     * ```
-     */
-    struct Wait {
-        /// The time at which the Provider should run again
-        NUClear::clock::time_point time;
-
-        /**
-         * Create a new Wait task with the time at which the Provider should run again.
-         *
-         * @param time the time at which the Provider should run again
-         */
-        explicit Wait(const NUClear::clock::time_point& time) : time(time) {}
     };
 
     /**

--- a/shared/extension/behaviour/ProviderScope.hpp
+++ b/shared/extension/behaviour/ProviderScope.hpp
@@ -31,7 +31,7 @@
 
 #include "RunReason.hpp"
 #include "commands.hpp"
-#include "unique_tasks.hpp"
+#include "task_types.hpp"
 
 namespace extension::behaviour {
     /**

--- a/shared/extension/behaviour/task_types.hpp
+++ b/shared/extension/behaviour/task_types.hpp
@@ -73,5 +73,4 @@ namespace extension::behaviour {
 
 }  // namespace extension::behaviour
 
-
 #endif  // EXTENSION_BEHAVIOUR_TASK_TYPES_HPP

--- a/shared/extension/behaviour/task_types.hpp
+++ b/shared/extension/behaviour/task_types.hpp
@@ -25,8 +25,8 @@
  * SOFTWARE.
  */
 
-#ifndef EXTENSION_BEHAVIOUR_UNIQUE_TASKS_HPP
-#define EXTENSION_BEHAVIOUR_UNIQUE_TASKS_HPP
+#ifndef EXTENSION_BEHAVIOUR_TASK_TYPES_HPP
+#define EXTENSION_BEHAVIOUR_TASK_TYPES_HPP
 
 #include <nuclear>
 
@@ -74,4 +74,4 @@ namespace extension::behaviour {
 }  // namespace extension::behaviour
 
 
-#endif
+#endif  // EXTENSION_BEHAVIOUR_TASK_TYPES_HPP

--- a/shared/extension/behaviour/unique_tasks.hpp
+++ b/shared/extension/behaviour/unique_tasks.hpp
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef EXTENSION_BEHAVIOUR_UNIQUE_TASKS_HPP
+#define EXTENSION_BEHAVIOUR_UNIQUE_TASKS_HPP
+
+#include <nuclear>
+
+namespace extension::behaviour {
+
+    /**
+     * This is a special task that should be emitted when a Provider finishes the task it was given.
+     * When this is emitted the director will re-execute the Provider which caused this task to run.
+     *
+     * ```
+     * emit<Task>(std::make_unique<Done>());
+     * ```
+     */
+    struct Done {};
+
+    /**
+     * This is a special task that should be emitted when a Provider doesn't want to change what it is doing.
+     * When this is emitted the director will just continue with whatever was previously emitted by this provider.
+     *
+     * ```
+     * emit<Task>(std::make_unique<Continue>());
+     * ```
+     */
+    struct Continue {};
+
+    /**
+     * This is a special task that can be emitted to trigger the Provider to run again at a given time.
+     *
+     * ```
+     * emit<Task>(std::make_unique<Wait>(NUClear::clock::now() + std::chrono::milliseconds(100)));
+     * ```
+     */
+    struct Wait {
+        /// The time at which the Provider should run again
+        NUClear::clock::time_point time;
+
+        /**
+         * Create a new Wait task with the time at which the Provider should run again.
+         *
+         * @param time the time at which the Provider should run again
+         */
+        explicit Wait(const NUClear::clock::time_point& time) : time(time) {}
+    };
+
+}  // namespace extension::behaviour
+
+
+#endif


### PR DESCRIPTION
Instead of emitting the task pack to Director and getting `run_task_pack` to check for `Continue`s, just do the check in the Behaviour extension before it reaches the Director. 

The purpose of this is to reduce the number of things the Director thread needs to do, as it is running on one thread with a lot to do.