### PR TITLE
Upgrade RoboCupConfiguration tool to use the Configuration extension and use SoccerNew

### DIFF
--- a/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.hpp
+++ b/module/tools/RoboCupConfiguration/src/RoboCupConfiguration.hpp
@@ -62,69 +62,15 @@ namespace module::tools {
         int player_id = 0;
         /// @brief Max player ID
         static const int MAX_PLAYER_ID = 6;
-
-        /// @brief Smart enum for the robot's position
-        struct Position {
-            enum Value { ALL_ROUNDER, STRIKER, GOALIE, DEFENDER, DYNAMIC };
-            Value value = Value::ALL_ROUNDER;
-
-            Position() = default;
-            Position(std::string const& str) {
-                // clang-format off
-                if (str == "ALL_ROUNDER") { value = Value::ALL_ROUNDER; }
-                else if (str == "STRIKER") { value = Value::STRIKER; }
-                else if (str == "GOALIE") { value = Value::GOALIE; }
-                else if (str == "DEFENDER") { value = Value::DEFENDER; }
-                else if (str == "DYNAMIC") { value = Value::DYNAMIC; }
-                else { throw std::runtime_error("Invalid robot position"); }
-                // clang-format on
-            }
-
-            /// @brief Convert the enum to a string
-            operator std::string() const {
-                switch (value) {
-                    case Value::ALL_ROUNDER: return "ALL_ROUNDER";
-                    case Value::STRIKER: return "STRIKER";
-                    case Value::DEFENDER: return "DEFENDER";
-                    case Value::GOALIE: return "GOALIE";
-                    case Value::DYNAMIC: return "DYNAMIC";
-                    default: throw std::runtime_error("enum Position's value is corrupt, unknown value stored");
-                }
-            }
-
-            /// @brief Get the full yaml name of the config for the current position
-            /// @return The full yaml name of the config for the current position
-            std::string get_config_name() {
-                switch (value) {
-                    case Value::ALL_ROUNDER: return "AllRounder.yaml";
-                    case Value::STRIKER: return "Striker.yaml";
-                    case Value::DEFENDER: return "Defender.yaml";
-                    case Value::GOALIE: return "Goalie.yaml";
-                    case Value::DYNAMIC: return "Dynamic.yaml";
-                    default: throw std::runtime_error("enum Position's value is corrupt, unknown value stored");
-                }
-            }
-
-            /// @brief Increment the enum, for toggle
-            void operator++() {
-                switch (value) {
-                    case Value::ALL_ROUNDER: value = Value::STRIKER; break;
-                    case Value::STRIKER: value = Value::GOALIE; break;
-                    case Value::GOALIE: value = Value::DEFENDER; break;
-                    case Value::DEFENDER: value = Value::DYNAMIC; break;
-                    case Value::DYNAMIC: value = Value::ALL_ROUNDER; break;
-                    default: value = Value::STRIKER;
-                }
-            }
-        } robot_position;
-
+        /// @brief Whether the robot is a goalie or not
+        bool is_goalie = false;
 
         /// @brief Display values
         struct Display {
             /// @brief Enum for options in first column
             enum class Column1 { ROBOT_NAME, WIFI_INTERFACE, IP_ADDRESS, SSID, PASSWORD, END };
             /// @brief Enum for options in second column
-            enum class Column2 { PLAYER_ID, TEAM_ID, POSITION, END };
+            enum class Column2 { PLAYER_ID, TEAM_ID, GOALIE, END };
             /// @brief Column 1 padding
             static const size_t C1_PAD = 2;
             /// @brief Column 1 selection position


### PR DESCRIPTION
The old way of reading config files was just a simple solution and didn't take into account merging, it just opened only the deepest file. This doesn't work when the fields are split across files, eg the default and a `nugus3` file. This PR instead uses the Configuration struct in the extension file. Saving also now checks for platform config. Saving still just dumps to one file for ease. 

I've also switched from `Soccer` to `SoccerNew` for game-specific config fields. 

This should fix the issues we've seen during practice games.