### PR TITLE
Prevent oscillations when in ready position

### DIFF
--- a/module/strategy/WalkToFieldPosition/data/config/WalkToFieldPosition.yaml
+++ b/module/strategy/WalkToFieldPosition/data/config/WalkToFieldPosition.yaml
@@ -1,5 +1,5 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-stop_threshold: 0.2
+stop_threshold: 0.15
 stopped_threshold: 0.4


### PR DESCRIPTION
The ready position uses WalkToFieldPosition, which has a radius within the target position in which to stop walking, and then a larger radius where if it exits that larger radius it will try to get into position again. 
Error in the system makes this drift and is the reason we have a radius, but it seems the annulus region is too small and in ready it oscillates between being happy and being outside of the larger radius.
This PR increases the annulus area by decreasing the size of the inner radius (`stop_threshold`).
Tested in robocup ready a couple of times and had no oscillations :+1: 