### PR TITLE
Fix some `b.py` errors which stop `--help` from running.

### DIFF
--- a/tools/nbs/video.py
+++ b/tools/nbs/video.py
@@ -29,6 +29,10 @@
 import multiprocessing
 import os
 
+# Tell tensorflow to shut up
+if "TF_CPP_MIN_LOG_LEVEL" not in os.environ:
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
 import numpy as np
 import tensorflow as tf
 from tqdm import tqdm

--- a/tools/utility/dockerise/register.py
+++ b/tools/utility/dockerise/register.py
@@ -31,6 +31,7 @@ from . import defaults
 
 def register(func, image=None, **kwargs):
     image = defaults.image_name("selected") if image is None else image
+
     def _register(command):
 
         # Only if we are using the internal image does it make sense to provide things like rebuild and clean

--- a/tools/utility/dockerise/register.py
+++ b/tools/utility/dockerise/register.py
@@ -29,7 +29,8 @@
 from . import defaults
 
 
-def register(func, image, **kwargs):
+def register(func, image=None, **kwargs):
+    image = defaults.image_name("selected") if image is None else image
     def _register(command):
 
         # Only if we are using the internal image does it make sense to provide things like rebuild and clean

--- a/tools/utility/nbs/protobuf_types.py
+++ b/tools/utility/nbs/protobuf_types.py
@@ -66,7 +66,7 @@ with tempfile.TemporaryDirectory() as protobuf_path:
     # Build the protocol buffers
     if (
         os.system(
-            "protoc --python_out={protobuf_path} -I{nuclear_dir} -I{user_dir} {proto_files}".format(
+            "protoc --python_out={protobuf_path} -I{nuclear_dir} -I{user_dir} -I/usr/include {proto_files}".format(
                 protobuf_path=protobuf_path,
                 nuclear_dir=nuclear_proto_dir,
                 user_dir=user_proto_dir,


### PR DESCRIPTION
#1556 removed some `try`/`except` blocks in `b.py` which were hiding errors. For the last two months, `b` would error if run without a tool (e.g. `./b --help`).

These errors have been fixed:
 - Add system libraries to the protobuf include path in `tools/utility/nbs/protobuf_types.py` (whether this caused an error seems to be platform-specific)
 - Add default arguments to the `image` kwarg of `tools/utility/dockerise/register`.
   - Unclear if this was the best way of doing it, but it mirrors what's done in `tools/utility/dockerise/run_on_docker` and fixes the issue.

Some annoying logs when running `./b help` have been suppressed by setting the Tensorflow log level in `tools/nbs/video.py`, matching what is already done in `tools/nbs/calibrate_cameras.py`. 

Other annoying logs I haven't been able to get rid of, as they seem to originate in C++ bindings, would love suggestions:
```
$ ./b -h
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1750747019.598968  200187 cuda_dnn.cc:8310] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
E0000 00:00:1750747019.601944  200187 cuda_blas.cc:1418] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
usage: b.py [-h] {docs,edit,shell,target,tests,yarn,install,format,build,configure,multi,optimise_localisation,optimise_odometry,run,unused,test,module,nbs,utility,nusense} ...

This script is an optional helper script for performing common tasks for working with the NUClear roles system.

positional arguments:
  {docs,edit,shell,target,tests,yarn,install,format,build,configure,multi,optimise_localisation,optimise_odometry,run,unused,test,module,nbs,utility,nusense}
                        The command to run from the script. See each help for more information.

options:
  -h, --help            show this help message and exit
  ```