### PR TITLE
Add a startup delay in Soccer

### DIFF
--- a/module/purpose/Soccer/data/config/Soccer.yaml
+++ b/module/purpose/Soccer/data/config/Soccer.yaml
@@ -7,6 +7,9 @@ force_playing: false
 # Delay in seconds before the robot starts playing after button press
 disable_idle_delay: 5
 
+# Delay in seconds before the robot can start playing after startup
+startup_delay: 3
+
 # The position of the robot
 # ALL_ROUNDER, GOALIE, STRIKER, DEFENDER, DYNAMIC
 position: DYNAMIC

--- a/module/purpose/Soccer/src/Soccer.hpp
+++ b/module/purpose/Soccer/src/Soccer.hpp
@@ -98,6 +98,8 @@ namespace module::purpose {
             bool force_playing = false;
             /// @brief Delay in seconds before the robot starts playing after button press
             int disable_idle_delay = 0;
+            /// @brief Delay in seconds before the robot can start playing after startup
+            int startup_delay = 0;
             /// @brief The soccer position of the robot
             Position position{};
             /// @brief The number of seconds to wait before assuming a teammate is inactive


### PR DESCRIPTION
Currently we set the gains of the servos to a low value when starting the robot up which is great to avoid having the robot aggressively move to its nominal standing pose, however, this causes problems when behaviour modules want to request the robot to walk immediately. This PR solves this problem for `robocup` by adding a short start up delay to the Soccer module. A better fix will be to revive and test `StartSafely` 