### PR TITLE
Remove console log handler from modules with keyboardwalk 

### DIFF
--- a/roles/fake/keyboardwalk.role
+++ b/roles/fake/keyboardwalk.role
@@ -4,7 +4,6 @@ nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
   extension::FileWatcher # Watches configuration files for changes
   support::SignalCatcher # Allows for graceful shutdown
-  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
   actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network

--- a/roles/keyboardwalk.role
+++ b/roles/keyboardwalk.role
@@ -4,7 +4,6 @@ nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
   extension::FileWatcher # Watches configuration files for changes
   support::SignalCatcher # Allows for graceful shutdown
-  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
   actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network

--- a/roles/test/localisation.role
+++ b/roles/test/localisation.role
@@ -5,7 +5,6 @@ nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
   extension::FileWatcher # Watches configuration files for changes
   support::SignalCatcher # Allows for graceful shutdown
-  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
   actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   support::configuration::GlobalConfig

--- a/roles/webots/demo.role
+++ b/roles/webots/demo.role
@@ -5,7 +5,6 @@ nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
   extension::FileWatcher # Watches configuration files for changes
   support::SignalCatcher # Allows for graceful shutdown
-  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
   actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   support::configuration::SoccerConfig # Field description

--- a/roles/webots/keyboardwalk.role
+++ b/roles/webots/keyboardwalk.role
@@ -3,7 +3,6 @@ nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
   extension::FileWatcher # Watches configuration files for changes
   support::SignalCatcher # Allows for graceful shutdown
-  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
   actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   # Network

--- a/roles/webots/localisation.role
+++ b/roles/webots/localisation.role
@@ -5,7 +5,6 @@ nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
   extension::FileWatcher # Watches configuration files for changes
   support::SignalCatcher # Allows for graceful shutdown
-  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
   actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   support::configuration::SoccerConfig # Field description

--- a/roles/webots/logging.role
+++ b/roles/webots/logging.role
@@ -5,7 +5,6 @@ nuclear_role(
   # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First and without it many roles do not run
   extension::FileWatcher # Watches configuration files for changes
   support::SignalCatcher # Allows for graceful shutdown
-  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
   # Configuration
   actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
   support::configuration::GlobalConfig


### PR DESCRIPTION
Keyboardwalk has it's own console log handler to work better with ncurses menu. This PR removes console log handler from modules with keyboard walk to prevent double up logs in console.