### PR TITLE
Fix GitHub actions runner out of memory during docker image build

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -31,6 +31,15 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # Free up space on the runner
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # Remove unneeded tools to free up more space
+          android: true
+          dotnet: true
+          haskell: true
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/nubots.yaml
+++ b/.github/workflows/nubots.yaml
@@ -50,6 +50,20 @@ jobs:
             cpp_changes:
               - '!{nusight2,.vscode,tools}/**'
 
+  # Free space for the Docker image
+  free-disk-space:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          android: false
+          dotnet: false
+          haskell: false
+
   # Build the docker image. This job is not conditional since we don't want it skipped
   # because other jobs depend on it. The actual building of the image is cached, so it
   # won't be doing unnecessary work if there are no relevant Dockerfile changes.

--- a/.github/workflows/nubots.yaml
+++ b/.github/workflows/nubots.yaml
@@ -51,11 +51,11 @@ jobs:
               - '!{nusight2,.vscode,tools}/**'
 
   # Free space for the Docker image
-  free-disk-space:
+  free_disk_space:
     runs-on: ubuntu-22.04
     steps:
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
@@ -69,6 +69,7 @@ jobs:
   # won't be doing unnecessary work if there are no relevant Dockerfile changes.
   build_docker:
     name: "Build docker image"
+    needs: [free_disk_space]
 
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04

--- a/.github/workflows/nubots.yaml
+++ b/.github/workflows/nubots.yaml
@@ -69,12 +69,10 @@ jobs:
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-          android: false
-          dotnet: false
-          haskell: false
+          # Remove unneeded tools to free up more space
+          android: true
+          dotnet: true
+          haskell: true
 
       # Figure out the tag to use for the Docker image
       - name: Set Docker tag

--- a/.github/workflows/nubots.yaml
+++ b/.github/workflows/nubots.yaml
@@ -50,26 +50,11 @@ jobs:
             cpp_changes:
               - '!{nusight2,.vscode,tools}/**'
 
-  # Free space for the Docker image
-  free_disk_space:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-          android: false
-          dotnet: false
-          haskell: false
-
   # Build the docker image. This job is not conditional since we don't want it skipped
   # because other jobs depend on it. The actual building of the image is cached, so it
   # won't be doing unnecessary work if there are no relevant Dockerfile changes.
   build_docker:
     name: "Build docker image"
-    needs: [free_disk_space]
 
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
@@ -80,6 +65,17 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # Free up space on the runner
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          android: false
+          dotnet: false
+          haskell: false
+
       # Figure out the tag to use for the Docker image
       - name: Set Docker tag
         run: |

--- a/.github/workflows/nusight.yaml
+++ b/.github/workflows/nusight.yaml
@@ -70,6 +70,15 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # Free up space on the runner
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # Remove unneeded tools to free up more space
+          android: true
+          dotnet: true
+          haskell: true
+
       # Figure out the tag to use for the Docker image
       - name: Set Docker tag
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -410,7 +410,11 @@ RUN pip install \
     Pillow \
     protobuf==4.21.2 \
     mycroft-mimic3-tts \
-    tqdm
+    tqdm \
+    optuna \
+    ruamel.yaml \
+    plotly \
+    scikit-learn
 
 # Install tools needed for building individual modules as well as development tools
 RUN install-package \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -410,11 +410,7 @@ RUN pip install \
     Pillow \
     protobuf==4.21.2 \
     mycroft-mimic3-tts \
-    tqdm \
-    optuna \
-    ruamel.yaml \
-    plotly \
-    scikit-learn
+    tqdm
 
 # Install tools needed for building individual modules as well as development tools
 RUN install-package \


### PR DESCRIPTION
A couple of PRs the last few days have encountered this issue where our Docker image is using too much disk space. We run CI on Ubuntu, and there are many packages that can be cut down to gain disk space. 

This tool https://github.com/marketplace/actions/free-disk-space-ubuntu seems to be a nice addition to do this, and cuts almost 30GB leaving us with room for growth.

Tested with adding libraries, observing it fail from disk space error, and applied the workflow update which resulted in the checks passing. Reverted the added libraries.