### PR TITLE
Add filewatcher config

### DIFF
--- a/module/extension/FileWatcher/data/config/FileWatcher.yaml
+++ b/module/extension/FileWatcher/data/config/FileWatcher.yaml
@@ -1,0 +1,1 @@
+log_level: INFO


### PR DESCRIPTION
Noticed recently filewatcher was broken on the robot, this missing config is probably why