### PR TITLE
Improve ps3walk walk command output

### DIFF
--- a/module/actuation/KinematicsConfiguration/data/config/KinematicsConfiguration.yaml
+++ b/module/actuation/KinematicsConfiguration/data/config/KinematicsConfiguration.yaml
@@ -25,7 +25,7 @@ head:
     base_position_from_origin: [-0.007, 0, 0.21] # [x, y, z]
   # head movement limits
   limits: # pitch limit is a function of yaw ... need to calculate this properly
-    yaw: [-1.14, 1.14] # [min_yaw, max_yaw]
+    yaw: [-0.95, 0.95] # [min_yaw, max_yaw]
     pitch: [-0.57, 0.46] # [min_pitch, max_pitch]
 # rough measurements
 arm:

--- a/module/actuation/KinematicsConfiguration/data/config/KinematicsConfiguration.yaml
+++ b/module/actuation/KinematicsConfiguration/data/config/KinematicsConfiguration.yaml
@@ -25,8 +25,8 @@ head:
     base_position_from_origin: [-0.007, 0, 0.21] # [x, y, z]
   # head movement limits
   limits: # pitch limit is a function of yaw ... need to calculate this properly
-    yaw: [-pi/4, pi/4] # [min_yaw, max_yaw]
-    pitch: [-pi/2, pi/8] # [min_pitch, max_pitch]
+    yaw: [-1.14, 1.14] # [min_yaw, max_yaw]
+    pitch: [-0.57, 0.46] # [min_pitch, max_pitch]
 # rough measurements
 arm:
   distance_between_shoulders: 0.17 # distance between shoulders

--- a/module/purpose/PS3Walk/data/config/PS3Walk.yaml
+++ b/module/purpose/PS3Walk/data/config/PS3Walk.yaml
@@ -3,3 +3,4 @@ log_level: INFO
 
 maximum_forward_velocity: 0.15
 maximum_rotational_velocity: 0.25
+max_acceleration: 0.1

--- a/module/purpose/PS3Walk/data/config/PS3Walk.yaml
+++ b/module/purpose/PS3Walk/data/config/PS3Walk.yaml
@@ -4,3 +4,16 @@ log_level: INFO
 maximum_forward_velocity: 0.15
 maximum_rotational_velocity: 0.25
 max_acceleration: 0.1
+
+# Button to script mappings
+button_scripts:
+  DPAD_UP: "Clap.yaml"
+  DPAD_DOWN: "TheRobot.yaml"
+  DPAD_LEFT: "Dab.yaml"
+  DPAD_RIGHT: "ArmDangle.yaml"
+  TRIANGLE: "Star.yaml"
+  CIRCLE: "RaiseTheRoof.yaml"
+  CROSS: "Crouch.yaml"
+  SQUARE: "Wave.yaml"
+  L1: "LEFT_LEG_KICK"
+  R1: "RIGHT_LEG_KICK"

