### PR TITLE
Fixes to RobotLocalisation and add penalisation info for teammates

### DIFF
--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
@@ -267,6 +267,11 @@ namespace module::localisation {
                                         const FieldDescription& field_desc) {
         std::vector<TrackedRobot> new_tracked_robots{};
 
+        // Sort tracked_robots so that robots that are teammates are at the front to prevent team mates being removed
+        std::sort(tracked_robots.begin(), tracked_robots.end(), [](const TrackedRobot& a, const TrackedRobot& b) {
+            return a.teammate_id > b.teammate_id;
+        });
+
         for (auto& tracked_robot : tracked_robots) {
             auto state = RobotModel<double>::StateVec(tracked_robot.ukf.get_state());
 

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
@@ -80,7 +80,7 @@ namespace module::localisation {
             /// @brief The number of times the robot has been undetected in a row
             long missed_count = 0;
             /// @brief A unique identifier for the robot
-            const unsigned long id;
+            unsigned long id;
             /// @brief The unique identifier of the robot if it is a teammate
             /// If it is not a teammate, this will be 0
             unsigned long teammate_id = 0;
@@ -110,6 +110,9 @@ namespace module::localisation {
         /// This variable will increase by one each time a new robot is added
         /// As it is unbounded, an unsigned long is used to store it
         unsigned long next_id = 0;
+
+        /// @brief How many times per second to run the maintenance step
+        static constexpr int UPDATE_RATE = 15;
 
         /// @brief Run Kalman filter prediction step for all tracked robots
         void prediction();

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
@@ -84,6 +84,9 @@ namespace module::localisation {
             /// @brief The unique identifier of the robot if it is a teammate
             /// If it is not a teammate, this will be 0
             unsigned long teammate_id = 0;
+            /// @brief Penalisation state for teammate
+            /// This allows behaviour systems to ignore teammates that are not in the game, but keep tracking them
+            bool penalised = false;
 
             /// @brief Constructor that sets the state for the UKF
             TrackedRobot(const Eigen::Vector3d& initial_rRWw, const Config::UKF& cfg_ukf, const unsigned long next_id)
@@ -121,7 +124,10 @@ namespace module::localisation {
         /// Creates a new tracked robot if the measurement is not associated with an existing robot
         /// @param robots_rRWw The new robot measurements in world coordinates
         /// @param teammate_id The unique identifier of the robot if it is a teammate
-        void data_association(const std::vector<Eigen::Vector3d>& robots_rRWw, uint teammate_id);
+        /// @param penalised Whether the robot is penalised or not
+        void data_association(const std::vector<Eigen::Vector3d>& robots_rRWw,
+                              uint teammate_id = 0,
+                              bool penalised   = false);
 
         /// @brief Run maintenance on the tracked robots
         /// This will remove any viewable robots that have been missed too many times or are too close to another robot

--- a/shared/message/localisation/Robot.proto
+++ b/shared/message/localisation/Robot.proto
@@ -56,6 +56,9 @@ message Robot {
 
     /// Team mate ID for NUsight if known
     uint32 teammate_id = 8;
+
+    /// Penalisation state, for teammates
+    bool penalised = 9;
 }
 
 message Robots {


### PR DESCRIPTION
- Added penalised information so we can track the info without any extra overhead - I did consider using the TeamMates message and tracking separately, but I'd rather replace all of that with just the `localisation::Robots` moving forward. No point in tracking robots twice. 
- Set defaults for teammate id and penalised so we don't need to explicitly set them in the VisionRobots loop
- Added a sort before the maintenance loop to put teammates first. This is because I noticed a bug where if a teammate and 'opponent' were too close, it would delete the teammate and just keep tracking it as an opponent. This should now add the teammate to the new vector and any opponents that are too close would be removed instead.
- Realised that if we see no robots and get no teammate messages, nothing runs in the RobotLocalisation module to trigger maintenance. This is not an unusual situation - no opponents, and our teammate gets taken off. It keeps thinking the teammate is there. Wanted to make sure that I didn't need to separately track 'how long since last seen our teammate', since this should be cleaned up in maintenance. Therefore I've moved the maintenance step into its own set-frequency loop and removed it in the other two reactions. 