### PR TITLE
Update the NUClearNet module to use NUClear's .address() rather than doing it itself

### DIFF
--- a/module/network/NUClearNet/CMakeLists.txt
+++ b/module/network/NUClearNet/CMakeLists.txt
@@ -1,29 +1,17 @@
-#[[
-MIT License
-
-Copyright (c) 2014 NUbots
-
-This file is part of the NUbots codebase.
-See https://github.com/NUbots/NUbots for further info.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-]]
+# Copyright (C) 2013-2016 Trent Houliston <trent@houliston.me>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Build our NUClear module
 nuclear_module()

--- a/module/network/NUClearNet/README.md
+++ b/module/network/NUClearNet/README.md
@@ -1,32 +1,54 @@
 # NUClearNet
 
 This module is responsible for connecting the system to the NUClear Network.
-In the configuration you must set a name, broadcast address and port.
-By setting these three the network will connect and be able to communicate with other NUClearNet systems that are on the same network.
+It establishes network connectivity between different NUClearNet systems that are on the same network.
 
-## Name
+The module requires proper network connectivity to function.
+Depending on the chosen networking mode, the following must be available:
+
+- For unicast mode: Direct connectivity to the target system
+- For broadcast mode: Network broadcast capabilities
+- For multicast mode: Multicast routing support on the network
+
+### Name
 
 If the name is left as an empty string in the configuration, the system will use the current host name as the name of the NUClearNet node.
 
-## Address
+### Address
 
-The NUClearNet system can take an IP address or a dns name as the address. The address is able to resolve to either IPv4 or IPv6 address.
+The NUClearNet system can take an IP address or a dns name as the address.
+The address is able to resolve to either IPv4 or IPv6 address.
 There are three main ways you can configure the network and use it.
 
-### Unicast Mode
+#### Unicast Mode
 
-In Unicast mode, you connect from this device to another device on a specific other system. This address may also be `127.0.0.1` if you wish to only connect to other NUClearNet binaries on the same system.
+In Unicast mode, you connect from this device to another device on a specific other system.
+This address may also be `127.0.0.1` if you wish to only connect to other NUClearNet binaries on the same system.
 In Unicast mode, you set the IP address here to the IP address of the other system you wish to connect to and on that system set the IP address of this system.
 This form of networking is useful when you are debugging and wish to make a small isolated NUClearNet system.
 
-### Broadcast Mode
+#### Broadcast Mode
 
-In broadcast mode, you set the address to the broadcast IP of your network (e.g. `192.168.1.255` for the network `192.168.1.0/24`). In this mode you will connect to all other systems that are running on that same network. In general you should prefer multicast mode over this mode so that you only send packets to systems that are specifically part of the NUClearNet node rather than sending to all computers on the network and using up the bandwidth.
+In broadcast mode, you set the address to the broadcast IP of your network (e.g. `192.168.1.255` for the network `192.168.1.0/24`).
+In this mode you will connect to all other systems that are running on that same network.
+In general you should prefer multicast mode over this mode so that you only send packets to systems that are specifically part of the NUClearNet node rather than sending to all computers on the network and using up the bandwidth.
 
-### Multicast Mode
+#### Multicast Mode
 
-In multicast mode you set either an IPv4 or IPv6 multicast address. Then provided your network correctly routes multicast packets it will connect to all other NUClearNet nodes that share the same multicast address. The default address for this is `239.226.152.162`
+In multicast mode you set either an IPv4 or IPv6 multicast address.
+Then provided your network correctly routes multicast packets it will connect to all other NUClearNet nodes that share the same multicast address.
+The default address for this is `239.226.152.162`
 
-## Port
+### Port
 
-The default port for NUClearNet is 7447. You can use different ports if you want to make several distinct NUClearNet networks on the same device.
+The default port for NUClearNet is 7447.
+You can use different ports if you want to make several distinct NUClearNet networks on the same device.
+
+## Consumes
+
+- `NUClear::message::NetworkJoin` Notification when another NUClearNet node joins the network
+- `NUClear::message::NetworkLeave` Notification when another NUClearNet node leaves the network
+
+## Emits
+
+- `NUClear::message::NetworkConfiguration` Emitted to configure the NUClear networking system with name, address, and port

--- a/module/network/NUClearNet/data/config/NUClearNet.yaml
+++ b/module/network/NUClearNet/data/config/NUClearNet.yaml
@@ -1,5 +1,3 @@
-log_level: INFO
-
 name: ""
-address: 239.226.152.162
+address: 192.168.189.255
 port: 7447