--- a/module/purpose/PS3Walk/src/PS3Walk.cpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.cpp
@@ -119,7 +119,6 @@ namespace module::purpose {
                                 if (moving) {
                                     log<INFO>("Stop walking");
                                     emit<Task>(std::make_unique<Walk>(Eigen::Vector3d::Zero()));
-                                    // emit<Task>(std::unique_ptr<Walk>(nullptr));
                                 }
                                 else {
                                     log<INFO>("Start walking");

--- a/module/purpose/PS3Walk/src/PS3Walk.cpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.cpp
@@ -28,6 +28,7 @@
 #include "PS3Walk.hpp"
 
 #include <nuclear>
+#include <unordered_map>
 
 #include "extension/Behaviour.hpp"
 #include "extension/Configuration.hpp"
@@ -70,6 +71,11 @@ namespace module::purpose {
             cfg.maximum_forward_velocity    = config["maximum_forward_velocity"].as<double>();
             cfg.maximum_rotational_velocity = config["maximum_rotational_velocity"].as<double>();
             cfg.max_acceleration            = config["max_acceleration"].as<double>();
+
+            // Load button to script mappings
+            for (const auto& script : config["button_scripts"].as<std::map<std::string, std::string>>()) {
+                cfg.button_scripts[script.first] = script.second;
+            }
         });
 
 
@@ -139,76 +145,118 @@ namespace module::purpose {
                                 head_locked = !head_locked;
                             }
                             break;
-                        // case BUTTON_DPAD_UP:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button DPAD_UP pressed");
-                        //         log<INFO>("Do a dance move Dpad up");
-                        //         emit<Task>(load_script<LimbsSequence>("Clap.yaml"), 3);
-                        //     }
-                        //     break;
-                        // case BUTTON_DPAD_DOWN:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button DPAD_DOWN pressed");
-                        //         log<INFO>("Do a dance Dpad down");
-                        //         emit<Task>(load_script<LimbsSequence>("TheRobot.yaml"), 3);
-                        //     }
-                        //     break;
-                        // case BUTTON_DPAD_LEFT:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button DPAD_LEFT pressed");
-                        //         log<INFO>("Do a dance Dpad left");
-                        //         emit<Task>(load_script<LimbsSequence>("Dab.yaml"), 3);
-                        //     }
-                        //     break;
-                        // case BUTTON_DPAD_RIGHT:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button DPAD_RIGHT pressed");
-                        //         log<INFO>("Do a dance Dpad right");
-                        //         emit<Task>(load_script<LimbsSequence>("ArmDangle.yaml"), 3);
-                        //     }
-                        //     break;
-                        // case BUTTON_TRIANGLE:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button TRIANGLE pressed");
-                        //         log<INFO>("Do a dance triangle");
-                        //         emit<Task>(load_script<LimbsSequence>("Star.yaml"), 3);
-                        //     }
-                        //     break;
-                        // case BUTTON_CIRCLE:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button CIRCLE pressed");
-                        //         log<INFO>("Do a dance circle");
-                        //         emit<Task>(load_script<LimbsSequence>("RaiseTheRoof.yaml"), 3);
-                        //     }
-                        //     break;
-                        // case BUTTON_CROSS:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button CROSS pressed");
-                        //         log<INFO>("Do a dance cross");
-                        //         emit<Task>(load_script<LimbsSequence>("Crouch.yaml"), 3);
-                        //     }
-                        //     break;
-                        // case BUTTON_SQUARE:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button SQUARE pressed");
-                        //         log<INFO>("Do a wave");
-                        //         emit<Task>(load_script<LimbsSequence>("Wave.yaml"), 3);
-                        //     }
-                        //     break;
-                        // case BUTTON_L1:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button L1 pressed");
-                        //         log<INFO>("Requesting Left Front Kick");
-                        //         emit<Task>(std::make_unique<Kick>(LimbID::LEFT_LEG), 3);
-                        //     }
-                        //     break;
-                        // case BUTTON_R1:
-                        //     if (event.value > 0) {
-                        //         log<INFO>("Button R1 pressed");
-                        //         log<INFO>("Requesting Right Front Kick");
-                        //         emit<Task>(std::make_unique<Kick>(LimbID::RIGHT_LEG), 3);
-                        //     }
-                        //     break;
+                        case BUTTON_DPAD_UP:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button DPAD_UP pressed");
+                                if (cfg.button_scripts.count("DPAD_UP") > 0) {
+                                    const auto& script = cfg.button_scripts.at("DPAD_UP");
+                                    log<INFO>("Running script:", script);
+                                    emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                            }
+                            break;
+                        case BUTTON_DPAD_DOWN:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button DPAD_DOWN pressed");
+                                if (cfg.button_scripts.count("DPAD_DOWN") > 0) {
+                                    const auto& script = cfg.button_scripts.at("DPAD_DOWN");
+                                    log<INFO>("Running script:", script);
+                                    emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                            }
+                            break;
+                        case BUTTON_DPAD_LEFT:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button DPAD_LEFT pressed");
+                                if (cfg.button_scripts.count("DPAD_LEFT") > 0) {
+                                    const auto& script = cfg.button_scripts.at("DPAD_LEFT");
+                                    log<INFO>("Running script:", script);
+                                    emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                            }
+                            break;
+                        case BUTTON_DPAD_RIGHT:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button DPAD_RIGHT pressed");
+                                if (cfg.button_scripts.count("DPAD_RIGHT") > 0) {
+                                    const auto& script = cfg.button_scripts.at("DPAD_RIGHT");
+                                    log<INFO>("Running script:", script);
+                                    emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                            }
+                            break;
+                        case BUTTON_TRIANGLE:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button TRIANGLE pressed");
+                                if (cfg.button_scripts.count("TRIANGLE") > 0) {
+                                    const auto& script = cfg.button_scripts.at("TRIANGLE");
+                                    log<INFO>("Running script:", script);
+                                    emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                            }
+                            break;
+                        case BUTTON_CIRCLE:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button CIRCLE pressed");
+                                if (cfg.button_scripts.count("CIRCLE") > 0) {
+                                    const auto& script = cfg.button_scripts.at("CIRCLE");
+                                    log<INFO>("Running script:", script);
+                                    emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                            }
+                            break;
+                        case BUTTON_CROSS:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button CROSS pressed");
+                                if (cfg.button_scripts.count("CROSS") > 0) {
+                                    const auto& script = cfg.button_scripts.at("CROSS");
+                                    log<INFO>("Running script:", script);
+                                    emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                            }
+                            break;
+                        case BUTTON_SQUARE:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button SQUARE pressed");
+                                if (cfg.button_scripts.count("SQUARE") > 0) {
+                                    const auto& script = cfg.button_scripts.at("SQUARE");
+                                    log<INFO>("Running script:", script);
+                                    emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                            }
+                            break;
+                        case BUTTON_L1:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button L1 pressed");
+                                if (cfg.button_scripts.count("L1") > 0) {
+                                    const auto& action = cfg.button_scripts.at("L1");
+                                    if (action == "LEFT_LEG_KICK") {
+                                        log<INFO>("Requesting Left Front Kick");
+                                        emit<Task>(std::make_unique<Kick>(LimbID::LEFT_LEG), 3);
+                                    }
+                                    else {
+                                        log<INFO>("Running script:", action);
+                                        emit<Task>(load_script<LimbsSequence>(action), 3);
+                                    }
+                                }
+                            }
+                            break;
+                        case BUTTON_R1:
+                            if (event.value > 0) {  // button down
+                                log<INFO>("Button R1 pressed");
+                                if (cfg.button_scripts.count("R1") > 0) {
+                                    const auto& action = cfg.button_scripts.at("R1");
+                                    if (action == "RIGHT_LEG_KICK") {
+                                        log<INFO>("Requesting Right Front Kick");
+                                        emit<Task>(std::make_unique<Kick>(LimbID::RIGHT_LEG), 3);
+                                    }
+                                    else {
+                                        log<INFO>("Running script:", action);
+                                        emit<Task>(load_script<LimbsSequence>(action), 3);
+                                    }
+                                }
+                            }
+                            break;
                         case BUTTON_L2:
                             if (event.value > 0) {
                                 log<INFO>("Button L2 pressed");

--- a/module/purpose/PS3Walk/src/PS3Walk.cpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.cpp
@@ -229,7 +229,7 @@ namespace module::purpose {
         });
 
         // output walk command based on updated strafe and rotation speed from joystick
