### PR TITLE
Add functionality for a support player

### DIFF
--- a/module/localisation/RobotLocalisation/data/config/RobotLocalisation.yaml
+++ b/module/localisation/RobotLocalisation/data/config/RobotLocalisation.yaml
@@ -19,3 +19,5 @@ association_distance: 0.5
 max_missed_count: 25
 
 max_distance_from_field: 1.0
+
+max_localisation_cost: 2.0

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
@@ -79,6 +79,7 @@ namespace module::localisation {
             cfg.association_distance            = config["association_distance"].as<double>();
             cfg.max_missed_count                = config["max_missed_count"].as<int>();
             cfg.max_distance_from_field         = config["max_distance_from_field"].as<double>();
+            cfg.max_localisation_cost           = config["max_localisation_cost"].as<double>();
         });
 
         on<Every<UPDATE_RATE, Per<std::chrono::seconds>>,
@@ -115,6 +116,12 @@ namespace module::localisation {
 
         on<Trigger<RoboCup>, With<Field>, Sync<RobotLocalisation>>().then(
             [this](const RoboCup& robocup, const Field& field) {
+                // Do not consider a teammate's localisation if their cost is too high
+                if (robocup.current_pose.cost > cfg.max_localisation_cost) {
+                    log<DEBUG>("Teammate's localisation cost is too high, not processing.");
+                    return;
+                }
+
                 // **Run prediction step**
                 prediction();
 

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.cpp
@@ -191,7 +191,9 @@ namespace module::localisation {
                 teammate_itr->ukf.measure(Eigen::Vector2d(rRWw.head<2>()),
                                           cfg.ukf.noise.measurement.position,
                                           MeasurementType::ROBOT_POSITION());
-                teammate_itr->seen = true;
+                teammate_itr->seen    = true;
+                teammate_itr->purpose = *purpose;
+
                 continue;
             }
 
@@ -227,7 +229,7 @@ namespace module::localisation {
                                         const FieldDescription& field_desc) {
         std::vector<TrackedRobot> new_tracked_robots{};
 
-        // Sort tracked_robots so that robots that are teammates are at the front to prevent team mates being removed
+        // Sort tracked_robots so that robots that are teammates are at the front to prevent teammates being removed
         std::sort(tracked_robots.begin(), tracked_robots.end(), [](const TrackedRobot& a, const TrackedRobot& b) {
             return a.purpose.player_id > b.purpose.player_id;
         });
@@ -284,6 +286,8 @@ namespace module::localisation {
                        tracked_robot.id,
                        ": ",
                        tracked_robot.teammate ? "Teammate" : "Opponent",
+                       "teammate ID: ",
+                       tracked_robot.purpose.player_id,
                        "position: ",
                        RobotModel<double>::StateVec(tracked_robot.ukf.get_state()).rRWw.transpose());
         }

--- a/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
+++ b/module/localisation/RobotLocalisation/src/RobotLocalisation.hpp
@@ -62,12 +62,12 @@ namespace module::localisation {
 
             /// @brief The maximum distance a measurement or other robot can be from another robot to be associated
             double association_distance = 0.0;
-
             /// @brief The maximum number of times a robot can be missed consecutively before it is removed
             int max_missed_count = 0;
-
             /// @brief The maximum distance a robot can be outside the field before it is ignored
             double max_distance_from_field = 0.0;
+            /// @brief The maximum cost for a localisation to be considered valid
+            double max_localisation_cost = 0.0;
 
         } cfg;
 

--- a/module/purpose/FieldPlayer/data/config/FieldPlayer.yaml
+++ b/module/purpose/FieldPlayer/data/config/FieldPlayer.yaml
@@ -5,3 +5,5 @@ ball_threshold: 0.5
 equidistant_threshold: 0.4
 ball_off_center_threshold: 0.75
 center_circle_offset: 0.5
+
+max_localisation_cost: 3.0

--- a/module/purpose/FieldPlayer/src/FieldPlayer.cpp
+++ b/module/purpose/FieldPlayer/src/FieldPlayer.cpp
@@ -76,8 +76,7 @@ namespace module::purpose {
                          const Field& field,
                          const GameState& game_state,
                          const GlobalConfig& global_config,
-                         const FieldDescription& fd,
-                         const std::shared_ptr<const Purpose>& purpose) {
+                         const FieldDescription& fd) {
                 // If the robot is uncertain about its position, it should not play
                 if (field.cost > cfg.max_localisation_cost) {
                     log<DEBUG>("Field cost is too high, not playing.");
@@ -114,16 +113,14 @@ namespace module::purpose {
 
                 // Find who has the ball, if any
                 // If there are no robots, use an empty vector
-                Who ball_pos = utility::strategy::ball_possession(
-                    ball->rBWw,
-                    (robots ? *robots : Robots{}),
-                    field.Hfw,
-                    sensors.Hrw,
-                    cfg.ball_threshold,
-                    cfg.equidistant_threshold,
-                    global_config.player_id,
-                    purpose ? purpose->purpose : SoccerPosition(SoccerPosition::UNKNOWN),
-                    ignore_ids);
+                Who ball_pos = utility::strategy::ball_possession(ball->rBWw,
+                                                                  (robots ? *robots : Robots{}),
+                                                                  field.Hfw,
+                                                                  sensors.Hrw,
+                                                                  cfg.ball_threshold,
+                                                                  cfg.equidistant_threshold,
+                                                                  global_config.player_id,
+                                                                  ignore_ids);
 
                 // If we have robots, determine if we are closest to the ball
                 // Otherwise assume we are alone and closest by default
@@ -139,15 +136,13 @@ namespace module::purpose {
                     }
                 }
                 const unsigned int closest_to_ball =
-                    robots ? utility::strategy::closest_to_ball_on_team(
-                        ball->rBWw,
-                        *robots,
-                        field.Hfw,
-                        sensors.Hrw,
-                        cfg.equidistant_threshold,
-                        global_config.player_id,
-                        purpose ? purpose->purpose : SoccerPosition(SoccerPosition::UNKNOWN),
-                        ignore_ids)
+                    robots ? utility::strategy::closest_to_ball_on_team(ball->rBWw,
+                                                                        *robots,
+                                                                        field.Hfw,
+                                                                        sensors.Hrw,
+                                                                        cfg.equidistant_threshold,
+                                                                        global_config.player_id,
+                                                                        ignore_ids)
                            : global_config.player_id;
                 bool is_closest = closest_to_ball == global_config.player_id;
 
@@ -212,14 +207,12 @@ namespace module::purpose {
                         }
                     }
                 }
-                bool furthest_back = robots ? utility::strategy::furthest_back(
-                                         *robots,
-                                         field.Hfw,
-                                         sensors.Hrw,
-                                         cfg.equidistant_threshold,
-                                         global_config.player_id,
-                                         purpose ? purpose->purpose : SoccerPosition(SoccerPosition::UNKNOWN),
-                                         ignore_ids)
+                bool furthest_back = robots ? utility::strategy::furthest_back(*robots,
+                                                                               field.Hfw,
+                                                                               sensors.Hrw,
+                                                                               cfg.equidistant_threshold,
+                                                                               global_config.player_id,
+                                                                               ignore_ids)
                                             : true;
                 if (furthest_back) {
                     log<DEBUG>("Defend!");

--- a/module/purpose/FieldPlayer/src/FieldPlayer.cpp
+++ b/module/purpose/FieldPlayer/src/FieldPlayer.cpp
@@ -40,6 +40,7 @@ namespace module::purpose {
     using message::purpose::Support;
     using message::strategy::FindBall;
     using message::strategy::LookAtBall;
+    using message::strategy::Search;
     using message::strategy::WalkToFieldPosition;
     using message::strategy::Who;
     using message::support::FieldDescription;
@@ -103,7 +104,7 @@ namespace module::purpose {
                 // Add inactive robots to the ignore list
                 if (robots) {
                     for (const auto& robot : robots->robots) {
-                        if (!robot.purpose.active) {
+                        if (robot.teammate && !robot.purpose.active) {
                             ignore_ids.push_back(robot.purpose.player_id);
                         }
                     }

--- a/module/purpose/FieldPlayer/src/FieldPlayer.hpp
+++ b/module/purpose/FieldPlayer/src/FieldPlayer.hpp
@@ -20,6 +20,8 @@ namespace module::purpose {
             /// @brief The offset to the center circle for the ready position.
             /// Avoids being in the center circle during another team's kickoff
             double center_circle_offset = 0.0;
+            /// @brief The maximum cost for a localisation to be considered valid
+            double max_localisation_cost = 0.0;
         } cfg;
 
     public:

--- a/module/purpose/Support/CMakeLists.txt
+++ b/module/purpose/Support/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Build our NUClear module
+nuclear_module()

--- a/module/purpose/Support/README.md
+++ b/module/purpose/Support/README.md
@@ -2,15 +2,24 @@
 
 ## Description
 
+This module runs a support field player. It stays aligned with the ball on the y-axis, and stays a quarter of the field length away from the ball on the y-axis on whichever side is closest to the robot. It is then ready to take over as the attacker if the attacker becomes inactive.
 
 ## Usage
 
+Include this module and emit a Support Director task to have the robot act as a support player. Intended to be used when teammates already occupy the attack and defend roles.
 
 ## Consumes
 
+- `message::purpose::Support` a task telling the robot to be a supporting player.
+- `message::localisation::Ball` information on where the ball is, to align with it.
+- `message::localisation::Field` to perform calculations in field space for positioning.
+- `message::input::Sensors` to get the position of the robot.
+- `message::support::FieldDescription` for positioning relative to field width.
 
 ## Emits
 
+- `message::strategy::WalkToFieldPosition` to tell the robot where to walk to on the field.
 
 ## Dependencies
 
+- `utility::math::euler::pos_rpy_to_transform` to change the position and orientation into a homogenous transformation matrix.

--- a/module/purpose/Support/README.md
+++ b/module/purpose/Support/README.md
@@ -1,0 +1,16 @@
+# Support
+
+## Description
+
+
+## Usage
+
+
+## Consumes
+
+
+## Emits
+
+
+## Dependencies
+

--- a/module/purpose/Support/data/config/Support.yaml
+++ b/module/purpose/Support/data/config/Support.yaml
@@ -1,0 +1,2 @@
+# Controls the minimum log level that NUClear log will display
+log_level: INFO

--- a/module/purpose/Support/src/Support.cpp
+++ b/module/purpose/Support/src/Support.cpp
@@ -38,12 +38,13 @@ namespace module::purpose {
 
                 // Keep in line with the ball on the x-axis, but stay on the other side of the field on the y-axis
                 Eigen::Vector3d position = rBFf;
-                position.y()             = rBFf.y() < 0 ? rBFf.y() + (fd.dimensions.field_width / 2)
-                                                        : rBFf.y() - (fd.dimensions.field_width / 2);
-
+                position.y()             = rBFf.y() < 0 ? rBFf.y() + (fd.dimensions.field_width / 4)
+                                                        : rBFf.y() - (fd.dimensions.field_width / 4);
+                // Bound x by the penalty areas
+                // Closest side, unless it wont fit
                 // Walk to the position
                 emit<Task>(
-                    std::make_unique<WalkToFieldPosition>(pos_rpy_to_transform(position, Eigen::Vector3d(0, 0, -M_PI)),
+                    std::make_unique<WalkToFieldPosition>(pos_rpy_to_transform(position, Eigen::Vector3d(0, 0, M_PI)),
                                                           true));
             });
     }

--- a/module/purpose/Support/src/Support.cpp
+++ b/module/purpose/Support/src/Support.cpp
@@ -1,0 +1,34 @@
+#include "Support.hpp"
+
+#include "extension/Behaviour.hpp"
+#include "extension/Configuration.hpp"
+
+#include "message/localisation/Ball.hpp"
+#include "message/purpose/Player.hpp"
+
+namespace module::purpose {
+
+    using extension::Configuration;
+
+    using message::localisation::Ball;
+    using message::purpose::Support;
+
+    Support::Support(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
+
+        on<Configuration>("Support.yaml").then([this](const Configuration& config) {
+            // Use configuration here from file Support.yaml
+            this->log_level = config["log_level"].as<NUClear::LogLevel>();
+        });
+
+        on<Provide<Support>, With<Ball>, With<Field>, With<FieldDescription>>.then(
+            [this](const Ball& ball, const Field& field, const FieldDescription& fd) {
+                // Get ball in field coordinates
+                Eigen::Vector3d rBFf = field.Hfw * ball.rBWw;
+
+                // Keep in line with the ball on the x-axis, but stay on the other side of the field on the y-axis
+                double y_position        = rBFf.y() < 0 ? rBFf.y() + cfg.y_offset : -fd.field_length / 2.0;
+                Eigen::Vecotr3d position = Eigen::Vector3d(rBFf.x(), fd.field_length / 2.0, 0.0);
+            });
+    }
+
+}  // namespace module::purpose

--- a/module/purpose/Support/src/Support.cpp
+++ b/module/purpose/Support/src/Support.cpp
@@ -3,6 +3,7 @@
 #include "extension/Behaviour.hpp"
 #include "extension/Configuration.hpp"
 
+#include "message/input/Sensors.hpp"
 #include "message/localisation/Ball.hpp"
 #include "message/localisation/Field.hpp"
 #include "message/purpose/Player.hpp"
@@ -17,6 +18,7 @@ namespace module::purpose {
 
     using SupportMsg = message::purpose::Support;
 
+    using message::input::Sensors;
     using message::localisation::Ball;
     using message::localisation::Field;
     using message::strategy::WalkToFieldPosition;
@@ -31,16 +33,28 @@ namespace module::purpose {
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
         });
 
-        on<Provide<SupportMsg>, With<Ball>, With<Field>, With<FieldDescription>>().then(
-            [this](const Ball& ball, const Field& field, const FieldDescription& fd) {
+        on<Provide<SupportMsg>, With<Ball>, With<Sensors>, With<Field>, With<FieldDescription>>().then(
+            [this](const Ball& ball, const Sensors& sensors, const Field& field, const FieldDescription& fd) {
                 // Get ball in field coordinates
                 Eigen::Vector3d rBFf = field.Hfw * ball.rBWw;
+                Eigen::Vector3d rBRr = sensors.Hrw * ball.rBWw;
 
                 // Keep in line with the ball on the x-axis, but stay on the other side of the field on the y-axis
                 Eigen::Vector3d position = rBFf;
-                position.y()             = rBFf.y() < 0 ? rBFf.y() + (fd.dimensions.field_width / 4)
+                position.y()             = rBRr.y() < 0 ? rBFf.y() + (fd.dimensions.field_width / 4)
                                                         : rBFf.y() - (fd.dimensions.field_width / 4);
+
+                // If there isn't really space to walk to the desired side, walk to the other side
+                if (position.y() > fd.dimensions.field_width / 2) {
+                    position.y() = rBFf.y() - (fd.dimensions.field_width / 4);
+                }
+                else if (position.y() < -fd.dimensions.field_width / 2) {
+                    position.y() = rBFf.y() + (fd.dimensions.field_width / 4);
+                }
+
                 // Bound x by the penalty areas
+                double penalty_area = fd.dimensions.field_length / 2 - fd.dimensions.penalty_area_length;
+                position.x()        = std::clamp(position.x(), -penalty_area, penalty_area);
                 // Closest side, unless it wont fit
                 // Walk to the position
                 emit<Task>(

--- a/module/purpose/Support/src/Support.cpp
+++ b/module/purpose/Support/src/Support.cpp
@@ -4,14 +4,25 @@
 #include "extension/Configuration.hpp"
 
 #include "message/localisation/Ball.hpp"
+#include "message/localisation/Field.hpp"
 #include "message/purpose/Player.hpp"
+#include "message/strategy/WalkToFieldPosition.hpp"
+#include "message/support/FieldDescription.hpp"
+
+#include "utility/math/euler.hpp"
 
 namespace module::purpose {
 
     using extension::Configuration;
 
+    using SupportMsg = message::purpose::Support;
+
     using message::localisation::Ball;
-    using message::purpose::Support;
+    using message::localisation::Field;
+    using message::strategy::WalkToFieldPosition;
+    using message::support::FieldDescription;
+
+    using utility::math::euler::pos_rpy_to_transform;
 
     Support::Support(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
 
@@ -20,14 +31,20 @@ namespace module::purpose {
             this->log_level = config["log_level"].as<NUClear::LogLevel>();
         });
 
-        on<Provide<Support>, With<Ball>, With<Field>, With<FieldDescription>>.then(
+        on<Provide<SupportMsg>, With<Ball>, With<Field>, With<FieldDescription>>().then(
             [this](const Ball& ball, const Field& field, const FieldDescription& fd) {
                 // Get ball in field coordinates
                 Eigen::Vector3d rBFf = field.Hfw * ball.rBWw;
 
                 // Keep in line with the ball on the x-axis, but stay on the other side of the field on the y-axis
-                double y_position        = rBFf.y() < 0 ? rBFf.y() + cfg.y_offset : -fd.field_length / 2.0;
-                Eigen::Vecotr3d position = Eigen::Vector3d(rBFf.x(), fd.field_length / 2.0, 0.0);
+                Eigen::Vector3d position = rBFf;
+                position.y()             = rBFf.y() < 0 ? rBFf.y() + (fd.dimensions.field_width / 2)
+                                                        : rBFf.y() - (fd.dimensions.field_width / 2);
+
+                // Walk to the position
+                emit<Task>(
+                    std::make_unique<WalkToFieldPosition>(pos_rpy_to_transform(position, Eigen::Vector3d(0, 0, -M_PI)),
+                                                          true));
             });
     }
 

--- a/module/purpose/Support/src/Support.cpp
+++ b/module/purpose/Support/src/Support.cpp
@@ -48,8 +48,7 @@ namespace module::purpose {
 
                 // Check which side we're closer to
                 bool prefer_left = std::abs(rRFf.y() - left_side_y) < std::abs(rRFf.y() - right_side_y);
-
-                position.y() = prefer_left ? left_side_y : right_side_y;
+                position.y()     = prefer_left ? left_side_y : right_side_y;
 
                 // If there isn't really space to walk to the preferred side, walk to the other side
                 if (position.y() > fd.dimensions.field_width / 2) {

--- a/module/purpose/Support/src/Support.hpp
+++ b/module/purpose/Support/src/Support.hpp
@@ -1,0 +1,23 @@
+#ifndef MODULE_PURPOSE_SUPPORT_HPP
+#define MODULE_PURPOSE_SUPPORT_HPP
+
+#include <nuclear>
+
+#include "extension/Behaviour.hpp"
+
+namespace module::purpose {
+
+class Support : public ::extension::behaviour::BehaviourReactor {
+private:
+    /// @brief Stores configuration values
+    struct Config {
+    } cfg;
+
+public:
+    /// @brief Called by the powerplant to build and setup the Support reactor.
+    explicit Support(std::unique_ptr<NUClear::Environment> environment);
+};
+
+}  // namespace module::purpose
+
+#endif  // MODULE_PURPOSE_SUPPORT_HPP

--- a/module/purpose/Support/src/Support.hpp
+++ b/module/purpose/Support/src/Support.hpp
@@ -7,16 +7,11 @@
 
 namespace module::purpose {
 
-class Support : public ::extension::behaviour::BehaviourReactor {
-private:
-    /// @brief Stores configuration values
-    struct Config {
-    } cfg;
-
-public:
-    /// @brief Called by the powerplant to build and setup the Support reactor.
-    explicit Support(std::unique_ptr<NUClear::Environment> environment);
-};
+    class Support : public ::extension::behaviour::BehaviourReactor {
+    public:
+        /// @brief Called by the powerplant to build and setup the Support reactor.
+        explicit Support(std::unique_ptr<NUClear::Environment> environment);
+    };
 
 }  // namespace module::purpose
 

--- a/module/strategy/FindObject/src/FindObject.cpp
+++ b/module/strategy/FindObject/src/FindObject.cpp
@@ -29,18 +29,26 @@
 #include "extension/Behaviour.hpp"
 #include "extension/Configuration.hpp"
 
+#include "message/input/GameState.hpp"
 #include "message/localisation/Ball.hpp"
 #include "message/planning/LookAround.hpp"
 #include "message/planning/WalkPath.hpp"
+#include "message/purpose/Purpose.hpp"
 #include "message/strategy/FindBall.hpp"
+#include "message/support/GlobalConfig.hpp"
 
 namespace module::strategy {
 
     using extension::Configuration;
+    using message::input::GameState;
     using message::localisation::Ball;
     using message::planning::LookAround;
     using message::planning::TurnOnSpot;
+    using message::purpose::Purpose;
+    using message::purpose::SoccerPosition;
     using message::strategy::FindBall;
+    using message::strategy::Search;
+    using message::support::GlobalConfig;
 
     FindObject::FindObject(std::unique_ptr<NUClear::Environment> environment)
         : BehaviourReactor(std::move(environment)) {
@@ -52,12 +60,42 @@ namespace module::strategy {
                 std::chrono::duration<double>(config["ball_search_timeout"].as<double>()));
         });
 
-        on<Provide<FindBall>, Optional<With<Ball>>>().then([this](const std::shared_ptr<const Ball>& ball) {
-            if (ball == nullptr || (NUClear::clock::now() - ball->time_of_measurement) > cfg.ball_search_timeout) {
+        on<Provide<FindBall>, Optional<With<Ball>>, Optional<With<GlobalConfig>>, Optional<With<GameState>>>().then(
+            [this](const std::shared_ptr<const Ball>& ball,
+                   const std::shared_ptr<const GlobalConfig>& global_config,
+                   const std::shared_ptr<const GameState>& game_state) {
+                if (ball == nullptr || (NUClear::clock::now() - ball->time_of_measurement) > cfg.ball_search_timeout) {
+                    emit<Task>(std::make_unique<LookAround>());
+                    emit<Task>(std::make_unique<TurnOnSpot>());
+
+                    // Emit purpose information if we are searching for the ball
+                    if (global_config) {
+                        emit(std::make_unique<Purpose>(global_config->player_id,
+                                                       SoccerPosition::UNKNOWN,
+                                                       true,
+                                                       false,
+                                                       game_state
+                                                           ? game_state->team.team_colour
+                                                           : GameState::TeamColour(GameState::TeamColour::UNKNOWN)));
+                    }
+                }
+            });
+
+        on<Provide<Search>, Optional<With<GlobalConfig>>, Optional<With<GameState>>>().then(
+            [this](const std::shared_ptr<const GlobalConfig>& global_config,
+                   const std::shared_ptr<const GameState>& game_state) {
+                // General search functionality, to identify landmarks
                 emit<Task>(std::make_unique<LookAround>());
                 emit<Task>(std::make_unique<TurnOnSpot>());
-            }
-        });
+
+                // Emit purpose information if we are searching for the ball
+                emit(std::make_unique<Purpose>(
+                    global_config ? global_config->player_id : 1,
+                    SoccerPosition::UNKNOWN,
+                    true,
+                    false,
+                    game_state ? game_state->team.team_colour : GameState::TeamColour(GameState::TeamColour::UNKNOWN)));
+            });
     }
 
 }  // namespace module::strategy

--- a/roles/robocup.role
+++ b/roles/robocup.role
@@ -67,7 +67,7 @@ nuclear_role(
   purpose::ReadyAttack
   purpose::Defend
   purpose::FieldPlayer
-  # purpose::Support
+  purpose::Support
   purpose::Goalie
   # Platform
   platform::${SUBCONTROLLER}::HardwareIO

--- a/roles/webots/robocup.role
+++ b/roles/webots/robocup.role
@@ -68,6 +68,6 @@ nuclear_role(
   purpose::ReadyAttack
   purpose::Defend
   purpose::FieldPlayer
-  # purpose::Support
+  purpose::Support
   purpose::Goalie
 )

--- a/shared/message/input/RoboCup.proto
+++ b/shared/message/input/RoboCup.proto
@@ -55,6 +55,9 @@ message Robot {
 
     /// Robot team, if known
     Team team = 4;
+
+    // Cost of localisation
+    float cost = 5;
 }
 
 message Ball {

--- a/shared/message/strategy/FindBall.proto
+++ b/shared/message/strategy/FindBall.proto
@@ -29,3 +29,6 @@ package message.strategy;
 
 /// A Task that requests to handle the finding of the ball when its location is unknown
 message FindBall {}
+
+/// A generic search task
+message Search {}

--- a/shared/utility/strategy/soccer_strategy.hpp
+++ b/shared/utility/strategy/soccer_strategy.hpp
@@ -33,15 +33,15 @@
 #include <algorithm>
 #include <utility>
 #include <vector>
-// todo remove after testing
-#include <nuclear>
 
 #include "message/localisation/Robot.hpp"
+#include "message/purpose/Purpose.hpp"
 #include "message/strategy/Who.hpp"
 
 namespace utility::strategy {
 
     using message::localisation::Robots;
+    using message::purpose::SoccerPosition;
     using message::strategy::Who;
 
     /**
@@ -103,6 +103,12 @@ namespace utility::strategy {
             if (equidistant && !robot.teammate) {
                 closest   = {Who{Who::OPPONENT}, distance_to_ball};
                 lowest_id = 0;
+            }
+            // If it is equidistant and a teammate, is someone is already the attacker they win
+            // Otherwise lowest ID wins
+            else if (equidistant && robot.teammate && robot.purpose.purpose == SoccerPosition::ATTACK) {
+                closest   = {Who{Who::TEAMMATE}, distance_to_ball};
+                lowest_id = robot.purpose.player_id;
             }
             // Equidistant teammates with a lower ID win
             else if (equidistant && (robot.purpose.player_id < lowest_id)) {
@@ -221,9 +227,10 @@ namespace utility::strategy {
 
                 // Check if equidistant to us
                 bool equidistant = std::abs(std::abs(rRFf.y()) - furthest) < equidistant_threshold;
-                // If the robot is further back than us, or equidistant and has a higher ID, then we are not the
-                // furthest back
+                // If the robot is further back than us, or equidistant and DEFEND position, or equidistant and has a
+                // higher ID, then we are not the furthest back
                 if ((!equidistant && (std::abs(rRFf.y()) > furthest))
+                    || (equidistant && (robot.purpose.purpose == SoccerPosition::DEFEND))
                     || (equidistant && (robot.purpose.player_id > self_id))) {
                     return false;
                 }

--- a/shared/utility/strategy/soccer_strategy.hpp
+++ b/shared/utility/strategy/soccer_strategy.hpp
@@ -31,18 +31,15 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <algorithm>
-#include <nuclear>
 #include <utility>
 #include <vector>
 
 #include "message/localisation/Robot.hpp"
-#include "message/purpose/Purpose.hpp"
 #include "message/strategy/Who.hpp"
 
 namespace utility::strategy {
 
     using message::localisation::Robots;
-    using message::purpose::SoccerPosition;
     using message::strategy::Who;
 
     /**


### PR DESCRIPTION
A few bug fix and setup things in here too, to make things work nicely.

- RobotLocalisation: Added a check to ignore teammates who have a high localisation cost.
- RobotLocalisation: Fixes a bug where the purpose wasn't being overwritten when a new message is received from a tracked teammate.
- RobotCommunication: Made GlobalConfig required, because otherwise there is not team ID associated with the message, which isn't helpful.
- RobotCommunication: Added the cost of localisation, to support first point above.
- RobotCommunication: Purpose player ID is overwritten with the global config player ID. This is to enforce consistency, as the global config is the main truth of player ID, and for empty purpose messages to still contain the correct player ID.
- FieldPlayer: Search if localisation is bad (head search pattern, turn on spot)
- FieldPlayer: Only ignore teammate IDs
- Emit unknown purpose in FindBall if the ball is lost - I don't like emitting the purpose in this layer, but I'm not sure of an alternative to properly catch this without having essentially an identical check in FieldPlayer (with ball timeout config, annoying to track both).
- New Support module that stays in line with the ball, a bit away to the side, ready to take over when needed.
- soccer_strategy: Fix logic in furthest_back to make sense.