### PR TITLE
Replace `stringcase` with `casefy` to fix warnings.

### DIFF
--- a/nuclear/README.md
+++ b/nuclear/README.md
@@ -51,7 +51,7 @@ These dependencies are:
 - Python3 with the following packages
   - argparse
   - Pillow
-  - stringcase
+  - casefy
 - Optional dependencies:
   - [pybind11](https://github.com/pybind/pybind11) for Python module support
   - [Google Protobuf 3](https://developers.google.com/protocol-buffers/) (both c++ and python libraries) for Neutron messaging
@@ -241,7 +241,7 @@ An `nbs` file has the following frames repeated continuously.
 
 | Name      | Type    | Description                                                                       |
 | --------- | ------- | --------------------------------------------------------------------------------- |
-| header    | char[3] | the header sequence 0xE2, 0x98, 0xA2 (the radioactive symbol ☢ in utf-8)          |
+| header    | char[3] | the header sequence 0xE2, 0x98, 0xA2 (the radioactive symbol ☢ in utf-8)         |
 | size      | uint32  | the size of the frame after this byte in bytes                                    |
 | timestamp | uint64  | the timestamp of this frame in microseconds. Does not have to be a utc timestamp. |
 | hash      | uint64  | a 64 bit hash that identifies the type of the message                             |

--- a/nuclear/cmake/Scripts/generator/OneOfField.py
+++ b/nuclear/cmake/Scripts/generator/OneOfField.py
@@ -26,7 +26,7 @@
 # SOFTWARE.
 #
 
-import stringcase
+import casefy
 from generator.Field import Field
 
 
@@ -36,7 +36,7 @@ class OneOfField:
 
         # Some booleans to describe the type
         self.one_of = True
-        self.type = "OneOf{}".format(stringcase.pascalcase(self.name))
+        self.type = "OneOf{}".format(casefy.pascalcase(self.name))
         self.fqn = "{}.{}".format(context.fqn, self.type)
         self.default_value = "{}()".format(self.type)
         self.trivially_copyable = False

--- a/nuclear/cmake/Scripts/generator/OneOfType.py
+++ b/nuclear/cmake/Scripts/generator/OneOfType.py
@@ -26,7 +26,7 @@
 # SOFTWARE.
 #
 
-import stringcase
+import casefy
 from generator.Field import Field
 from generator.textutil import dedent, indent
 
@@ -35,7 +35,7 @@ class OneOfType:
     def __init__(self, name, fields, context):
 
         self.package = context.package
-        self.name = "OneOf{}".format(stringcase.pascalcase(name))
+        self.name = "OneOf{}".format(casefy.pascalcase(name))
         self.fqn = "{}.{}".format(context.fqn, self.name)
         self.include_path = context.include_path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # Protobuf/Neutron/NBS
     "protoc-exe==22.0rc1",
     "xxhash==3.5.0",
-    "stringcase==1.2.0",
+    "casefy==1.1.0",
     "protoc-wheel==21.1",
     #"protobuf==4.21.12", # Use this for NUSense nanopb message generation
     "protobuf==5.27.0",

--- a/uv.lock
+++ b/uv.lock
@@ -101,6 +101,15 @@ wheels = [
 ]
 
 [[package]]
+name = "casefy"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/24/9c732e8e3585a1dc621c9c1349e55e87070c95d3c2d57bd8c5083ec8d731/casefy-1.1.0.tar.gz", hash = "sha256:849d6e0f80506fac70ab8e18999a4ca1eb7d8f70941682383d64aa22a7497f8f", size = 123884, upload-time = "2025-03-07T14:36:44.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/6a/1766f8c163951a3c9aeb30a4e6f5de9b2eed8389e3906c4cf30fcb475be6/casefy-1.1.0-py3-none-any.whl", hash = "sha256:a3dfcb14d85902d90702db1e9835760237f6a73ec0ae3b7e991ad767513a3cbc", size = 6539, upload-time = "2025-03-07T14:36:37.546Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -777,6 +786,7 @@ version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "black" },
+    { name = "casefy" },
     { name = "cmakelang" },
     { name = "colorama" },
     { name = "gcovr" },
@@ -802,7 +812,6 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "setuptools" },
     { name = "si-prefix" },
-    { name = "stringcase" },
     { name = "tensorflow" },
     { name = "termcolor" },
     { name = "tqdm" },
@@ -812,6 +821,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "black", specifier = "==24.10.0" },
+    { name = "casefy", specifier = "==1.1.0" },
     { name = "cmakelang", specifier = "==0.6.13" },
     { name = "colorama", specifier = "==0.4.6" },
     { name = "gcovr", specifier = "==7.2" },
@@ -837,7 +847,6 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = "==0.18.10" },
     { name = "setuptools", specifier = ">=80.3.1" },
     { name = "si-prefix", specifier = "==1.3.3" },
-    { name = "stringcase", specifier = "==1.2.0" },
     { name = "tensorflow", specifier = "==2.18.0" },
     { name = "termcolor", specifier = "==2.5.0" },
     { name = "tqdm", specifier = "==4.67.1" },
@@ -1537,12 +1546,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/9f/14c511cda174aa1ad9b0e42b64ff5a71db35d08b0d80dc044dae958921e5/sqlalchemy-2.0.40-cp312-cp312-win_amd64.whl", hash = "sha256:2be94d75ee06548d2fc591a3513422b873490efb124048f50556369a834853b0", size = 2108526, upload-time = "2025-03-27T18:45:58.965Z" },
     { url = "https://files.pythonhosted.org/packages/d1/7c/5fc8e802e7506fe8b55a03a2e1dab156eae205c91bee46305755e086d2e2/sqlalchemy-2.0.40-py3-none-any.whl", hash = "sha256:32587e2e1e359276957e6fe5dad089758bc042a971a8a09ae8ecf7a8fe23d07a", size = 1903894, upload-time = "2025-03-27T18:40:43.796Z" },
 ]
-
-[[package]]
-name = "stringcase"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/1f/1241aa3d66e8dc1612427b17885f5fcd9c9ee3079fc0d28e9a3aeeb36fa3/stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008", size = 2958, upload-time = "2017-08-06T01:40:57.021Z" }
 
 [[package]]
 name = "tensorboard"


### PR DESCRIPTION
Replace abandonware `stringcase` package, which was causing the following errors when building due to not using raw strings:
```
...
[47/1097] Building classes for /home/nubots/NUbots/shared/message/input/GameState.proto
/home/nubots/build/.venv/lib/python3.12/site-packages/stringcase.py:247: SyntaxWarning: invalid escape sequence '\W'
  return re.sub("\W+", "", string)
...
  ```

Chose `casefy` ([github](https://github.com/dmlls/python-casefy), [PyPI](https://pypi.org/project/casefy/)) as it's a `stringcase` replacement created in response to `stringcase`'s abandonment, and has a compatible API. Also considered `stringcase-new` ([GitHub](https://github.com/zahlman/stringcase-new), [PyPI](https://pypi.org/project/stringcase-new/1.2.2/)) which is a complete drop-in replacement for `stringcase`, but only has 105 monthly downloads vs >2M for `casefy`.

Aside: does NUClear really need a full package just to PascalCase names?