--- a/module/network/NUClearNet/src/NUClearNet.cpp
+++ b/module/network/NUClearNet/src/NUClearNet.cpp
@@ -1,105 +1,47 @@
 /*
- * MIT License
+ * Copyright (C) 2013-2016 Trent Houliston <trent@houliston.me>
  *
- * Copyright (c) 2013 NUbots
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
- * This file is part of the NUbots codebase.
- * See https://github.com/NUbots/NUbots for further info.
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #include "NUClearNet.hpp"
 
 #include "extension/Configuration.hpp"
 
-#include "utility/support/network.hpp"
-
 namespace module::network {
 
     using extension::Configuration;
-    using NUClear::message::CommandLineArguments;
 
     NUClearNet::NUClearNet(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
 
-        on<Configuration, Trigger<CommandLineArguments>>("NUClearNet.yaml")
-            .then([this](const Configuration& config, const CommandLineArguments& args) {
-                log_level                   = config["log_level"].as<NUClear::LogLevel>();
-                auto netConfig              = std::make_unique<NUClear::message::NetworkConfiguration>();
-                auto name                   = config["name"].as<std::string>();
-                netConfig->name             = name.empty() ? utility::support::get_hostname() : name;
-                netConfig->announce_address = config["address"].as<std::string>();
-                netConfig->announce_port    = config["port"].as<uint16_t>();
-
-                // Check if --team_id is set in the command line arguments
-                // Use this to set the name, to uniquely identify the robot
-                if (std::find(args.begin(), args.end(), "--team_id") != args.end()) {
-                    // Get the index of the team_id
-                    auto it = std::find(args.begin(), args.end(), "--team_id");
-                    if (it + 1 != args.end()) {
-                        netConfig->name += "_" + *(it + 1);
-                    }
-                }
-
-                emit<Scope::INLINE>(netConfig);
-            });
+        on<Configuration>("NUClearNet.yaml").then([this](const Configuration& config) {
+            auto net_config              = std::make_unique<NUClear::message::NetworkConfiguration>();
+            net_config->name             = config["name"].as<std::string>();
+            net_config->announce_address = config["address"].as<std::string>();
+            net_config->announce_port    = config["port"].as<uint16_t>();
+            emit<Scope::INLINE>(net_config);
+        });
 
         on<Trigger<NUClear::message::NetworkJoin>>().then([this](const NUClear::message::NetworkJoin& event) {
-            char c[255];
-            std::memset(c, 0, sizeof(c));
-            std::string addr;
-            int port = 0;
-
-            switch (event.address.sock.sa_family) {
-                case AF_INET:
-                    addr = inet_ntop(event.address.sock.sa_family, &event.address.ipv4.sin_addr, c, sizeof(c));
-                    port = ntohs(event.address.ipv4.sin_port);
-                    break;
-
-                case AF_INET6:
-                    addr = inet_ntop(event.address.sock.sa_family, &event.address.ipv6.sin6_addr, c, sizeof(c));
-                    port = ntohs(event.address.ipv6.sin6_port);
-                    break;
-            }
-
+            auto [addr, port] = event.address.address();
             log<INFO>("Connected to", event.name, "on", addr + ":" + std::to_string(port));
         });
 
         on<Trigger<NUClear::message::NetworkLeave>>().then([this](const NUClear::message::NetworkLeave& event) {
-            char c[255];
-            std::memset(c, 0, sizeof(c));
-            std::string addr;
-            int port = 0;
-
-            switch (event.address.sock.sa_family) {
-                case AF_INET:
-                    addr = inet_ntop(event.address.sock.sa_family, &event.address.ipv4.sin_addr, c, sizeof(c));
-                    port = ntohs(event.address.ipv4.sin_port);
-                    break;
-
-                case AF_INET6:
-                    addr = inet_ntop(event.address.sock.sa_family, &event.address.ipv6.sin6_addr, c, sizeof(c));
-                    port = ntohs(event.address.ipv6.sin6_port);
-                    break;
-            }
-
+            auto [addr, port] = event.address.address();
             log<INFO>("Disconnected from", event.name, "on", addr + ":" + std::to_string(port));
         });
     }
+
 }  // namespace module::network

--- a/module/network/NUClearNet/src/NUClearNet.hpp
+++ b/module/network/NUClearNet/src/NUClearNet.hpp
@@ -1,28 +1,18 @@
 /*
- * MIT License
+ * Copyright (C) 2013-2016 Trent Houliston <trent@houliston.me>
  *
- * Copyright (c) 2014 NUbots
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
- * This file is part of the NUbots codebase.
- * See https://github.com/NUbots/NUbots for further info.
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #ifndef MODULE_NETWORK_NUCLEARNET_HPP
@@ -33,10 +23,12 @@
 namespace module::network {
 
     class NUClearNet : public NUClear::Reactor {
+
     public:
         /// @brief Called by the powerplant to build and setup the NUClearNet reactor.
         explicit NUClearNet(std::unique_ptr<NUClear::Environment> environment);
     };
+
 }  // namespace module::network
 
 #endif  // MODULE_NETWORK_NUCLEARNET_HPP


### PR DESCRIPTION
Sync from 4AI

Updates the NUClearNet module to use the .address() that will mean it prints properly regardless of the underlying network type.
Also it's simpler.