### PR TITLE
Prevent segmentation fault in field localisation when no field line intersections exist

### DIFF
--- a/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
@@ -288,6 +288,11 @@ namespace module::localisation {
     std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> FieldLocalisationNLopt::data_association(
         const std::shared_ptr<const FieldIntersections>& field_intersections,
         const Eigen::Isometry3d& Hfw) {
+        // If there are no field intersections, return an empty vector
+        if (!field_intersections || field_intersections->intersections.empty()) {
+            return {};
+        }
+
         // Field intersection measurement associated with a landmark (known landmark, intersection detection)
         std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> associations;
 


### PR DESCRIPTION
The data association function is run in the main loop for NUsight visualisation purposes without checking if its nullptr. The function itself doesn't check for nullptr, even though its a shared pointer. This PR fixes this by returning an empty vector if field intersections doesn't exist or is empty.

I encountered this while testing on the real robot - it's pretty uncommon for the robot to start without any field intersections seen at all though.