### PR TITLE
Remove ball search timeout

### DIFF
--- a/module/strategy/WalkToBall/data/config/WalkToBall.yaml
+++ b/module/strategy/WalkToBall/data/config/WalkToBall.yaml
@@ -1,9 +1,6 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-# How long to wait until the ball is lost and we should walk in a search pattern
-ball_search_timeout: 5
-
 # Y - Offset for ball position such that ball is approached with foot behind ball
 ball_y_offset: 0.0
 

--- a/module/strategy/WalkToBall/data/config/webots/WalkToBall.yaml
+++ b/module/strategy/WalkToBall/data/config/webots/WalkToBall.yaml
@@ -1,9 +1,6 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-# How long to wait until the ball is lost and we should walk in a search pattern
-ball_search_timeout: 2
-
 # Y - Offset for ball position such that ball is approached with foot behind ball
 ball_y_offset: 0.1
 

--- a/module/strategy/WalkToBall/src/WalkToBall.hpp
+++ b/module/strategy/WalkToBall/src/WalkToBall.hpp
@@ -38,8 +38,6 @@ namespace module::strategy {
     private:
         /// @brief Stores configuration values
         struct Config {
-            /// @brief Length of time before the ball detection is too old and we should search for the ball
-            NUClear::clock::duration ball_search_timeout{};
 
             /// @brief Offset to align the ball with the robot's foot
             double ball_y_offset = 0.0;


### PR DESCRIPTION
Remove ball search timeout to avoid conflicts with `FindBall` timeout. Intended logic now is that the robot should always be trying to find the ball and `FindBall` will take over priority if needed