### PR TITLE
Fix warnings in NUsight coming from text component

### DIFF
--- a/nusight2/src/client/components/localisation/r3f_components/text_billboard.tsx
+++ b/nusight2/src/client/components/localisation/r3f_components/text_billboard.tsx
@@ -44,17 +44,10 @@ export const TextBillboard = ({
 }) => {
   const textGeometry = useTextGeometry(text);
 
-  const textWidth = textGeometry?.boundingBox
-    ? textGeometry.boundingBox.max.x - textGeometry.boundingBox.min.x
-    : 0;
-  const textHeight = textGeometry?.boundingBox
-    ? textGeometry.boundingBox.max.y - textGeometry.boundingBox.min.y
-    : 0;
+  const textWidth = textGeometry?.boundingBox ? textGeometry.boundingBox.max.x - textGeometry.boundingBox.min.x : 0;
+  const textHeight = textGeometry?.boundingBox ? textGeometry.boundingBox.max.y - textGeometry.boundingBox.min.y : 0;
 
-  const backdropGeometry = useMemo(
-    () => textBackdropGeometry(textWidth, textHeight),
-    [textWidth, textHeight]
-  );
+  const backdropGeometry = useMemo(() => textBackdropGeometry(textWidth, textHeight), [textWidth, textHeight]);
 
   if (!textGeometry) return null;
 

--- a/nusight2/src/client/components/localisation/r3f_components/text_billboard.tsx
+++ b/nusight2/src/client/components/localisation/r3f_components/text_billboard.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import * as THREE from "three";
 
-import { TextGeometryHelper } from "./text_geometry_helper";
+import { useTextGeometry } from "./text_geometry_helper";
 
 const TEXT_OPACITY = 1;
 const TEXT_BACKDROP_OPACITY = 0.5;
@@ -24,9 +24,7 @@ const textBackdropGeometry = (width: number, height: number) => {
   shape.lineTo(x + radius, y);
   shape.quadraticCurveTo(x, y, x, y + radius);
 
-  const geometry = new THREE.ShapeGeometry(shape);
-
-  return geometry;
+  return new THREE.ShapeGeometry(shape);
 };
 
 export const TextBillboard = ({
@@ -44,11 +42,24 @@ export const TextBillboard = ({
   cameraPitch: number;
   cameraYaw: number;
 }) => {
-  const textGeometry = useMemo(() => TextGeometryHelper(text), [text]);
-  textGeometry.computeBoundingBox();
-  const textWidth = textGeometry.boundingBox ? textGeometry.boundingBox.max.x - textGeometry.boundingBox.min.x : 0;
-  const textHeight = textGeometry.boundingBox ? textGeometry.boundingBox.max.y - textGeometry.boundingBox.min.y : 0;
-  const backdropGeometry = useMemo(() => textBackdropGeometry(textWidth, textHeight), [textWidth, textHeight]);
+  const textGeometry = useTextGeometry(text);
+
+  // Always define fallback dimensions
+  const textWidth = textGeometry?.boundingBox
+    ? textGeometry.boundingBox.max.x - textGeometry.boundingBox.min.x
+    : 0;
+  const textHeight = textGeometry?.boundingBox
+    ? textGeometry.boundingBox.max.y - textGeometry.boundingBox.min.y
+    : 0;
+
+  // ✅ Always call useMemo
+  const backdropGeometry = useMemo(
+    () => textBackdropGeometry(textWidth, textHeight),
+    [textWidth, textHeight]
+  );
+
+  // Early return to avoid rendering broken mesh
+  if (!textGeometry) return null;
 
   return (
     <object3D position={position} rotation={[Math.PI / 2 + cameraPitch, 0, -Math.PI / 2 + cameraYaw, "ZXY"]}>

--- a/nusight2/src/client/components/localisation/r3f_components/text_billboard.tsx
+++ b/nusight2/src/client/components/localisation/r3f_components/text_billboard.tsx
@@ -44,7 +44,6 @@ export const TextBillboard = ({
 }) => {
   const textGeometry = useTextGeometry(text);
 
-  // Always define fallback dimensions
   const textWidth = textGeometry?.boundingBox
     ? textGeometry.boundingBox.max.x - textGeometry.boundingBox.min.x
     : 0;
@@ -52,13 +51,11 @@ export const TextBillboard = ({
     ? textGeometry.boundingBox.max.y - textGeometry.boundingBox.min.y
     : 0;
 
-  // ✅ Always call useMemo
   const backdropGeometry = useMemo(
     () => textBackdropGeometry(textWidth, textHeight),
     [textWidth, textHeight]
   );
 
-  // Early return to avoid rendering broken mesh
   if (!textGeometry) return null;
 
   return (

--- a/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
+++ b/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { TextGeometry } from "three/examples/jsm/geometries/TextGeometry";
-import { FontLoader } from "three/examples/jsm/loaders/FontLoader";
 import type { Font } from "three/examples/jsm/loaders/FontLoader";
+import { FontLoader } from "three/examples/jsm/loaders/FontLoader";
 
 export const useTextGeometry = (text: string): TextGeometry | null => {
   const [geometry, setGeometry] = useState<TextGeometry | null>(null);

--- a/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
+++ b/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
@@ -3,7 +3,6 @@ import { TextGeometry } from "three/examples/jsm/geometries/TextGeometry";
 import { FontLoader } from "three/examples/jsm/loaders/FontLoader";
 import type { Font } from "three/examples/jsm/loaders/FontLoader";
 
-// Hook: properly named and safe to call
 export const useTextGeometry = (text: string): TextGeometry | null => {
   const [geometry, setGeometry] = useState<TextGeometry | null>(null);
 
@@ -14,7 +13,7 @@ export const useTextGeometry = (text: string): TextGeometry | null => {
       const newGeometry = new TextGeometry(text, {
         font,
         size: 0.1,
-        height: 0,
+        depth: 0,
       });
       setGeometry(newGeometry);
     });

--- a/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
+++ b/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { TextGeometry } from "three/examples/jsm/geometries/TextGeometry";
-import type { Font } from "three/examples/jsm/loaders/FontLoader";
 import { FontLoader } from "three/examples/jsm/loaders/FontLoader";
 
 export const useTextGeometry = (text: string): TextGeometry | null => {

--- a/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
+++ b/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useState } from "react";
 import { TextGeometry } from "three/examples/jsm/geometries/TextGeometry";
 import { FontLoader } from "three/examples/jsm/loaders/FontLoader";
+import type { Font } from "three/examples/jsm/loaders/FontLoader";
 
-export const TextGeometryHelper = (text: string): TextGeometry => {
+// Hook: properly named and safe to call
+export const useTextGeometry = (text: string): TextGeometry | null => {
   const [geometry, setGeometry] = useState<TextGeometry | null>(null);
 
   useEffect(() => {
     const loader = new FontLoader();
 
-    // Load font asynchronously
-    loader.load("/fonts/roboto/Roboto_Medium_Regular.json", (font: any) => {
+    loader.load("/fonts/roboto/Roboto_Medium_Regular.json", (font: Font) => {
       const newGeometry = new TextGeometry(text, {
-        font: font,
+        font,
         size: 0.1,
         height: 0,
       });
@@ -19,5 +20,5 @@ export const TextGeometryHelper = (text: string): TextGeometry => {
     });
   }, [text]);
 
-  return geometry || new TextGeometry("");
+  return geometry;
 };

--- a/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
+++ b/nusight2/src/client/components/localisation/r3f_components/text_geometry_helper.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { TextGeometry } from "three/examples/jsm/geometries/TextGeometry";
 import { FontLoader } from "three/examples/jsm/loaders/FontLoader";
+import type { Font } from "three/examples/jsm/loaders/FontLoader";
 
 export const useTextGeometry = (text: string): TextGeometry | null => {
   const [geometry, setGeometry] = useState<TextGeometry | null>(null);


### PR DESCRIPTION
When running `./b yarn start`, I encountered the warning

```
Warning: Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. You can only call Hooks at the top level of your React function. For more information, see https://reactjs.org/link/rules-of-hooks Error Component Stack
    at TextBillboard (text_billboard.tsx:43:3)
    at PurposeLabel (purpose_label.tsx:18:3)
    at object3D (<anonymous>)
```

There was also another warning to do with height being deprecated for depth. 

This PR updates the billboard text code to no longer produce either of these warnings.