### PR TITLE
Refactor RobotLocalisation to make way for more functionality (eg team association)

### DIFF
--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
@@ -92,11 +92,7 @@ namespace module::localisation {
                 maintenance(horizon);
 
                 // **Debugging output**
-                // Print tracked_robots ids
-                log<DEBUG>("Robots tracked:");
-                for (const auto& tracked_robot : tracked_robots) {
-                    log<DEBUG>("\tID: ", tracked_robot.id);
-                }
+                debug_info();
 
                 // **Emit the localisation of the robots**
                 auto localisation_robots = std::make_unique<LocalisationRobots>();
@@ -199,6 +195,14 @@ namespace module::localisation {
         }
 
         tracked_robots = std::move(new_tracked_robots);
+    }
+
+    void RobotLocalisation::debug_info() {
+        // Print tracked_robots ids
+        log<DEBUG>("Robots tracked:");
+        for (const auto& tracked_robot : tracked_robots) {
+            log<DEBUG>("\tID: ", tracked_robot.id);
+        }
     }
 
 }  // namespace module::localisation

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
@@ -31,7 +31,6 @@
 #include "extension/Configuration.hpp"
 
 #include "message/localisation/Robot.hpp"
-#include "message/vision/GreenHorizon.hpp"
 #include "message/vision/Robot.hpp"
 
 #include "utility/nusight/NUhelpers.hpp"
@@ -72,123 +71,134 @@ namespace module::localisation {
             cfg.max_missed_count                = config["max_missed_count"].as<int>();
         });
 
