### PR TITLE
Add ability to use VisualMesh with GPU in Docker + Change webots image format to RGBA

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -435,6 +435,8 @@ RUN chmod 440 /etc/sudoers.d/user
 ARG user_uid=1000
 ARG user_gid=$user_uid
 ARG dialout_gid=20
+ARG video_gid=44
+ARG render_gid=110
 
 # useradd -G is not sufficient to add the nubots user to the dialout
 # group as docker manages to lose supplementary groups when changing
@@ -442,8 +444,10 @@ ARG dialout_gid=20
 # Also need to add "--group-add dialout" to the docker run command in run.py
 # Add user to uucp as well so people can directly test with arch/ubuntu/pop devices
 RUN groupadd --gid $dialout_gid dialout \
+    && groupadd --gid $video_gid video_host \
+    && groupadd --gid $render_gid render_host \
     && groupadd --gid $user_gid nubots \
-    && useradd --uid $user_uid --gid nubots -G audio,dialout,uucp -m nubots
+    && useradd --uid $user_uid --gid nubots -G audio,dialout,uucp,video_host,render_host -m nubots
 
 USER nubots
 

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -840,7 +840,7 @@ namespace module::platform {
             // Read each field of msg, translate it to our protobuf and emit the data
             auto sensor_data = std::make_unique<RawSensors>();
 
-            sensor_data->timestamp = NUClear::clock::now();
+            sensor_data->timestamp = NUClear::clock::time_point(std::chrono::milliseconds(sensor_measurements.time));
 
             for (const auto& position : sensor_measurements.position_sensors) {
                 auto& servo            = translate_servo_id(position.name, sensor_data->servo);
@@ -921,11 +921,11 @@ namespace module::platform {
             image->name           = camera.name;
             image->dimensions.x() = camera.width;
             image->dimensions.y() = camera.height;
-            image->format         = fourcc("BGR3");  // Change to "JPEG" when webots compression is implemented
+            image->format         = fourcc("RGBA");  // Change to "JPEG" when webots compression is implemented
             image->data           = camera.image;
 
             image->id        = camera_context[camera.name].id;
-            image->timestamp = NUClear::clock::now();
+            image->timestamp = NUClear::clock::time_point(std::chrono::milliseconds(sensor_measurements.time));
 
             Eigen::Isometry3d Hcw;
 

--- a/module/vision/VisualMesh/data/config/webots/VisualMesh.yaml
+++ b/module/vision/VisualMesh/data/config/webots/VisualMesh.yaml
@@ -6,13 +6,12 @@
 #   spotlight:
 #     distance: the distance range for the spotlight mesh to be generated for
 #     radius: the search radius to do at that distance (NOT THE RADIUS OF THE OBJECT)
-
 cameras:
   left_camera:
     concurrent: 2
     network: config/networks/WebotsNetwork.yaml
-    engine: cpu
-    cache_directory: "" # unneeded for cpu engine
+    engine: opencl
+    cache_directory: "./vision_cache/"
     classifier:
       height: [0.5, 1.0]
       max_distance: 11

--- a/module/vision/Yolo/data/config/webots/Yolo.yaml
+++ b/module/vision/Yolo/data/config/webots/Yolo.yaml
@@ -23,4 +23,4 @@ nms_threshold: 0.5
 nms_score_threshold: 0.1
 
 # OpenVino device (CPU, GPU)
-device: CPU
+device: GPU

--- a/module/vision/Yolo/src/Yolo.cpp
+++ b/module/vision/Yolo/src/Yolo.cpp
@@ -109,6 +109,10 @@ namespace module::vision {
                         img_cv = cv::Mat(height, width, CV_8UC1, const_cast<uint8_t*>(img.data.data()));
                         cv::cvtColor(img_cv, img_cv, cv::COLOR_BayerRG2RGB);
                         break;
+                    case utility::vision::fourcc("RGBA"):
+                        img_cv = cv::Mat(height, width, CV_8UC4, const_cast<uint8_t*>(img.data.data()));
+                        cv::cvtColor(img_cv, img_cv, cv::COLOR_RGBA2BGR);
+                        break;
                     default: log<WARN>("Image format not supported: ", utility::vision::fourcc(img.format)); return;
                 }
 

--- a/tools/utility/dockerise/run.py
+++ b/tools/utility/dockerise/run.py
@@ -174,6 +174,11 @@ def run(func, image, hostname="docker", ports=[], docker_context=None):
             "audio",
             "--group-add",
             "dialout",
+            "--group-add",
+            "video_host",
+            "--group-add",
+            "render_host",
+            "--privileged",
         ]
 
         # Work out if we are using an internal image


### PR DESCRIPTION
This PR make required changes to use opencl engine with the VisualMesh which increases runtime performance in webots a considerable amount. The user will need to have a gpu/igpu which supports opencl.

This requires the following PR on the webots side : https://github.com/NUbots/NUWebots/pull/103
