### PR TITLE
Fix the FieldPlayer module to search when needed

### DIFF
--- a/module/purpose/FieldPlayer/src/FieldPlayer.cpp
+++ b/module/purpose/FieldPlayer/src/FieldPlayer.cpp
@@ -65,6 +65,7 @@ namespace module::purpose {
     using message::purpose::ReadyAttack;
     using message::purpose::SoccerPosition;
     using message::purpose::Support;
+    using message::strategy::FindBall;
     using message::strategy::LookAtBall;
     using message::strategy::Search;
     using message::strategy::WalkToFieldPosition;
@@ -90,16 +91,16 @@ namespace module::purpose {
         on<Provide<FieldPlayerMsg>,
            Optional<With<Ball>>,
            Optional<With<Robots>>,
+           Optional<With<Field>>,
            With<Sensors>,
-           With<Field>,
            With<GameState>,
            With<GlobalConfig>,
            With<FieldDescription>,
            When<Phase, std::equal_to, Phase::PLAYING>>()
             .then([this](const std::shared_ptr<const Ball>& ball,
                          const std::shared_ptr<const Robots>& robots,
+                         const std::shared_ptr<const Field>& field,
                          const Sensors& sensors,
-                         const Field& field,
                          const GameState& game_state,
                          const GlobalConfig& global_config,
                          const FieldDescription& fd) {
@@ -117,8 +118,15 @@ namespace module::purpose {
                     return;
                 }
 
+                // If there's no field, search because it's hard to do anything without localisation
+                if (!field) {
+                    log<DEBUG>("No field, searching for landmarks to localise.");
+                    emit<Task>(std::make_unique<Search>());
+                    return;
+                }
+
                 // If the robot is uncertain about its position, it should not play
-                if (cfg.search_when_lost && field.cost > cfg.max_localisation_cost) {
+                if (cfg.search_when_lost && field->cost > cfg.max_localisation_cost) {
                     log<DEBUG>("Field cost is too high, not playing.");
                     emit(std::make_unique<Purpose>(global_config.player_id,
                                                    SoccerPosition::UNKNOWN,
@@ -136,6 +144,7 @@ namespace module::purpose {
 
                 // If there's no ball message, we can't play, just look for the ball
                 if (ball == nullptr) {
+                    emit<Task>(std::make_unique<FindBall>(), 2);
                     return;
                 }
 
@@ -154,7 +163,7 @@ namespace module::purpose {
                 // If there are no robots, use an empty vector
                 Who ball_pos = utility::strategy::ball_possession(ball->rBWw,
                                                                   (robots ? *robots : Robots{}),
-                                                                  field.Hfw,
+                                                                  field->Hfw,
                                                                   sensors.Hrw,
                                                                   cfg.ball_threshold,
                                                                   cfg.equidistant_threshold,
@@ -164,7 +173,7 @@ namespace module::purpose {
                 // If we have robots, determine if we are closest to the ball
                 // Otherwise assume we are alone and closest by default
                 // Only consider the goalie if the ball is in the defending third
-                Eigen::Vector3d rBFf     = field.Hfw * ball->rBWw;
+                Eigen::Vector3d rBFf     = field->Hfw * ball->rBWw;
                 double defending_third_x = fd.dimensions.field_length / 3.0;
                 if (robots && rBFf.x() < defending_third_x) {
                     for (const auto& robot : robots->robots) {
@@ -177,7 +186,7 @@ namespace module::purpose {
                 const unsigned int closest_to_ball =
                     robots ? utility::strategy::closest_to_ball_on_team(ball->rBWw,
                                                                         *robots,
-                                                                        field.Hfw,
+                                                                        field->Hfw,
                                                                         sensors.Hrw,
                                                                         cfg.equidistant_threshold,
                                                                         global_config.player_id,
@@ -187,7 +196,7 @@ namespace module::purpose {
 
                 // Determine if we need to wait for the other team to kick off
                 // If the ball moves, it is in play
-                bool ball_moved   = (field.Hfw * ball->rBWw).norm() > cfg.ball_off_center_threshold;
+                bool ball_moved   = (field->Hfw * ball->rBWw).norm() > cfg.ball_off_center_threshold;
                 bool kickoff_wait = !ball_moved && !game_state.our_kick_off
                                     && (game_state.secondary_time - NUClear::clock::now()).count() > 0;
                 // At this point, if a penalty state is in progress, it must be in sub_mode 1,
@@ -235,7 +244,7 @@ namespace module::purpose {
                     }
                 }
                 bool furthest_back = robots ? utility::strategy::furthest_back(*robots,
-                                                                               field.Hfw,
+                                                                               field->Hfw,
                                                                                sensors.Hrw,
                                                                                cfg.equidistant_threshold,
                                                                                global_config.player_id,

--- a/module/purpose/FieldPlayer/src/FieldPlayer.cpp
+++ b/module/purpose/FieldPlayer/src/FieldPlayer.cpp
@@ -67,7 +67,6 @@ namespace module::purpose {
     using message::purpose::Support;
     using message::strategy::FindBall;
     using message::strategy::LookAtBall;
-    using message::strategy::Search;
     using message::strategy::WalkToFieldPosition;
     using message::strategy::Who;
     using message::support::FieldDescription;
@@ -118,10 +117,10 @@ namespace module::purpose {
                     return;
                 }
 
-                // If there's no field, search because it's hard to do anything without localisation
-                if (!field) {
-                    log<DEBUG>("No field, searching for landmarks to localise.");
-                    emit<Task>(std::make_unique<Search>());
+                // Search if no ball or field
+                if (!field || !ball) {
+                    log<DEBUG>("No field or ball, searching for landmarks to localise.");
+                    emit<Task>(std::make_unique<FindBall>());
                     return;
                 }
 
@@ -135,18 +134,12 @@ namespace module::purpose {
                                                    game_state.team.team_colour));
 
                     // Search for landmarks to localise
-                    emit<Task>(std::make_unique<Search>());
+                    emit<Task>(std::make_unique<FindBall>());
                     return;
                 }
 
                 // Always look at the ball if possible
-                emit<Task>(std::make_unique<LookAtBall>(), 1);  // Track the ball
-
-                // If there's no ball message, we can't play, just look for the ball
-                if (ball == nullptr) {
-                    emit<Task>(std::make_unique<FindBall>(), 2);
-                    return;
-                }
+                emit<Task>(std::make_unique<LookAtBall>(), 1);
 
                 // Make an ignore list with inactive teammates
                 std::vector<unsigned int> ignore_ids{};


### PR DESCRIPTION
My bad. Moving the search into Attack and Support (and not Defend) removed the ability to search when there's no ball. We also only ran the FieldPlayer when a Field message exists, but if we never see the field then this will never run. Changed Field to optional and search when nullptr.