### PR TITLE
Change ps3walk enable scripts button

### DIFF
--- a/module/purpose/PS3Walk/src/PS3Walk.cpp
+++ b/module/purpose/PS3Walk/src/PS3Walk.cpp
@@ -292,9 +292,9 @@ namespace module::purpose {
                                 log<INFO>("Button L2 pressed");
                             }
                             break;
-                        case BUTTON_R2:
+                        case BUTTON_RIGHT_JOYSTICK:
                             if (event.value > 0) {
-                                log<INFO>("Button R2 pressed");
+                                log<INFO>("Button BUTTON_RIGHT_JOYSTICK pressed");
                                 if (scripts_enabled) {
                                     log<INFO>("Scripts disabled");
                                 }


### PR DESCRIPTION
The current button to enable scripts was easily pressed and triggering scripts accidentally was common, this changes to a button which is not easily misspressed. 