### PR TITLE
Add in-step kick

### DIFF
--- a/module/skill/KickWalk/src/KickWalk.cpp
+++ b/module/skill/KickWalk/src/KickWalk.cpp
@@ -29,19 +29,18 @@
 #include "extension/Behaviour.hpp"
 #include "extension/Configuration.hpp"
 
+#include "message/behaviour/state/WalkState.hpp"
 #include "message/skill/Kick.hpp"
 #include "message/skill/Walk.hpp"
-
-#include "message/behaviour/state/WalkState.hpp"
 
 
 namespace module::skill {
 
     using extension::Configuration;
 
+    using message::behaviour::state::WalkState;
     using message::skill::Kick;
     using message::skill::Walk;
-    using message::behaviour::state::WalkState;
 
     KickWalk::KickWalk(std::unique_ptr<NUClear::Environment> environment) : BehaviourReactor(std::move(environment)) {
         on<Configuration>("KickWalk.yaml").then([this](const Configuration& config) {
@@ -52,37 +51,40 @@ namespace module::skill {
             cfg.new_kick_wait_time       = config["new_kick_wait_time"].as<double>();
         });
 
-        on<Provide<Kick>, Uses<Walk>, With<WalkState>>().then(
-            [this](const Kick& kick, const RunReason& run_reason, const Uses<Walk>& walk_provider, const WalkState& walk_state) {
-                log<INFO>("KickWalk module received a kick request for leg: ", kick.leg);
-                if (run_reason == RunReason::NEW_TASK && walk_state.state != WalkState::State::STOPPED && !walk_state.velocity_target.isZero()) {
-                    if (NUClear::clock::now() - last_kick_end < std::chrono::seconds(cfg.new_kick_wait_time)) {
-                        log<DEBUG>("KickWalk is waiting for cooldown after last kick.");
-                        NUClear::clock::time_point wait_until =
-                            last_kick_end + std::chrono::seconds(cfg.new_kick_wait_time);
-                        emit<Task>(std::make_unique<Wait>(wait_until));
-                        return;
-                    }
-
-                    log<DEBUG>("KickWalk module received a kick request for leg: ", kick.leg);
-
-                    emit<Task>(std::make_unique<Walk>(walk_state.velocity_target, true, kick.leg));
-                }
-                // The wait triggered the provider
-                else if (run_reason == RunReason::SUBTASK_DONE && !walk_provider.done) {
-                    // Slow approach
-                    log<DEBUG>("KickWalk module received a kick request for leg: ", kick.leg);
-                    emit<Task>(std::make_unique<Walk>(walk_state.velocity_target, true, kick.leg));
-                }
-
-                // If the walk says the kick is done, emit a Done task
-                if (run_reason == RunReason::SUBTASK_DONE) {
-                    log<DEBUG>("KickWalk step completed, kick done for leg: ", kick.leg);
-                    last_kick_end = NUClear::clock::now();
-                    emit<Task>(std::make_unique<Done>());
+        on<Provide<Kick>, Uses<Walk>, With<WalkState>>().then([this](const Kick& kick,
+                                                                     const RunReason& run_reason,
+                                                                     const Uses<Walk>& walk_provider,
+                                                                     const WalkState& walk_state) {
+            log<INFO>("KickWalk module received a kick request for leg: ", kick.leg);
+            if (run_reason == RunReason::NEW_TASK && walk_state.state != WalkState::State::STOPPED
+                && !walk_state.velocity_target.isZero()) {
+                if (NUClear::clock::now() - last_kick_end < std::chrono::seconds(cfg.new_kick_wait_time)) {
+                    log<DEBUG>("KickWalk is waiting for cooldown after last kick.");
+                    NUClear::clock::time_point wait_until =
+                        last_kick_end + std::chrono::seconds(cfg.new_kick_wait_time);
+                    emit<Task>(std::make_unique<Wait>(wait_until));
                     return;
                 }
-            });
+
+                log<DEBUG>("KickWalk module received a kick request for leg: ", kick.leg);
+
+                emit<Task>(std::make_unique<Walk>(walk_state.velocity_target, true, kick.leg));
+            }
+            // The wait triggered the provider
+            else if (run_reason == RunReason::SUBTASK_DONE && !walk_provider.done) {
+                // Slow approach
+                log<DEBUG>("KickWalk module received a kick request for leg: ", kick.leg);
+                emit<Task>(std::make_unique<Walk>(walk_state.velocity_target, true, kick.leg));
+            }
+
+            // If the walk says the kick is done, emit a Done task
+            if (run_reason == RunReason::SUBTASK_DONE) {
+                log<DEBUG>("KickWalk step completed, kick done for leg: ", kick.leg);
+                last_kick_end = NUClear::clock::now();
+                emit<Task>(std::make_unique<Done>());
+                return;
+            }
+        });
     }
 
 }  // namespace module::skill

--- a/module/skill/Walk/data/config/Walk.yaml
+++ b/module/skill/Walk/data/config/Walk.yaml
@@ -47,3 +47,11 @@ kick:
   kick_velocity_x: 0.35 # Forward velocity during kick (m/s)
   kick_velocity_y: 0.001 # Lateral velocity during kick (m/s)
   kick_timing_offset: 0.1 # Buffer time before the kick starts (in seconds)
+
+  # Kick trajectory parameters
+  kick_height: 0.07 # Height of the foot during kick (m)
+  kick_forward_distance: 0.085 # Forward distance the foot moves during kick (m)
+  kick_backward_distance: 0.05 # Backward distance for windup (m)
+  kick_apex_ratio: 0.6 # Ratio of step period when foot is at highest point during kick
+  kick_timing_ratio: 0.8 # Ratio of step period when the actual kick occurs
+  kick_windup_ratio: 0.4 # Ratio of step period when windup occurs

--- a/module/skill/Walk/data/config/Walk.yaml
+++ b/module/skill/Walk/data/config/Walk.yaml
@@ -49,9 +49,9 @@ kick:
   kick_timing_offset: 0.1 # Buffer time before the kick starts (in seconds)
 
   # Kick trajectory parameters
-  kick_height: 0.07 # Height of the foot during kick (m)
-  kick_forward_distance: 0.085 # Forward distance the foot moves during kick (m)
-  kick_backward_distance: 0.05 # Backward distance for windup (m)
+  kick_height: 0.1 # Height of the foot during kick (m)
+  kick_forward_distance: 0.11 # Forward distance the foot moves during kick (m)
+  kick_backward_distance: 0.075 # Backward distance for windup (m)
   kick_apex_ratio: 0.6 # Ratio of step period when foot is at highest point during kick
   kick_timing_ratio: 0.8 # Ratio of step period when the actual kick occurs
   kick_windup_ratio: 0.4 # Ratio of step period when windup occurs

--- a/module/skill/Walk/data/config/webots/Walk.yaml
+++ b/module/skill/Walk/data/config/webots/Walk.yaml
@@ -47,3 +47,11 @@ kick:
   kick_velocity_x: 0.5 # Forward velocity during kick (m/s)
   kick_velocity_y: 0.05 # Lateral velocity during kick (m/s)
   kick_timing_offset: 0.1 # Buffer time before the kick starts (in seconds)
+
+  # Kick trajectory parameters
+  kick_height: 0.07 # Height of the foot during kick (m)
+  kick_forward_distance: 0.085 # Forward distance the foot moves during kick (m)
+  kick_backward_distance: 0.05 # Backward distance for windup (m)
+  kick_apex_ratio: 0.6 # Ratio of step period when foot is at highest point during kick
+  kick_timing_ratio: 0.8 # Ratio of step period when the actual kick occurs
+  kick_windup_ratio: 0.4 # Ratio of step period when windup occurs

--- a/module/skill/Walk/data/config/webots/Walk.yaml
+++ b/module/skill/Walk/data/config/webots/Walk.yaml
@@ -49,9 +49,9 @@ kick:
   kick_timing_offset: 0.1 # Buffer time before the kick starts (in seconds)
 
   # Kick trajectory parameters
-  kick_height: 0.07 # Height of the foot during kick (m)
-  kick_forward_distance: 0.085 # Forward distance the foot moves during kick (m)
-  kick_backward_distance: 0.05 # Backward distance for windup (m)
-  kick_apex_ratio: 0.6 # Ratio of step period when foot is at highest point during kick
+  kick_height: 0.085 # Height of the foot during kick (m)
+  kick_forward_distance: 0.12 # Forward distance the foot moves during kick (m)
+  kick_backward_distance: 0.085 # Backward distance for windup (m)
+  kick_apex_ratio: 0.7 # Ratio of step period when foot is at highest point during kick
   kick_timing_ratio: 0.8 # Ratio of step period when the actual kick occurs
   kick_windup_ratio: 0.4 # Ratio of step period when windup occurs

--- a/module/skill/Walk/src/Walk.cpp
+++ b/module/skill/Walk/src/Walk.cpp
@@ -88,10 +88,11 @@ namespace module::skill {
                 config["walk"]["torso"]["final_position_ratio"].as<Expression>();
 
             // Configure kick parameters
-            cfg.walk_generator_parameters.kick_height = config["kick"]["kick_height"].as<double>();
+            cfg.walk_generator_parameters.kick_height           = config["kick"]["kick_height"].as<double>();
             cfg.walk_generator_parameters.kick_forward_distance = config["kick"]["kick_forward_distance"].as<double>();
-            cfg.walk_generator_parameters.kick_backward_distance = config["kick"]["kick_backward_distance"].as<double>();
-            cfg.walk_generator_parameters.kick_apex_ratio = config["kick"]["kick_apex_ratio"].as<double>();
+            cfg.walk_generator_parameters.kick_backward_distance =
+                config["kick"]["kick_backward_distance"].as<double>();
+            cfg.walk_generator_parameters.kick_apex_ratio   = config["kick"]["kick_apex_ratio"].as<double>();
             cfg.walk_generator_parameters.kick_timing_ratio = config["kick"]["kick_timing_ratio"].as<double>();
             cfg.walk_generator_parameters.kick_windup_ratio = config["kick"]["kick_windup_ratio"].as<double>();
 
@@ -199,7 +200,9 @@ namespace module::skill {
 
                 // Update the walk engine and emit the stability state, only if not falling/fallen
                 if (stability != Stability::FALLEN) {
-                    switch (walk_generator.update(time_delta, velocity_target, sensors.planted_foot_phase, kick_step_in_progress).value) {
+                    switch (walk_generator
+                                .update(time_delta, velocity_target, sensors.planted_foot_phase, kick_step_in_progress)
+                                .value) {
                         case WalkState::State::STARTING:
                         case WalkState::State::WALKING:
                         case WalkState::State::KICKING:

--- a/module/skill/Walk/src/Walk.cpp
+++ b/module/skill/Walk/src/Walk.cpp
@@ -160,7 +160,6 @@ namespace module::skill {
 
                 // Always enter the kick if its a new kick, otherwise only enter if we're not done yet
                 if (walk_task.kick) {
-                    log<INFO>("Kick step requested");
                     double current_time    = walk_generator.get_time();
                     double full_period     = walk_generator.get_step_period();
                     WalkState::Phase phase = walk_generator.get_phase();
@@ -192,6 +191,7 @@ namespace module::skill {
                         if ((end_of && correct_support) || (!end_of && !correct_support)) {
                             kick_step_in_progress = false;
                             emit<Task>(std::make_unique<Done>());
+                            log<INFO>("Kick step ended");
                         }
                         // Otherwise continue to kick
                     }

--- a/module/skill/Walk/src/Walk.cpp
+++ b/module/skill/Walk/src/Walk.cpp
@@ -192,14 +192,10 @@ namespace module::skill {
                         if ((end_of && correct_support) || (!end_of && !correct_support)) {
                             kick_step_in_progress = false;
                             emit<Task>(std::make_unique<Done>());
-                            log<INFO>("Kick step ended");
-                            // return;
                         }
                         // Otherwise continue to kick
                     }
                 }
-
-                log<INFO>("Kick step in progress: ", kick_step_in_progress);
 
                 // Update the walk engine and emit the stability state, only if not falling/fallen
                 if (stability != Stability::FALLEN) {

--- a/module/skill/Walk/src/Walk.cpp
+++ b/module/skill/Walk/src/Walk.cpp
@@ -86,6 +86,15 @@ namespace module::skill {
             cfg.walk_generator_parameters.torso_sway_ratio  = config["walk"]["torso"]["sway_ratio"].as<double>();
             cfg.walk_generator_parameters.torso_final_position_ratio =
                 config["walk"]["torso"]["final_position_ratio"].as<Expression>();
+
+            // Configure kick parameters
+            cfg.walk_generator_parameters.kick_height = config["kick"]["kick_height"].as<double>();
+            cfg.walk_generator_parameters.kick_forward_distance = config["kick"]["kick_forward_distance"].as<double>();
+            cfg.walk_generator_parameters.kick_backward_distance = config["kick"]["kick_backward_distance"].as<double>();
+            cfg.walk_generator_parameters.kick_apex_ratio = config["kick"]["kick_apex_ratio"].as<double>();
+            cfg.walk_generator_parameters.kick_timing_ratio = config["kick"]["kick_timing_ratio"].as<double>();
+            cfg.walk_generator_parameters.kick_windup_ratio = config["kick"]["kick_windup_ratio"].as<double>();
+
             walk_generator.set_parameters(cfg.walk_generator_parameters);
             cfg.walk_generator_parameters.only_switch_when_planted =
                 config["walk"]["only_switch_when_planted"].as<bool>();
@@ -184,11 +193,13 @@ namespace module::skill {
                             kick_step_in_progress = false;
                             emit<Task>(std::make_unique<Done>());
                             log<INFO>("Kick step ended");
-                            return;
+                            // return;
                         }
                         // Otherwise continue to kick
                     }
                 }
+
+                log<INFO>("Kick step in progress: ", kick_step_in_progress);
 
                 // Update the walk engine and emit the stability state, only if not falling/fallen
                 if (stability != Stability::FALLEN) {

--- a/shared/message/behaviour/state/WalkState.proto
+++ b/shared/message/behaviour/state/WalkState.proto
@@ -36,8 +36,9 @@ message WalkState {
         UNKNOWN  = 0;
         STARTING = 1;
         WALKING  = 2;
-        STOPPING = 3;
-        STOPPED  = 4;
+        KICKING  = 3;
+        STOPPING = 4;
+        STOPPED  = 5;
     }
 
     enum Phase {

--- a/shared/utility/skill/WalkGenerator.hpp
+++ b/shared/utility/skill/WalkGenerator.hpp
@@ -243,7 +243,8 @@ namespace utility::skill {
             else if (kick_requested && engine_state.value == WalkState::State::WALKING) {
                 // Kick is requested and we are walking, transition to kicking
                 engine_state = WalkState::State::KICKING;
-            } else if (!kick_requested && engine_state.value == WalkState::State::KICKING) {
+            }
+            else if (!kick_requested && engine_state.value == WalkState::State::KICKING) {
                 // Kick is not requested and we are kicking, transition to walking
                 engine_state = WalkState::State::WALKING;
             }
@@ -567,17 +568,17 @@ namespace utility::skill {
          * @brief Generate kicking trajectories for the torso and swing foot.
          */
         void generate_kicking_trajectories(const Vec3& velocity_target) {
-               // Compute the next step placement in the planted foot frame based on the requested velocity target
-               Vec3 step = Vec3::Zero();
-               step.x()  = std::max(std::min(velocity_target.x() * p.step_period, p.step_limits.x()), -p.step_limits.x());
-               step.y()  = std::max(std::min(velocity_target.y() * p.step_period, p.step_limits.y()), -p.step_limits.y());
-               step.z()  = std::max(std::min(velocity_target.z() * p.step_period, p.step_limits.z()), -p.step_limits.z());
+            // Compute the next step placement in the planted foot frame based on the requested velocity target
+            Vec3 step = Vec3::Zero();
+            step.x()  = std::max(std::min(velocity_target.x() * p.step_period, p.step_limits.x()), -p.step_limits.x());
+            step.y()  = std::max(std::min(velocity_target.y() * p.step_period, p.step_limits.y()), -p.step_limits.y());
+            step.z()  = std::max(std::min(velocity_target.z() * p.step_period, p.step_limits.z()), -p.step_limits.z());
 
-               // Generate torso trajectory
-               generate_torso_trajectory(step, velocity_target);
+            // Generate torso trajectory
+            generate_torso_trajectory(step, velocity_target);
 
-               // Generate kick swing foot trajectory
-               generate_kick_swing_foot_trajectory(step, velocity_target);
+            // Generate kick swing foot trajectory
+            generate_kick_swing_foot_trajectory(step, velocity_target);
         }
 
         /**

--- a/shared/utility/skill/WalkGenerator.hpp
+++ b/shared/utility/skill/WalkGenerator.hpp
@@ -90,6 +90,25 @@ namespace utility::skill {
 
             /// @brief Option to only switch between planted foot if the next foot is planted
             bool only_switch_when_planted = false;
+
+            // ******************************** Kick Parameters ********************************
+            /// @brief Kick height (in meters) - how high the foot goes during kick
+            Scalar kick_height = 0.07;
+
+            /// @brief Kick forward distance (in meters) - how far forward the foot moves during kick
+            Scalar kick_forward_distance = 0.085;
+
+            /// @brief Kick backward distance (in meters) - how far back the foot moves during windup
+            Scalar kick_backward_distance = 0.05;
+
+            /// @brief Ratio of the step_period where the foot should be at its highest point during kick, between [0 1]
+            Scalar kick_apex_ratio = 0.6;
+
+            /// @brief Ratio of the step_period where the kick should occur, between [0 1]
+            Scalar kick_timing_ratio = 0.8;
+
+            /// @brief Ratio of the step_period where the windup should occur, between [0 1]
+            Scalar kick_windup_ratio = 0.4;
         };
 
         /**
@@ -224,6 +243,9 @@ namespace utility::skill {
             else if (kick_requested && engine_state.value == WalkState::State::WALKING) {
                 // Kick is requested and we are walking, transition to kicking
                 engine_state = WalkState::State::KICKING;
+            } else if (!kick_requested && engine_state.value == WalkState::State::KICKING) {
+                // Kick is not requested and we are kicking, transition to walking
+                engine_state = WalkState::State::WALKING;
             }
 
             // If the sensors have detected either double support or next foot planted, allow switching the planted foot
@@ -423,6 +445,59 @@ namespace utility::skill {
         }
 
         /**
+         * @brief Generate kick swing foot trajectory for the current step.
+         * @param step Step placement in the planted foot frame.
+         * @param velocity_target Requested velocity target (dx, dy, dtheta).
+         */
+        void generate_kick_swing_foot_trajectory(const Vec3& step, const Vec3& velocity_target) {
+            // Create a waypoint variable to use for all waypoints
+            Waypoint<Scalar> wp;
+
+            // ******************************** Kick Swing Foot Trajectory ********************************
+            swing_foot_trajectory.clear();
+
+            // Start waypoint: Current swing foot position
+            wp.time_point       = 0.0;
+            wp.position         = Hps_start.translation();
+            wp.velocity         = Vec3::Zero();
+            wp.orientation      = mat_to_rpy_intrinsic(Hps_start.rotation());
+            wp.angular_velocity = Vec3::Zero();
+            swing_foot_trajectory.add_waypoint(wp);
+
+            // Windup waypoint: Move foot back and up for windup
+            wp.time_point       = p.kick_windup_ratio * p.step_period;
+            wp.position         = Vec3(-p.kick_backward_distance, get_foot_width_offset(), p.kick_height);
+            wp.velocity         = Vec3(velocity_target.x(), velocity_target.y(), 0);
+            wp.orientation      = Vec3(0.0, 0.0, velocity_target.z() * p.kick_windup_ratio * p.step_period);
+            wp.angular_velocity = Vec3(0.0, 0.0, velocity_target.z());
+            swing_foot_trajectory.add_waypoint(wp);
+
+            // Kick apex waypoint: Foot at highest point during kick
+            wp.time_point       = p.kick_apex_ratio * p.step_period;
+            wp.position         = Vec3(0, get_foot_width_offset(), p.kick_height);
+            wp.velocity         = Vec3(velocity_target.x(), velocity_target.y(), 0);
+            wp.orientation      = Vec3(0.0, 0.0, velocity_target.z() * p.kick_apex_ratio * p.step_period);
+            wp.angular_velocity = Vec3(0.0, 0.0, velocity_target.z());
+            swing_foot_trajectory.add_waypoint(wp);
+
+            // Kick waypoint: Foot forward for the actual kick
+            wp.time_point       = p.kick_timing_ratio * p.step_period;
+            wp.position         = Vec3(p.kick_forward_distance, get_foot_width_offset(), p.kick_height * 0.8);
+            wp.velocity         = Vec3(velocity_target.x(), velocity_target.y(), 0);
+            wp.orientation      = Vec3(0.0, 0.0, velocity_target.z() * p.kick_timing_ratio * p.step_period);
+            wp.angular_velocity = Vec3(0.0, 0.0, velocity_target.z());
+            swing_foot_trajectory.add_waypoint(wp);
+
+            // End waypoint: Return to ground position
+            wp.time_point       = p.step_period;
+            wp.position         = Vec3(step.x(), get_foot_width_offset() + step.y(), 0);
+            wp.velocity         = Vec3::Zero();
+            wp.orientation      = Vec3(0, 0, step.z());
+            wp.angular_velocity = Vec3::Zero();
+            swing_foot_trajectory.add_waypoint(wp);
+        }
+
+        /**
          * @brief Generate walking trajectories for the torso and swing foot.
          * @param velocity_target Requested velocity target (dx, dy, dtheta).
          */
@@ -501,8 +576,8 @@ namespace utility::skill {
                // Generate torso trajectory
                generate_torso_trajectory(step, velocity_target);
 
-               // Generate swing foot trajectory
-               generate_swing_foot_trajectory(step, velocity_target);
+               // Generate kick swing foot trajectory
+               generate_kick_swing_foot_trajectory(step, velocity_target);
         }
 
         /**


### PR DESCRIPTION
Building upon https://github.com/NUbots/NUbots/pull/1619 this PR adds a new state to the walk engine for generating an in-step kick. This is very similar to before, but rather than just increasing the walk velocity (which just increases the step length essentially), this adds extra tuning parameters for adjusting the trajectory of the step kick.