### PR TITLE
TEMP: Fix keyboardwalk freezing 

### DIFF
--- a/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
+++ b/module/purpose/KeyboardWalk/src/KeyboardWalk.cpp
@@ -133,7 +133,7 @@ namespace module::purpose {
         });
 
         // Trigger when stdin has something to read
-        on<IO>(STDIN_FILENO, IO::READ).then([this] {
+        on<Always>().then([this] {
             switch (tolower(getch())) {
                 case 'w': forward(); break;
                 case 'a': left(); break;


### PR DESCRIPTION
This PR provides a temporary fix for keyboard walk freezing when using the keyboard. The fix is sub-optimal as it locks up a thread purely for listening for keyboard events, but it's a fix... 

The real issue is something to do with using `getch()` and `on<IO>` together resulting in the module freezing, but I don't have a fix for it currently. 