+        on<Trigger<VisionRobots>, With<GreenHorizon>, Single>().then(
+            [this](const VisionRobots& vision_robots, const GreenHorizon& horizon) {
+                // **Run prediction step**
+                prediction();
 
-        on<Trigger<VisionRobots>, With<GreenHorizon>, Single>().then([this](const VisionRobots& vision_robots,
-                                                                            const GreenHorizon& horizon) {
-            // Print tracked_robots ids
-            log<DEBUG>("Robots tracked:");
-            for (const auto& tracked_robot : tracked_robots) {
-                log<DEBUG>("\tID: ", tracked_robot.id);
-            }
-
-            // Set all tracked robots to unseen
-            for (auto& tracked_robot : tracked_robots) {
-                tracked_robot.seen = false;
-            }
-
-            // **************** Data association ****************
-            if (!vision_robots.robots.empty()) {
+                // **Data association**
+                // Transform the robot positions from camera coordinates to world coordinates
                 Eigen::Isometry3d Hwc = Eigen::Isometry3d(vision_robots.Hcw).inverse();
+                // Make a vector with the transformed position
+                std::vector<Eigen::Vector3d> robots_rRWw{};
                 for (const auto& vision_robot : vision_robots.robots) {
-                    // Position of robot {r} in world {w} space
-                    auto rRWw = Hwc * vision_robot.rRCc;
-
-                    // Data association: find tracked robot which is associated with the vision measurement
-                    data_association(rRWw);
+                    Eigen::Vector3d rRWw = Hwc * vision_robot.rRCc;
+                    robots_rRWw.push_back(rRWw);
                 }
-            }
+                // Run data association
+                data_association(robots_rRWw);
 
-            // **************** Robot tracking maintenance ****************
-            for (auto& tracked_robot : tracked_robots) {
-                auto state = RobotModel<double>::StateVec(tracked_robot.ukf.get_state());
+                // **Run maintenance step**
+                maintenance(horizon);
 
-                // If a tracked robot has moved outside of view, keep it as seen so we don't lose it
-                // A robot is outside of view if it is not within the green horizon
-                // TODO (tom): It may be better to use fov and image size to determine if a robot should be seen
-                if (!point_in_convex_hull(horizon.horizon, Eigen::Vector3d(state.rRWw.x(), state.rRWw.y(), 0))) {
-                    tracked_robot.seen = true;
+                // **Debugging output**
+                // Print tracked_robots ids
+                log<DEBUG>("Robots tracked:");
+                for (const auto& tracked_robot : tracked_robots) {
+                    log<DEBUG>("\tID: ", tracked_robot.id);
                 }
 
-                // If the tracked robot has not been seen, increment the consecutively missed count
-                tracked_robot.missed_count = tracked_robot.seen ? 0 : tracked_robot.missed_count + 1;
-            }
-
-            // Make a vector to store kept robots
-            std::vector<TrackedRobot> new_tracked_robots;
-            // Only keep robots that are not missing or too close to others
-            for (const auto& tracked_robot : tracked_robots) {
-                if (tracked_robot.missed_count > cfg.max_missed_count) {
-                    log<DEBUG>(fmt::format("Removing robot {} due to missed count", tracked_robot.id));
-                    continue;
+                // **Emit the localisation of the robots**
+                auto localisation_robots = std::make_unique<LocalisationRobots>();
+                for (const auto& tracked_robot : tracked_robots) {
+                    auto state = RobotModel<double>::StateVec(tracked_robot.ukf.get_state());
+                    LocalisationRobot localisation_robot;
+                    localisation_robot.id                  = tracked_robot.id;
+                    localisation_robot.rRWw                = Eigen::Vector3d(state.rRWw.x(), state.rRWw.y(), 0);
+                    localisation_robot.vRw                 = Eigen::Vector3d(state.vRw.x(), state.vRw.y(), 0);
+                    localisation_robot.covariance          = tracked_robot.ukf.get_covariance();
+                    localisation_robot.time_of_measurement = tracked_robot.last_time_update;
+                    localisation_robots->robots.push_back(localisation_robot);
                 }
-
-                if (std::any_of(tracked_robots.begin(), tracked_robots.end(), [&](const auto& other_robot) {
-                        return &tracked_robot != &other_robot
-                               && (tracked_robot.get_rRWw() - other_robot.get_rRWw()).norm() < cfg.association_distance;
-                    })) {
-                    log<DEBUG>(fmt::format("Removing robot {} due to proximity", tracked_robot.id));
-                    continue;
-                }
-
-                // If neither case is true, keep the robot
-                new_tracked_robots.push_back(tracked_robot);
-            }
-            tracked_robots = std::move(new_tracked_robots);
-
-            // Emit the localisation of the robots
-            auto localisation_robots = std::make_unique<LocalisationRobots>();
-            for (const auto& tracked_robot : tracked_robots) {
-                auto state = RobotModel<double>::StateVec(tracked_robot.ukf.get_state());
-                LocalisationRobot localisation_robot;
-                localisation_robot.id                  = tracked_robot.id;
-                localisation_robot.rRWw                = Eigen::Vector3d(state.rRWw.x(), state.rRWw.y(), 0);
-                localisation_robot.vRw                 = Eigen::Vector3d(state.vRw.x(), state.vRw.y(), 0);
-                localisation_robot.covariance          = tracked_robot.ukf.get_covariance();
-                localisation_robot.time_of_measurement = tracked_robot.last_time_update;
-                localisation_robots->robots.push_back(localisation_robot);
-            }
-            emit(std::move(localisation_robots));
-        });
+                emit(std::move(localisation_robots));
+            });
     }
 
-    void RobotLocalisation::data_association(const Eigen::Vector3d& rRWw) {
-        // If we have no robots yet, this must be a new robot
-        if (tracked_robots.empty()) {
-            tracked_robots.emplace_back(TrackedRobot(rRWw, cfg.ukf, next_id++));
-            return;
-        }
-
-        // Get the closest robot we have to the given vision measurement
-        auto closest_robot_itr =
-            std::min_element(tracked_robots.begin(),
-                             tracked_robots.end(),
-                             [&rRWw](const TrackedRobot& a, const TrackedRobot& b) {
-                                 // Get each robot's x-y 2D position in the world
-                                 auto a_rRWw = a.get_rRWw();
-                                 auto b_rRWw = b.get_rRWw();
-                                 // Compare to see which is closer to the robot vision measurement position
-                                 return (rRWw.head<2>() - a_rRWw).norm() < (rRWw.head<2>() - b_rRWw).norm();
-                             });
-        double closest_distance = (rRWw.head<2>() - closest_robot_itr->get_rRWw()).norm();
-
-        // If the closest robot is far enough away, add this as a new robot
-        if (closest_distance > cfg.association_distance) {
-            tracked_robots.emplace_back(TrackedRobot(rRWw, cfg.ukf, next_id++));
-            return;
-        }
-
-        // Update the filter on the robot associated with the vision measurement
+    void RobotLocalisation::prediction() {
         auto now = NUClear::clock::now();
-        const auto dt =
-            std::chrono::duration_cast<std::chrono::duration<double>>(now - closest_robot_itr->last_time_update)
-                .count();
-        closest_robot_itr->last_time_update = now;
-        closest_robot_itr->ukf.time(dt);
-        closest_robot_itr->ukf.measure(Eigen::Vector2d(rRWw.head<2>()),
-                                       cfg.ukf.noise.measurement.position,
-                                       MeasurementType::ROBOT_POSITION());
-        closest_robot_itr->seen = true;
+
+        for (auto& tracked_robot : tracked_robots) {
+            double dt =
+                std::chrono::duration_cast<std::chrono::duration<double>>(now - tracked_robot.last_time_update).count();
+            tracked_robot.last_time_update = now;
+            tracked_robot.ukf.time(dt);
+            tracked_robot.seen = false;
+        }
     }
 
+    void RobotLocalisation::data_association(const std::vector<Eigen::Vector3d>& robots_rRWw) {
+        for (const auto& rRWw : robots_rRWw) {
+            if (tracked_robots.empty()) {
+                // If there are no tracked robots, add this as a new robot
+                tracked_robots.emplace_back(TrackedRobot(rRWw, cfg.ukf, next_id++));
+                tracked_robots.back().seen = true;
+                continue;
+            }
+
+            // Get the closest robot we have to the given vision measurement
+            auto closest_robot_itr =
+                std::min_element(tracked_robots.begin(),
+                                 tracked_robots.end(),
+                                 [&rRWw](const TrackedRobot& a, const TrackedRobot& b) {
+                                     // Get each robot's x-y 2D position in the world
+                                     auto a_rRWw = a.get_rRWw();
+                                     auto b_rRWw = b.get_rRWw();
+                                     // Compare to see which is closer to the robot vision measurement position
+                                     return (rRWw.head<2>() - a_rRWw).norm() < (rRWw.head<2>() - b_rRWw).norm();
+                                 });
+            double closest_distance = (rRWw.head<2>() - closest_robot_itr->get_rRWw()).norm();
+
+            // If the closest robot is far enough away, add this as a new robot
+            if (closest_distance > cfg.association_distance) {
+                tracked_robots.emplace_back(TrackedRobot(rRWw, cfg.ukf, next_id++));
+                tracked_robots.back().seen = true;
+                return;
+            }
+            else {
+                closest_robot_itr->ukf.measure(Eigen::Vector2d(rRWw.head<2>()),
+                                               cfg.ukf.noise.measurement.position,
+                                               MeasurementType::ROBOT_POSITION());
+                closest_robot_itr->seen = true;
+            }
+        }
+    }
+
+    void RobotLocalisation::maintenance(const GreenHorizon& horizon) {
+        std::vector<TrackedRobot> new_tracked_robots{};
+
+        for (auto& tracked_robot : tracked_robots) {
+            auto state = RobotModel<double>::StateVec(tracked_robot.ukf.get_state());
+
+            // If a tracked robot has moved outside of view, keep it as seen so we don't lose it
+            // A robot is outside of view if it is not within the green horizon
+            // TODO (tom): It may be better to use fov and image size to determine if a robot should be seen
+            if (!point_in_convex_hull(horizon.horizon, Eigen::Vector3d(state.rRWw.x(), state.rRWw.y(), 0))) {
+                tracked_robot.seen = true;
+            }
+
+            // If the tracked robot has not been seen, increment the consecutively missed count
+            tracked_robot.missed_count = tracked_robot.seen ? 0 : tracked_robot.missed_count + 1;
+
+            // Don't add this robot if it has been missed too many times
+            if (tracked_robot.missed_count > cfg.max_missed_count) {
+                log<DEBUG>(fmt::format("Removing robot {} due to missed count", tracked_robot.id));
+                continue;
+            }
+
+            // Check if this robot is too close to any kept robot
+            if (std::any_of(new_tracked_robots.begin(), new_tracked_robots.end(), [&](const auto& other_robot) {
+                    return (tracked_robot.get_rRWw() - other_robot.get_rRWw()).norm() < cfg.association_distance;
+                })) {
+                log<DEBUG>(fmt::format("Removing robot {} due to proximity", tracked_robot.id));
+                continue;
+            }
+
+
+            // If removal conditions not met, keep the robot
+            new_tracked_robots.push_back(tracked_robot);
+        }
+
+        tracked_robots = std::move(new_tracked_robots);
+    }
 
 }  // namespace module::localisation

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
@@ -197,7 +197,7 @@ namespace module::localisation {
         tracked_robots = std::move(new_tracked_robots);
     }
 
-    void RobotLocalisation::debug_info() {
+    void RobotLocalisation::debug_info() const {
         // Print tracked_robots ids
         log<DEBUG>("Robots tracked:");
         for (const auto& tracked_robot : tracked_robots) {

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
@@ -116,6 +116,9 @@ namespace module::localisation {
         /// @param horizon The green horizon from the vision system, to determine if a robot is in view
         void maintenance(const message::vision::GreenHorizon& horizon);
 
+        /// @brief Print out the current state of the tracked robots
+        void debug_info() const;
+
     public:
         /// @brief Called by the powerplant to build and setup the RobotLocalisation reactor.
         explicit RobotLocalisation(std::unique_ptr<NUClear::Environment> environment);

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
@@ -32,6 +32,8 @@
 
 #include "RobotModel.hpp"
 
+#include "message/vision/GreenHorizon.hpp"
+
 #include "utility/math/filter/UKF.hpp"
 
 namespace module::localisation {
@@ -100,6 +102,19 @@ namespace module::localisation {
         /// This variable will increase by one each time a new robot is added
         /// As it is unbounded, an unsigned long is used to store it
         unsigned long next_id = 0;
+
+        /// @brief Run Kalman filter prediction step for all tracked robots
+        void prediction();
+
+        /// @brief Associate the given robot measurements with the tracked robots
+        /// Creates a new tracked robot if the measurement is not associated with an existing robot
+        /// @param robots_rRWw The new robot measurements in world coordinates
+        void data_association(const std::vector<Eigen::Vector3d>& robots_rRWw);
+
+        /// @brief Run maintenance on the tracked robots
+        /// This will remove any viewable robots that have been missed too many times or are too close to another robot
+        /// @param horizon The green horizon from the vision system, to determine if a robot is in view
+        void maintenance(const message::vision::GreenHorizon& horizon);
 
     public:
         /// @brief Called by the powerplant to build and setup the RobotLocalisation reactor.


### PR DESCRIPTION
I've made some refactoring changes while working on team association, and so to keep that PR focused and to reduce issues later (given there are a few people working in this file on different projects), I've moved those changes into this PR. It aims to keep steps of the localisation method discrete and contained in functions.

Tested in webots, looked good.