### PR TITLE
Fix bug making the robot walk when pressing localisation reset button during penalisation

### DIFF
--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -177,9 +177,9 @@ namespace module::purpose {
 
         on<Trigger<ButtonMiddleUp>>().then([this] { emit<Scope::INLINE>(std::make_unique<Buzzer>(0)); });
 
-        on<Trigger<DisableIdle>>().then([this] {
-            // If the robot is not idle, restart the Director graph for the soccer scenario!
-            if (!idle) {
+        on<Trigger<DisableIdle>, With<GameState>>().then([this](const GameState& game_state) {
+            // If the robot is not idle nor penalised, restart the Director graph for the soccer scenario!
+            if (!idle && game_state.self.penalty_reason == GameState::PenaltyReason::UNPENALISED) {
                 emit<Task>(std::make_unique<FindPurpose>(), 1);
                 emit<Task>(std::make_unique<FallRecovery>(), 2);
                 log<INFO>("Idle mode disabled");

--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -145,6 +145,7 @@ namespace module::purpose {
             // If the robot is unpenalised, stop standing still and find its purpose
             if (!cfg.force_playing && !idle && self_unpenalisation.context == GameEvents::Context::SELF) {
                 emit<Task>(std::make_unique<FindPurpose>(), 1);
+                emit<Task>(std::make_unique<FallRecovery>(), 2);
             }
         });
 

--- a/module/purpose/Soccer/src/Soccer.cpp
+++ b/module/purpose/Soccer/src/Soccer.cpp
@@ -143,7 +143,7 @@ namespace module::purpose {
 
         on<Trigger<Unpenalisation>>().then([this](const Unpenalisation& self_unpenalisation) {
             // If the robot is unpenalised, stop standing still and find its purpose
-            if (!cfg.force_playing && self_unpenalisation.context == GameEvents::Context::SELF) {
+            if (!cfg.force_playing && !idle && self_unpenalisation.context == GameEvents::Context::SELF) {
                 emit<Task>(std::make_unique<FindPurpose>(), 1);
             }
         });


### PR DESCRIPTION
The logic with penalisation and button presses is wrong. The robot will start playing again if the middle button is pressed during penalisation (bad!), and it will also start playing again if penalisation ends and idle is still set (not too bad but mightt be annoying).
This PR fixes those issues to check idle/penalisation in the relevant spots.