-        on<Every<20, Per<std::chrono::seconds>>>().then([this] {
+        on<Every<UPDATE_FREQUENCY, Per<std::chrono::seconds>>>().then([this] {
             if (!head_locked) {
                 // Create a unit vector in the direction the head should be pointing
                 Eigen::Vector3d uPCt = (Eigen::AngleAxisd(head_yaw, Eigen::Vector3d::UnitZ())
@@ -241,8 +241,7 @@ namespace module::purpose {
 
             if (moving) {
                 // Apply acceleration limiting
-                // Calculate time elapsed (20 per second = 0.05 seconds per cycle)
-                const double dt = 0.05;
+                const double dt = 1.0 / UPDATE_FREQUENCY;
 
                 // Calculate maximum allowed change in velocity components
                 double max_delta = cfg.max_acceleration * dt;

--- a/module/purpose/PS3Walk/src/PS3Walk.cpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.cpp
@@ -148,87 +148,111 @@ namespace module::purpose {
                         case BUTTON_DPAD_UP:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button DPAD_UP pressed");
-                                if (cfg.button_scripts.count("DPAD_UP") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("DPAD_UP") > 0) {
                                     const auto& script = cfg.button_scripts.at("DPAD_UP");
                                     log<INFO>("Running script:", script);
                                     emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
                                 }
                             }
                             break;
                         case BUTTON_DPAD_DOWN:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button DPAD_DOWN pressed");
-                                if (cfg.button_scripts.count("DPAD_DOWN") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("DPAD_DOWN") > 0) {
                                     const auto& script = cfg.button_scripts.at("DPAD_DOWN");
                                     log<INFO>("Running script:", script);
                                     emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
                                 }
                             }
                             break;
                         case BUTTON_DPAD_LEFT:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button DPAD_LEFT pressed");
-                                if (cfg.button_scripts.count("DPAD_LEFT") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("DPAD_LEFT") > 0) {
                                     const auto& script = cfg.button_scripts.at("DPAD_LEFT");
                                     log<INFO>("Running script:", script);
                                     emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
                                 }
                             }
                             break;
                         case BUTTON_DPAD_RIGHT:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button DPAD_RIGHT pressed");
-                                if (cfg.button_scripts.count("DPAD_RIGHT") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("DPAD_RIGHT") > 0) {
                                     const auto& script = cfg.button_scripts.at("DPAD_RIGHT");
                                     log<INFO>("Running script:", script);
                                     emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
                                 }
                             }
                             break;
                         case BUTTON_TRIANGLE:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button TRIANGLE pressed");
-                                if (cfg.button_scripts.count("TRIANGLE") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("TRIANGLE") > 0) {
                                     const auto& script = cfg.button_scripts.at("TRIANGLE");
                                     log<INFO>("Running script:", script);
                                     emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
                                 }
                             }
                             break;
                         case BUTTON_CIRCLE:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button CIRCLE pressed");
-                                if (cfg.button_scripts.count("CIRCLE") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("CIRCLE") > 0) {
                                     const auto& script = cfg.button_scripts.at("CIRCLE");
                                     log<INFO>("Running script:", script);
                                     emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
                                 }
                             }
                             break;
                         case BUTTON_CROSS:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button CROSS pressed");
-                                if (cfg.button_scripts.count("CROSS") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("CROSS") > 0) {
                                     const auto& script = cfg.button_scripts.at("CROSS");
                                     log<INFO>("Running script:", script);
                                     emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
                                 }
                             }
                             break;
                         case BUTTON_SQUARE:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button SQUARE pressed");
-                                if (cfg.button_scripts.count("SQUARE") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("SQUARE") > 0) {
                                     const auto& script = cfg.button_scripts.at("SQUARE");
                                     log<INFO>("Running script:", script);
                                     emit<Task>(load_script<LimbsSequence>(script), 3);
+                                }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
                                 }
                             }
                             break;
                         case BUTTON_L1:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button L1 pressed");
