### PR TITLE
[Merge into a feature branch, not main] Use the walk generator's clock and step period to stop/start the kick

### DIFF
--- a/module/skill/KickWalk/data/config/KickWalk.yaml
+++ b/module/skill/KickWalk/data/config/KickWalk.yaml
@@ -2,5 +2,5 @@
 log_level: INFO
 
 # Step kick parameters
-kick_velocity_x: 0.5 # Forward velocity during kick (m/s)
-kick_velocity_y: 0.05 # Lateral velocity during kick (m/s)
+kick_approach_velocity_x: 0.05 # Approach kick velocity x (m/s)
+kick_approach_velocity_y: 0.0 # Approach kick velocity y (m/s)

--- a/module/skill/KickWalk/src/KickWalk.cpp
+++ b/module/skill/KickWalk/src/KickWalk.cpp
@@ -23,57 +23,40 @@ namespace module::skill {
         on<Configuration>("KickWalk.yaml").then([this](const Configuration& config) {
             log<INFO>("KickWalk configuration loaded");
             // Use configuration here from file KickWalk.yaml
-            this->log_level     = config["log_level"].as<NUClear::LogLevel>();
-            cfg.kick_velocity_x = config["kick_velocity_x"].as<double>();
-            cfg.kick_velocity_y = config["kick_velocity_y"].as<double>();
+            this->log_level              = config["log_level"].as<NUClear::LogLevel>();
+            cfg.kick_approach_velocity_x = config["kick_approach_velocity_x"].as<double>();
+            cfg.kick_approach_velocity_y = config["kick_approach_velocity_y"].as<double>();
         });
 
-        on<Provide<Kick>, With<WalkState>>().then(
-            [this](const Kick& kick, const RunReason& run_reason, const WalkState& walk_state) {
+        on<Provide<Kick>, Uses<Walk>, With<WalkState>>().then(
+            [this](const Kick& kick, const RunReason& run_reason, const Uses<Walk>& walk, const WalkState& walk_state) {
                 if (run_reason == RunReason::NEW_TASK) {
-                    // log<INFO>("KickWalk module received a kick request for leg: ", kick.leg);
-                    log<INFO>("KickWalk starting - checking foot phase for leg: ", kick.leg);
-
-                    // Determine the optimal phase for the kick
-                    WalkState::Phase optimal_phase;
-                    if (kick.leg == LimbID::LEFT_LEG) {
-                        optimal_phase = WalkState::Phase::RIGHT;  // Right foot is planted
-                    }
-                    else {
-                        optimal_phase = WalkState::Phase::LEFT;  // Left foot is planted
-                    }
-                    log<INFO>("Current walk phase: ", walk_state.phase, " - Optimal phase for kick: ", optimal_phase);
-
-                    emit(graph("KickWalk/requested_kick_leg", int(kick.leg)));
-                    emit(graph("KickWalk/optimal_phase", int(optimal_phase)));
-                    emit(graph("KickWalk/walk_state_phase", int(walk_state.phase)));
-
-                    // Guard condition: only proceed if in optimal phase
-                    // if (walk_state.phase != optimal_phase) {
-                    //     log<INFO>("Wrong phase for kick - current: ",
-                    //               walk_state.phase,
-                    //               " needed: ",
-                    //               optimal_phase,
-                    //               " - not emitting Walk task");
-                    //     return;  // Don't emit anything - PlanKick will retry
-                    // }
-
-                    log<INFO>("Optimal phase detected - executing kick");
-
-                    Eigen::Vector3d walk_velocity;
-                    if (kick.leg == LimbID::RIGHT_LEG) {
-                        walk_velocity = Eigen::Vector3d(cfg.kick_velocity_x, -cfg.kick_velocity_y, 0.0);
-                    }
-                    else {
-                        walk_velocity = Eigen::Vector3d(cfg.kick_velocity_x, cfg.kick_velocity_y, 0.0);
+                    if (NUClear::clock::now() - last_kick_end < std::chrono::seconds(2)) {
+                        log<INFO>("KickWalk is waiting for cooldown after last kick.");
+                        NUClear::clock::time_point wait_until = last_kick_end + std::chrono::seconds(2);
+                        emit<Task>(std::make_unique<Wait>(wait_until));
+                        return;
                     }
 
-                    emit<Task>(std::make_unique<Walk>(walk_velocity, true));
+                    log<INFO>("KickWalk module received a kick request for leg: ", kick.leg);
+
+                    // Slow approach
+                    Eigen::Vector3d walk_velocity =
+                        Eigen::Vector3d(cfg.kick_approach_velocity_x, cfg.kick_approach_velocity_y, 0.0);
+                    emit<Task>(std::make_unique<Walk>(walk_velocity, true, kick.leg));
+                }
+                // The wait triggered the provider
+                else if (run_reason == RunReason::SUBTASK_DONE && !walk.done) {
+                    // Slow approach
+                    log<INFO>("KickWalk module received a kick request for leg: ", kick.leg);
+                    Eigen::Vector3d walk_velocity =
+                        Eigen::Vector3d(cfg.kick_approach_velocity_x, cfg.kick_approach_velocity_y, 0.0);
                 }
 
                 // If the walk says the kick is done, emit a Done task
                 if (run_reason == RunReason::SUBTASK_DONE) {
                     log<INFO>("KickWalk step completed, kick done for leg: ", kick.leg);
+                    last_kick_end = NUClear::clock::now();
                     emit<Task>(std::make_unique<Done>());
                     return;
                 }

--- a/module/skill/KickWalk/src/KickWalk.hpp
+++ b/module/skill/KickWalk/src/KickWalk.hpp
@@ -14,18 +14,20 @@ namespace module::skill {
     private:
         /// @brief Stores configuration values
         struct Config {
-            double kick_step_length  = 0.15;  // Length of kick step (m)
-            double kick_step_height  = 0.08;  // Height of kick step (m)
-            double kick_velocity_x   = 0.2;   // Forward velocity during kick (m/s)
-            double kick_velocity_y   = 0.05;  // Lateral velocity during kick (m/s)
-            double normal_velocity_x = 0.1;   // Normal forward walking velocity (m/s)
-            int kick_steps           = 2;     // Number of steps to execute kick over
+            double kick_step_length         = 0.15;  // Length of kick step (m)
+            double kick_step_height         = 0.08;  // Height of kick step (m)
+            double kick_approach_velocity_x = 0.0;   // Forward velocity during kick (m/s)
+            double kick_approach_velocity_y = 0.0;   // Lateral velocity during kick (m/s)
+            double normal_velocity_x        = 0.1;   // Normal forward walking velocity (m/s)
+            int kick_steps                  = 2;     // Number of steps to execute kick over
 
             // State tracking
             utility::input::LimbID current_kick_leg = utility::input::LimbID::UNKNOWN;
             int kick_step_count                     = 0;
             bool is_kicking                         = false;
         } cfg;
+
+        NUClear::clock::time_point last_kick_end = NUClear::clock::now();
 
     public:
         /// @brief Called by the powerplant to build and setup the KickWalk reactor.

--- a/module/skill/Walk/data/config/webots/Walk.yaml
+++ b/module/skill/Walk/data/config/webots/Walk.yaml
@@ -43,5 +43,6 @@ arms:
   left_elbow: -0.7
 
 kick:
-  max_time: 0.3 # Max time to complete the kick mstep (in seconds)
-  min_time: 0.04 # Min time to complete the kick mstep (in seconds)
+  # Step kick parameters
+  kick_velocity_x: 0.5 # Forward velocity during kick (m/s)
+  kick_velocity_y: 0.05 # Lateral velocity during kick (m/s)

--- a/module/skill/Walk/src/Walk.hpp
+++ b/module/skill/Walk/src/Walk.hpp
@@ -60,9 +60,10 @@ namespace module::skill {
             /// @brief Walk engine parameters
             utility::skill::WalkGenerator<double>::WalkParameters walk_generator_parameters{};
 
-            /// @brief Allowed time to complete the kick step (in seconds)
-            double max_time = 0.3;
-            double min_time = 0.1;
+            /// @brief The velocity to kick the ball with (x direction)
+            double kick_velocity_x = 0.0;
+            /// @brief The velocity to kick the ball with (y direction)
+            double kick_velocity_y = 0.0;
         } cfg;
 
         /// @brief Last time we updated the walk engine
@@ -73,6 +74,7 @@ namespace module::skill {
 
         /// @brief Used to track the step phase for the step kick
         bool kick_step_in_progress = false;
+        bool done_sent             = false;
         /// @brief Store the kick phase
         message::behaviour::state::WalkState::Phase initial_kick_phase;
         NUClear::clock::time_point kick_step_start_time;

--- a/shared/message/skill/Walk.proto
+++ b/shared/message/skill/Walk.proto
@@ -31,5 +31,8 @@ import "Vector.proto";
 
 message Walk {
     vec3 velocity_target = 1;
+    /// Whether to kick or not
     bool kick = 2;
+    /// Leg to kick with
+    uint32 leg = 3;
 }


### PR DESCRIPTION
- Moves logic for leg and phase into the Walk module
- Start kicking at the end of the previous step (could try out start of kick step instead) 
- End at the end of the step
- Adds a wait into the KickWalk so multiple kicks aren't trigged in succession

Looks pretty clean in Webots.

@Crafty15 hopefully this helps with the timing. Feel free to merge if you want to use it.