### PR TITLE
Add force playing capability to SoccerNew

### DIFF
--- a/module/purpose/SoccerNew/src/SoccerNew.cpp
+++ b/module/purpose/SoccerNew/src/SoccerNew.cpp
@@ -88,6 +88,10 @@ namespace module::purpose {
             cfg.disable_idle_delay = config["disable_idle_delay"].as<int>();
             cfg.is_goalie          = config["is_goalie"].as<bool>();
             cfg.startup_delay      = config["startup_delay"].as<int>();
+
+            if (cfg.force_playing) {
+                emit(std::make_unique<GameState::Phase>(GameState::Phase::PLAYING));
+            }
         });
 
         // Start the Director graph for the soccer scenario!


### PR DESCRIPTION
Forgot to add this before getting the new behaviour in. To avoid having to rewrite the general structure of the FieldPlayer, I think an easy solution is to just emit a playing phase. We don't typically use force playing with a game controller running since the usual use case is not wanting to have to set the game controller up just to do some testing. If there is a game controller running, then the user can just filter out the messages by setting the `udp_filter_address` in the game controller yaml. 

Tested in Webots.