### PR TITLE
Add a delay to RobotCommunication to prevent empty/incorrect messages

### DIFF
--- a/module/network/RobotCommunication/data/config/RobotCommunication.yaml
+++ b/module/network/RobotCommunication/data/config/RobotCommunication.yaml
@@ -1,5 +1,7 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
+startup_delay: 3
+
 send_port: 3737
 receive_port: 3737
 broadcast_ip: "10.1.255.255"

--- a/module/network/RobotCommunication/src/RobotCommunication.hpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.hpp
@@ -44,6 +44,8 @@ namespace module::network {
             std::string broadcast_ip = "";
             /// @brief Set this to only receive packets from this IP address
             std::string udp_filter_address = "";
+            /// @brief A delay before the first message is sent, to allow reasonable data to be collected
+            int startup_delay = 0;
         } cfg;
 
         /// @brief ignore packets from these IP addresses


### PR DESCRIPTION
The robot sends a message to its team mates pretty much immediately, but the system isn't really in a good spot yet. Everything is essentially zero, and localisation needs a bit to settle anyway. This PR adds a delay before sending any messages, so that there is a higher chance their data is useful.

Practically, this prevents the team robot localisation from thinking there is a team mate in the center of the field.