### PR TITLE
Check ball for nullptr before proceeding in FieldPlayer

### DIFF
--- a/module/purpose/FieldPlayer/src/FieldPlayer.cpp
+++ b/module/purpose/FieldPlayer/src/FieldPlayer.cpp
@@ -76,6 +76,11 @@ namespace module::purpose {
                 emit<Task>(std::make_unique<FindBall>(), 2);    // Need to know where the ball is
                 emit<Task>(std::make_unique<LookAtBall>(), 1);  // Track the ball
 
+                // If there's no ball message, only emit the tasks to find it
+                if (ball == nullptr) {
+                    return;
+                }
+
                 // If we have robots, determine if we are closest to the ball
                 // Otherwise assume we are alone and closest by default
                 const unsigned int closest_to_ball =


### PR DESCRIPTION
I think this got lost in some of the clean up. Seg fault if no ball is seen at all yet in the program.