### PR TITLE
Add role and debug log for testing R2R communication

### DIFF
--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -139,6 +139,8 @@ namespace module::network {
 
                                 // Filter out messages from ourselves and from other teams
                                 if (!own_player_message && own_team_message) {
+                                    log<DEBUG>("Message received from teammate ID",
+                                               incoming_msg.current_pose.player_id);
                                     emit(std::make_unique<RoboCup>(std::move(incoming_msg)));
                                 }
                             });

--- a/roles/test/robotcommunication.role
+++ b/roles/test/robotcommunication.role
@@ -1,0 +1,17 @@
+# A test role to check if robot communication between robots is working. Set RobotCommunication's log level to `DEBUG`
+# to see a log each time a teammate sends a message, with the teammate's ID.
+nuclear_role(
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig # Field description
+  support::configuration::GlobalConfig
+  # Network input
+  input::GameController
+  network::RobotCommunication
+  # Platform
+  platform::${SUBCONTROLLER}::HardwareIO
+)


### PR DESCRIPTION
This was useful during RoboCup to make sure things were working. 