### PR TITLE
Fix seg fault in RobotLocalisation from invalid constructor param

### DIFF
--- a/module/localisation/RobotLocalisation/src/RobotModel.hpp
+++ b/module/localisation/RobotLocalisation/src/RobotModel.hpp
@@ -69,6 +69,9 @@ namespace module::localisation {
             StateVec(const Eigen::MatrixBase<OtherDerived>& state)
                 : rRWw(state.template segment<2>(PX)), vRw(state.template segment<2>(VX)) {}
 
+            StateVec(const Eigen::Matrix<Scalar, 2, 1>& position)
+                : rRWw(position), vRw(Eigen::Matrix<Scalar, 2, 1>::Zero()) {}
+
             [[nodiscard]] Eigen::Matrix<Scalar, size, 1> getStateVec() const {
                 Eigen::Matrix<Scalar, size, 1> state = Eigen::Matrix<Scalar, size, 1>::Zero();
                 state.template segment<2>(PX)        = rRWw;


### PR DESCRIPTION
Hard to show here but [this line](https://github.com/NUbots/NUbots/blob/c533d5e2d0a8618b985c54b826dd24db80857a42/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp#L98) was throwing a seg fault in debug mode because the config value its sending through is a 2D vector, whereas RobotModel has only a StateVec constructor wanting a 4D Vector to fill the position and velocity components. This PR adds a constructor to RobotModel so that passing a 2D vector will work.

I didn't encounter this in release, only debug. 