### PR TITLE
Fix script tuner play by specifying TIME as the done condition for scripts

### DIFF
--- a/shared/utility/skill/Script.hpp
+++ b/shared/utility/skill/Script.hpp
@@ -246,7 +246,10 @@ namespace utility::skill {
             // Add the servos in the frame to a map
             std::map<uint32_t, ServoCommand> servos{};
             for (const auto& target : frame.targets) {
-                servos[target.id] = ServoCommand(time, target.position, ServoState(target.gain, target.torque));
+                servos[target.id] = ServoCommand(time,
+                                                 target.position,
+                                                 ServoState(target.gain, target.torque),
+                                                 ServoCommand::DoneType::TIME);
             }
 
             // Add the map to the pack. This represents one sequence of servos.


### PR DESCRIPTION
`play` not working was because we have a new enum for 'when should a servo be considered done?' in the `ServoCommand` message, and while it was set to `TIME`-based in the normal script function, there was another overloaded function missed here (which is used by script tuner) that hadn't got the field set. Since it wasn't set, it defaulted to `NONE`.

This PR sets the servo Done condition to `TIME` for the load_script function that was missed in the original PR and results in `play` working in script tuner.