### PR TITLE
Stand still after fall

### DIFF
--- a/module/skill/GetUp/README.md
+++ b/module/skill/GetUp/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-A Behaviour module that will run the appropriate getup script for the robot. It is first delayed so that the robot can settle into it's final position to improve side detection accuracy.
+A Behaviour module that will run the appropriate getup script for the robot. First a StandStill task is emitted, then the getup task is delayed so that the robot can settle into it's final position to improve side detection accuracy. Additionally, if after the delay the robot detects that it is on its side, another delay will be emitted.
 
 ## Usage
 

--- a/module/skill/GetUp/README.md
+++ b/module/skill/GetUp/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-A Behaviour module that will run the appropriate getup script for the robot. First a StandStill task is emitted, then the getup task is delayed so that the robot can settle into it's final position to improve side detection accuracy. Additionally, if after the delay the robot detects that it is on its side, another delay will be emitted.
+A Behaviour module that will run the appropriate getup script for the robot. First a StandStill task is emitted, then the getup task is delayed so that the robot can settle into it's final position to improve side detection accuracy. Additionally, if after the delay the robot detects that it is on its left/right side, another delay will be emitted.
 
 ## Usage
 

--- a/module/skill/GetUp/src/GetUp.cpp
+++ b/module/skill/GetUp/src/GetUp.cpp
@@ -35,6 +35,7 @@
 #include "message/behaviour/state/Stability.hpp"
 #include "message/input/Sensors.hpp"
 #include "message/skill/GetUp.hpp"
+#include "message/strategy/StandStill.hpp"
 
 #include "utility/skill/Script.hpp"
 
@@ -45,6 +46,7 @@ namespace module::skill {
     using message::behaviour::state::Stability;
     using message::input::Sensors;
     using GetUpTask = message::skill::GetUp;
+    using message::strategy::StandStill;
     using utility::skill::load_script;
 
     GetUp::GetUp(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
@@ -63,6 +65,9 @@ namespace module::skill {
                                                                                  const Uses<BodySequence>& body,
                                                                                  const Sensors& sensors) {
             if (run_reason == RunReason::NEW_TASK) {
+                // Stand still
+                log<INFO>("Standing still...");
+                emit<Task>(std::make_unique<StandStill>());
                 // Wait so that sensors have time to settle
                 log<INFO>("Delaying getup...");
                 emit<Task>(std::make_unique<Wait>(NUClear::clock::now() + std::chrono::milliseconds(cfg.delay_time)));


### PR DESCRIPTION
Adds a StandStill command before the delay so that the robot stops walking after it falls over but before the get up script is run. 

### Labels Info 

G-Motion 
L-C++