### PR TITLE
[Merging into feature branch] Consider case where ball is missing, prevent echoes

### DIFF
--- a/module/localisation/BallLocalisation/data/config/BallLocalisation.yaml
+++ b/module/localisation/BallLocalisation/data/config/BallLocalisation.yaml
@@ -28,10 +28,10 @@ max_rejections: 25
 use_r2r_balls: true
 
 # Maximum time in seconds before a teammates ball is discarded
-team_ball_recency: 5.0
+team_ball_recency: 3.0
 
-# Maximum acceptable error in meters for the combined team ball
+# Maximum acceptable standard deviation in meters for the combined team ball
 team_guess_error: 0.5
 
-# Maxmimum time in seconds where we have not seen the ball before defaulting to team guesses
+# Maximimum time in seconds where we have not seen the ball before defaulting to team guesses
 team_guess_default_timer: 2.0

--- a/module/network/RobotCommunication/data/config/RobotCommunication.yaml
+++ b/module/network/RobotCommunication/data/config/RobotCommunication.yaml
@@ -1,6 +1,7 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 startup_delay: 3
+ball_timeout: 3
 
 send_port: 3737
 receive_port: 3737

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -68,6 +68,8 @@ namespace module::network {
                 log_level = config["log_level"].as<NUClear::LogLevel>();
                 // Delay before sending messages
                 cfg.startup_delay = config["startup_delay"].as<int>();
+                // Ball timeout to use the ball position
+                cfg.ball_timeout = std::chrono::seconds(config["ball_timeout"].as<int>());
 
                 // Need to determine send and receive ports
                 cfg.send_port = config["send_port"].as<uint>();
@@ -225,9 +227,11 @@ namespace module::network {
                     msg->kick_target.y() = kick->target.y();
                 }
 
-                // Ball
-                if (loc_ball) {
-                    // convert position of ball from world to field space
+                // Ball information
+                // Check if the ball has been seen recently, if it hasn't the message fields will 0
+                // and the confidence will be 0
+                if (loc_ball && (NUClear::clock::now() - loc_ball->time_of_measurement < cfg.ball_timeout)) {
+                    // Convert position of ball from world to field space
                     if (field) {
                         Eigen::Vector3d rBWw = loc_ball->rBWw;
                         // Transform the field state into Hfw
@@ -235,12 +239,13 @@ namespace module::network {
                         Eigen::Vector3d rBFf  = Hfw * rBWw;
                         // Store our position from field to ball
                         msg->ball.position = rBFf.cast<float>();
-
-                        // Confidence - our own estimates are 1.0, while if it's from a teammate, we have no confidence
-                        // This it to prevent everyone echoing
-                        msg->ball.confidence = loc_ball->confidence;
                     }
 
+
+                    // Confidence - our own estimates are 1.0, while if it's from a teammate, we have no confidence
+                    // This it to prevent everyone echoing
+                    msg->ball.confidence = loc_ball->confidence;
+                    log<INFO>("Ball confidence: ", msg->ball.confidence, " from player: ", config.player_id);
                     msg->ball.covariance = loc_ball->covariance.block(0, 0, 3, 3).cast<float>();
 
                     msg->ball.velocity = (loc_ball->vBw).cast<float>();

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -235,6 +235,10 @@ namespace module::network {
                         Eigen::Vector3d rBFf  = Hfw * rBWw;
                         // Store our position from field to ball
                         msg->ball.position = rBFf.cast<float>();
+
+                        // Confidence - our own estimates are 1.0, while if it's from a teammate, we have no confidence
+                        // This it to prevent everyone echoing
+                        msg->ball.confidence = loc_ball->confidence;
                     }
 
                     msg->ball.covariance = loc_ball->covariance.block(0, 0, 3, 3).cast<float>();

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -240,8 +240,6 @@ namespace module::network {
                         // Store our position from field to ball
                         msg->ball.position = rBFf.cast<float>();
                     }
-
-
                     // Confidence - our own estimates are 1.0, while if it's from a teammate, we have no confidence
                     // This it to prevent everyone echoing
                     msg->ball.confidence = loc_ball->confidence;

--- a/module/network/RobotCommunication/src/RobotCommunication.hpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.hpp
@@ -46,6 +46,8 @@ namespace module::network {
             std::string udp_filter_address = "";
             /// @brief A delay before the first message is sent, to allow reasonable data to be collected
             int startup_delay = 0;
+            /// @brief The timeout for the ball position to be used
+            std::chrono::seconds ball_timeout{0};
         } cfg;
 
         /// @brief ignore packets from these IP addresses

--- a/shared/message/input/RoboCup.proto
+++ b/shared/message/input/RoboCup.proto
@@ -74,6 +74,10 @@ message Ball {
     /// The covariance measure of the balls [x, y, z] values
     /// If this is unavailable leave this unset
     fmat3 covariance = 3;
+
+    /// The confidence of the ball measurement
+    /// 0.0 means no confidence, 1.0 means full confidence
+    double confidence = 4;
 }
 
 /// The current playing state of the robot

--- a/shared/message/localisation/Ball.proto
+++ b/shared/message/localisation/Ball.proto
@@ -42,12 +42,15 @@ message Ball {
     /// Covariance of state (rBWw, vBw)
     mat4 covariance = 3;
 
+    /// The ball's confidence in the measurement
+    double confidence = 4;
+
     /// Time the ball measurement was taken
-    google.protobuf.Timestamp time_of_measurement = 4;
+    google.protobuf.Timestamp time_of_measurement = 5;
 
     /// Homogeneous transformation matrix from world to camera space
-    iso3 Hcw = 5;
+    iso3 Hcw = 6;
 
     /// Average ball position collected from the team when using robot-to-robot communication
-    vec3 average_rBWw = 6;
+    vec3 average_rBWw = 7;
 }


### PR DESCRIPTION
Just some more things I noticed. If the ball is completely lost, the robots will keep echoing to each other. 
Added in a confidence on the ball, so that we can ignore balls that are not firsthand knowledge. 
Even then, there is an issue with old confident ball messages being sent to teammates, so I've added time filtering on the emission of balls.

This should be the last thing - works well in webots when I test it. 