### PR TITLE
Adapt mahony gains online based on STABILITY state

### DIFF
--- a/module/input/SensorFilter/data/config/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/SensorFilter.yaml
@@ -10,10 +10,16 @@ foot_down:
 
 # Mahony filter for roll + pitch
 mahony:
-  # Proportional gain
-  Kp: 0.2
   # Integral gain
   Ki: 0.1
+  # Adaptive gains based on stability state
+  adaptive_gains:
+    # More aggressive gain when standing (stationary)
+    standing:
+      Kp: 0.8
+    # Default gain for dynamic states (walking, falling, etc.)
+    dynamic:
+      Kp: 0.2
   # Initial bias
   initial_bias: [0, 0, 0]
   # Initial orientation (roll, pitch, yaw)

--- a/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
+++ b/module/input/SensorFilter/data/config/webots/SensorFilter.yaml
@@ -1,9 +1,15 @@
 # Mahony filter for roll + pitch
 mahony:
-  # Proportional gain
-  Kp: 0.5
   # Integral gain
-  Ki: 0.3
+  Ki: 0.2
+  # Adaptive gains based on stability state
+  adaptive_gains:
+    # More aggressive gain when standing (stationary)
+    standing:
+      Kp: 0.5
+    # Default gain for dynamic states (walking, falling, etc.)
+    dynamic:
+      Kp: 0.2
   # Initial bias
   initial_bias:
     - 0

--- a/module/input/SensorFilter/src/SensorFilter.cpp
+++ b/module/input/SensorFilter/src/SensorFilter.cpp
@@ -61,8 +61,10 @@ namespace module::input {
             nugus_model = tinyrobotics::import_urdf<double, n_servos>(config["urdf_path"].as<std::string>());
 
             // Configure the Mahony filter
-            mahony_filter = MahonyFilter<double>(
-                config["mahony"]["Kp"].as<Expression>(),
+            cfg.adaptive_gains.standing_Kp = config["mahony"]["adaptive_gains"]["standing"]["Kp"].as<double>();
+            cfg.adaptive_gains.dynamic_Kp  = config["mahony"]["adaptive_gains"]["dynamic"]["Kp"].as<double>();
+            mahony_filter                  = MahonyFilter<double>(
+                cfg.adaptive_gains.standing_Kp,
                 config["mahony"]["Ki"].as<Expression>(),
                 Eigen::Vector3d(config["mahony"]["initial_bias"].as<Expression>()),
                 rpy_intrinsic_to_mat(Eigen::Vector3d(config["mahony"]["initial_rpy"].as<Expression>())));

--- a/module/input/SensorFilter/src/SensorFilter.hpp
+++ b/module/input/SensorFilter/src/SensorFilter.hpp
@@ -67,6 +67,14 @@ namespace module::input {
                 double threshold   = 0.0;
             } foot_down;
 
+            /// @brief Adaptive Mahony filter gains based on stability state
+            struct AdaptiveGains {
+                /// @brief Kp gain for standing state
+                double standing_Kp = 0.0;
+                /// @brief Kp gain for dynamic states
+                double dynamic_Kp = 0.0;
+            } adaptive_gains;
+
             /// @brief The number of times a button must be pressed before it is considered pressed
             int button_debounce_threshold = 0;
             /// @brief Cutoff frequency for the low pass filter of torso x velocity

--- a/module/input/SensorFilter/src/sensorfilter/update_odometry.cpp
+++ b/module/input/SensorFilter/src/sensorfilter/update_odometry.cpp
@@ -82,6 +82,14 @@ namespace module::input {
                 .count(),
             0.0);
 
+        // Adapt Mahony filter Kp gain based on stability state
+        if (stability == Stability::STANDING) {
+            mahony_filter.set_Kp(cfg.adaptive_gains.standing_Kp);
+        }
+        else {
+            mahony_filter.set_Kp(cfg.adaptive_gains.dynamic_Kp);
+        }
+
         // Perform Mahony update
         const auto Rwt_mahony      = mahony_filter.update(sensors->accelerometer, sensors->gyroscope, dt);
         Eigen::Vector3d rpy_mahony = mat_to_rpy_intrinsic(Rwt_mahony);

--- a/shared/utility/math/filter/MahonyFilter.hpp
+++ b/shared/utility/math/filter/MahonyFilter.hpp
@@ -112,6 +112,26 @@ namespace utility {
                 void set_state(const Eigen::Matrix<Scalar, 3, 3>& Rwb) {
                     this->Rwb = Rwb;
                 }
+
+                /// @brief Set the proportional gain
+                void set_Kp(const Scalar new_Kp) {
+                    this->Kp = new_Kp;
+                }
+
+                /// @brief Get the current proportional gain
+                Scalar get_Kp() const {
+                    return Kp;
+                }
+
+                /// @brief Set the integral gain
+                void set_Ki(const Scalar new_Ki) {
+                    this->Ki = new_Ki;
+                }
+
+                /// @brief Get the current integral gain
+                Scalar get_Ki() const {
+                    return Ki;
+                }
             };
 
         }  // namespace filter


### PR DESCRIPTION
This pull request introduces adaptive proportional gain (`Kp`) functionality to the Mahony filter, allowing it to adjust based on the system's stability state (e.g., standing vs. dynamic states). The idea is to allow faster convergence when standing and sensor noise is minimal, but reduce correction gains when moving.