-                                if (cfg.button_scripts.count("L1") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("L1") > 0) {
                                     const auto& action = cfg.button_scripts.at("L1");
                                     if (action == "LEFT_LEG_KICK") {
                                         log<INFO>("Requesting Left Front Kick");
@@ -239,12 +263,15 @@ namespace module::purpose {
                                         emit<Task>(load_script<LimbsSequence>(action), 3);
                                     }
                                 }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
+                                }
                             }
                             break;
                         case BUTTON_R1:
                             if (event.value > 0) {  // button down
                                 log<INFO>("Button R1 pressed");
-                                if (cfg.button_scripts.count("R1") > 0) {
+                                if (scripts_enabled && cfg.button_scripts.count("R1") > 0) {
                                     const auto& action = cfg.button_scripts.at("R1");
                                     if (action == "RIGHT_LEG_KICK") {
                                         log<INFO>("Requesting Right Front Kick");
@@ -254,6 +281,9 @@ namespace module::purpose {
                                         log<INFO>("Running script:", action);
                                         emit<Task>(load_script<LimbsSequence>(action), 3);
                                     }
+                                }
+                                else if (!scripts_enabled) {
+                                    log<INFO>("Scripts are disabled. Enable with R2.");
                                 }
                             }
                             break;
@@ -265,6 +295,13 @@ namespace module::purpose {
                         case BUTTON_R2:
                             if (event.value > 0) {
                                 log<INFO>("Button R2 pressed");
+                                if (scripts_enabled) {
+                                    log<INFO>("Scripts disabled");
+                                }
+                                else {
+                                    log<INFO>("Scripts enabled");
+                                }
+                                scripts_enabled = !scripts_enabled;
                             }
                             break;
                     }

--- a/module/purpose/PS3Walk/src/PS3Walk.hpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.hpp
@@ -95,6 +95,9 @@ namespace module::purpose {
         /// @brief Stores whether the robot will change its head direction or not
         bool head_locked = true;
 
+        /// @brief Stores whether scripts are enabled or not
+        bool scripts_enabled = false;
+
         /// @brief stores the head pitch value
         double head_pitch = 0.0;
 

--- a/module/purpose/PS3Walk/src/PS3Walk.hpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.hpp
@@ -76,6 +76,8 @@ namespace module::purpose {
         struct Config {
             double maximum_forward_velocity    = 0;
             double maximum_rotational_velocity = 0;
+            /// @brief Maximum allowed acceleration per second (in m/s²)
+            double max_acceleration = 0.5;  // This value can be configured
         } cfg;
 
         /// @brief Controls interactions with the PS3 controller
@@ -95,6 +97,9 @@ namespace module::purpose {
 
         /// @brief stores the head yaw value
         double head_yaw = 0.0;
+
+        /// @brief Stores the previous walk command for acceleration limiting
+        Eigen::Vector3d previous_walk_command = Eigen::Vector3d::Zero();
     };
 }  // namespace module::purpose
 

--- a/module/purpose/PS3Walk/src/PS3Walk.hpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.hpp
@@ -31,6 +31,7 @@
 
 #include <Eigen/Core>
 #include <nuclear>
+#include <unordered_map>
 
 #include "Joystick.hpp"
 
@@ -78,6 +79,8 @@ namespace module::purpose {
             double maximum_rotational_velocity = 0;
             /// @brief Maximum allowed acceleration per second (in m/s²)
             double max_acceleration = 0.5;
+            /// @brief Maps button names to script filenames
+            std::unordered_map<std::string, std::string> button_scripts;
         } cfg;
 
         /// @brief Controls interactions with the PS3 controller

--- a/module/purpose/PS3Walk/src/PS3Walk.hpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.hpp
@@ -77,7 +77,7 @@ namespace module::purpose {
             double maximum_forward_velocity    = 0;
             double maximum_rotational_velocity = 0;
             /// @brief Maximum allowed acceleration per second (in m/s²)
-            double max_acceleration = 0.5;  // This value can be configured
+            double max_acceleration = 0.5;
         } cfg;
 
         /// @brief Controls interactions with the PS3 controller
@@ -100,6 +100,9 @@ namespace module::purpose {
 
         /// @brief Stores the previous walk command for acceleration limiting
         Eigen::Vector3d previous_walk_command = Eigen::Vector3d::Zero();
+
+        /// @brief The frequency at which the PS3Walk commands are updated
+        static constexpr size_t UPDATE_FREQUENCY = 20;
     };
 }  // namespace module::purpose
 

--- a/module/purpose/PS3Walk/src/PS3Walk.hpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.hpp
@@ -88,7 +88,7 @@ namespace module::purpose {
         bool moving = false;
 
         /// @brief Stores whether the robot will change its head direction or not
-        bool head_locked = false;
+        bool head_locked = true;
 
         /// @brief stores the head pitch value
         double head_pitch = 0.0;

--- a/roles/keyboardwalk.role
+++ b/roles/keyboardwalk.role
@@ -8,6 +8,8 @@ nuclear_role(
   # Configuration
   actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
+  network::NUClearNet
+  network::NetworkForwarder
   network::PlotJuggler
   # Sensors
   input::SensorFilter

--- a/roles/ps3walk.role
+++ b/roles/ps3walk.role
@@ -8,6 +8,8 @@ nuclear_role(
   # Configuration
   actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network
+  network::NUClearNet
+  network::NetworkForwarder
   network::PlotJuggler
   # Sensors
   input::SensorFilter


### PR DESCRIPTION
This PR does the following:

1. Adds acceleration limit to joystick commands to improve controlling robot with ps3 controller sticks
2. Adds scripts/button mapping to configuration file (disables scripts by default, toggled with R2)
3. Adds new limits to the head pitch/yaw to prevent head servos reaching limits
4. Lock head by default
5. Adds nusight stuff to both ps3walk and keyboardwalk