### PR TITLE
Simplify the State message to reduce frequency and add a link to parent

### DIFF
--- a/module/extension/Director/src/director/emit_state.cpp
+++ b/module/extension/Director/src/director/emit_state.cpp
@@ -49,41 +49,20 @@ namespace module::extension {
 
             auto& proto_group = director_state.groups.at(group_id.hash_code());
 
-            update(proto_group.done, group.done);
             update(proto_group.active_provider, group.active_provider ? group.active_provider->id : 0);
-
-            std::vector<uint64_t> watcher_ids;
-            watcher_ids.reserve(group.watchers.size());
-            for (const auto& watcher : group.watchers) {
-                watcher_ids.push_back(watcher->requester_id);
-            }
-            update(proto_group.watchers, watcher_ids);
+            update(proto_group.parent_provider, group.active_task ? group.active_task->requester_id : 0);
 
             // Rebuild subtasks for this group
             std::vector<uint64_t> subtask_ids;
             subtask_ids.reserve(group.subtasks.size());
             for (const auto& subtask : group.subtasks) {
-                subtask_ids.push_back(subtask->requester_task_id);
+                subtask_ids.emplace_back(subtask->name,
+                                         subtask->type.hash_code(),
+                                         subtask->priority,
+                                         subtask->optional);
             }
             update(proto_group.subtasks, subtask_ids);
         }
-
-        // We rebuild all the tasks each time from all subtasks
-        std::map<uint64_t, DirectorState::DirectorTask> new_tasks;
-        for (const auto& group_entry : groups) {
-            for (const auto& subtask : group_entry.second.subtasks) {
-                if (subtask) {
-                    auto& proto_task                 = new_tasks[subtask->requester_task_id];
-                    proto_task.name                  = subtask->name;
-                    proto_task.target_group          = subtask->type.hash_code();
-                    proto_task.requester_provider_id = subtask->requester_id;
-                    proto_task.priority              = subtask->priority;
-                    proto_task.optional              = subtask->optional;
-                }
-            }
-        }
-
-        update(director_state.tasks, new_tasks);
 
         // If we updated the state, emit it
         if (state_changed) {

--- a/module/extension/Director/src/director/emit_state.cpp
+++ b/module/extension/Director/src/director/emit_state.cpp
@@ -53,15 +53,12 @@ namespace module::extension {
             update(proto_group.parent_provider, group.active_task ? group.active_task->requester_id : 0);
 
             // Rebuild subtasks for this group
-            std::vector<uint64_t> subtask_ids;
-            subtask_ids.reserve(group.subtasks.size());
+            std::vector<DirectorState::DirectorTask> subtasks;
+            subtasks.reserve(group.subtasks.size());
             for (const auto& subtask : group.subtasks) {
-                subtask_ids.emplace_back(subtask->name,
-                                         subtask->type.hash_code(),
-                                         subtask->priority,
-                                         subtask->optional);
+                subtasks.emplace_back(subtask->name, subtask->type.hash_code(), subtask->priority, subtask->optional);
             }
-            update(proto_group.subtasks, subtask_ids);
+            update(proto_group.subtasks, subtasks);
         }
 
         // If we updated the state, emit it

--- a/shared/message/behaviour/Director.proto
+++ b/shared/message/behaviour/Director.proto
@@ -40,12 +40,10 @@ message DirectorState {
         string name = 1;
         /// The id of the group that this task wants to run on
         uint64 target_group = 2;
-        /// The id of the provider that is requesting this task
-        uint64 requester_provider_id = 3;
         /// The priority of this task
-        int32 priority = 4;
+        int32 priority = 3;
         /// If this task is optional
-        bool optional = 5;
+        bool optional = 4;
     };
 
     message Provider {
@@ -87,20 +85,16 @@ message DirectorState {
         string type = 1;
         /// The ids of the providers that are part of this group
         repeated uint64 provider_ids = 2;
-        /// If the groups last run emitted a done task
-        bool done = 3;
         /// The id of the provider that is currently active or 0 if no provider is active
-        uint64 active_provider = 4;
-        /// Task ids that are watching this group
-        repeated uint64 watchers = 5;
-        /// The ids of the tasks that are currently running
-        repeated uint64 subtasks = 6;
+        uint64 active_provider = 3;
+        /// The id of the provider that is currently controlling this group
+        uint64 parent_provider = 4;
+        /// The ids of the tasks that this group wants to run/is running
+        repeated DirectorTask subtasks = 5;
     }
 
     /// Groups of providers
     map<uint64, Group> groups = 1;
     /// Providers in the system
     map<uint64, Provider> providers = 2;
-    /// Tasks that are currently running
-    map<uint64, DirectorTask> tasks = 3;
 }


### PR DESCRIPTION
Change what data is sent to
- Reduce the frequency of emits (watchers and done changed very frequently)
- Fix up the parentage links.
  As the tasks ids aren't put in as they change too much they were originally omitted. Now the parent provider which made the task is put into each group so you can link them back.