### PR TITLE
Fix vector positions for lead robot during kick off

### DIFF
--- a/module/purpose/ReadyAttack/data/config/ReadyAttack.yaml
+++ b/module/purpose/ReadyAttack/data/config/ReadyAttack.yaml
@@ -2,7 +2,7 @@
 log_level: INFO
 
 # The offset to ensure the robot is definitely outside of the center circle
-center_circle_offset: 0.4
+center_circle_offset: 0.5
 
 # The distance away from the ball when it's the opponent's penalty (0.75 per rules, use 1m to ensure compliance)
 penalty_defend_distance: 1.0

--- a/module/purpose/ReadyAttack/src/ReadyAttack.cpp
+++ b/module/purpose/ReadyAttack/src/ReadyAttack.cpp
@@ -73,7 +73,7 @@ namespace module::purpose {
                     // Waiting for kick off, position outside the center circle
                     log<DEBUG>("Waiting for kick off...");
                     Eigen::Vector3d rPFf =
-                        Eigen::Vector3d(0, 0, fd.dimensions.center_circle_diameter / 2 + cfg.center_circle_offset);
+                        Eigen::Vector3d(fd.dimensions.center_circle_diameter / 2 + cfg.center_circle_offset, 0.0, 0.0);
                     emit<Task>(std::make_unique<WalkToFieldPosition>(
                         utility::math::euler::pos_rpy_to_transform(rPFf, Eigen::Vector3d(0, 0, -M_PI)),
                         true));

--- a/shared/utility/strategy/positioning.hpp
+++ b/shared/utility/strategy/positioning.hpp
@@ -113,7 +113,7 @@ namespace utility::strategy {
         double c_rad = field_desc.dimensions.center_circle_diameter / 2.0;
         if (is_kickoff_robot) {
             Eigen::Vector3d p = kick_off ? Eigen::Vector3d(c_rad / 2 + center_offset, 0.0, 0.0)
-                                         : Eigen::Vector3d(c_rad + center_offset, 0.0, M_PI);
+                                         : Eigen::Vector3d(c_rad + center_offset, 0.0, 0.0);
             return utility::math::euler::pos_rpy_to_transform(p, Eigen::Vector3d(0, 0, -M_PI));
         }
 


### PR DESCRIPTION
Previously would have made the robot walk to the center in the opponent's kick off, penalising us.