### PR TITLE
Penalty behaviour (kick taker and goalie)

### DIFF
--- a/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
@@ -193,10 +193,10 @@ namespace module::localisation {
 
         on<Trigger<PenaltyReset>>().then([this](const PenaltyReset& reset) {
             log<INFO>("Resetting field localisation for penalty kick");
-            state              = reset.penalty_kick_position;
-            filtered_state     = state;
-            first_measurement  = true;
-            last_certain_state = state;  // Update the last certain state
+            state = reset.penalty_kick_position;
+            kf.set_state(state);
+            last_reset         = NUClear::clock::now();
+            last_certain_state = state;
         });
 
         on<Trigger<FieldLines>,

--- a/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
@@ -45,6 +45,7 @@ namespace module::localisation {
     using message::localisation::Field;
     using message::localisation::FinishReset;
     using message::localisation::Line;
+    using message::localisation::PenaltyReset;
     using message::localisation::ResetFieldLocalisation;
     using message::localisation::RobotPoseGroundTruth;
     using message::localisation::UncertaintyResetFieldLocalisation;
@@ -188,6 +189,14 @@ namespace module::localisation {
             kf.set_state(state);
             startup    = true;
             last_reset = NUClear::clock::now();
+        });
+
+        on<Trigger<PenaltyReset>>().then([this](const PenaltyReset& reset) {
+            log<INFO>("Resetting field localisation for penalty kick");
+            state              = reset.penalty_kick_position;
+            filtered_state     = state;
+            first_measurement  = true;
+            last_certain_state = state;  // Update the last certain state
         });
 
         on<Trigger<FieldLines>,

--- a/module/purpose/PenaltyShootout/CMakeLists.txt
+++ b/module/purpose/PenaltyShootout/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Build our NUClear module
+nuclear_module()

--- a/module/purpose/PenaltyShootout/README.md
+++ b/module/purpose/PenaltyShootout/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This module handles penalty shootout scenarios in robot soccer. It manages the robot's behavior during penalty kicks, with different actions depending on whether the robot is taking the penalty shot or acting as a goalkeeper.
+This module handles penalty shootout scenarios in robot soccer. It manages the robot's behaviour during penalty kicks, with different actions depending on whether the robot is taking the penalty shot or acting as a goalkeeper.
 
 When it's the robot's kick off (taking the penalty), the robot will search for the ball, walk to it, and attempt to kick it into the goal. When it's the opponent's kick off (acting as goalkeeper), the robot remains stationary on the goal line and tracks the ball with its head, as per RoboCup rules that prevent goalkeepers from moving off the line during penalty kicks.
 

--- a/module/purpose/PenaltyShootout/README.md
+++ b/module/purpose/PenaltyShootout/README.md
@@ -1,0 +1,11 @@
+# PenaltyShootout
+
+## Description
+
+## Usage
+
+## Consumes
+
+## Emits
+
+## Dependencies

--- a/module/purpose/PenaltyShootout/README.md
+++ b/module/purpose/PenaltyShootout/README.md
@@ -2,10 +2,31 @@
 
 ## Description
 
+This module handles penalty shootout scenarios in robot soccer. It manages the robot's behavior during penalty kicks, with different actions depending on whether the robot is taking the penalty shot or acting as a goalkeeper.
+
+When it's the robot's kick off (taking the penalty), the robot will search for the ball, walk to it, and attempt to kick it into the goal. When it's the opponent's kick off (acting as goalkeeper), the robot remains stationary on the goal line and tracks the ball with its head, as per RoboCup rules that prevent goalkeepers from moving off the line during penalty kicks.
+
 ## Usage
+
+Include this module in a role and execute during penalty shootout game phases. The module automatically activates when the game state indicates a penalty shootout scenario. Press the middle button after robot placement for penalty taker or goalie to reset localisation.
 
 ## Consumes
 
+- `message::input::GameState` to determine if it's our kick off or the opponent's
+- `message::input::GameState::Phase` to specifically check for the playing phase during penalty shootouts
+- `message::localisation::Ball` for ball detection and tracking during penalty execution
+- `message::input::ButtonMiddleDown` and `message::input::ButtonMiddleUp` for localisation reset
+- `message::support::FieldDescription` to calculate penalty mark and goal positions for localisation
+
 ## Emits
 
-## Dependencies
+- `message::behaviour::state::Stability` initial stability state on startup
+- `message::behaviour::state::WalkState` initial walk state on startup
+- `message::skill::Walk` for basic walking and standing
+- `message::skill::Look` for looking forward when idle and tracking the ball
+- `message::planning::LookAround` when the ball cannot be found within the timeout period
+- `message::strategy::WalkToKickBall` when it's our kick off, to approach and kick the ball
+- `message::strategy::LookAtBall` to track the ball with the head
+- `message::strategy::FallRecovery` to handle falls
+- `message::localisation::PenaltyReset` for resetting robot position when middle button is pressed
+- `message::output::Buzzer` for audio feedback when middle button is released

--- a/module/purpose/PenaltyShootout/data/config/PenaltyShootout.yaml
+++ b/module/purpose/PenaltyShootout/data/config/PenaltyShootout.yaml
@@ -1,0 +1,11 @@
+# Controls the minimum log level that NUClear log will display
+log_level: INFO
+
+# Distance from the ball at which the goalie will act
+ball_action_distance: 1.0
+
+# Delay before the penalty shootout starts
+startup_delay: 2
+
+# Timeout for searching for the ball
+ball_search_timeout: 3

--- a/module/purpose/PenaltyShootout/data/config/PenaltyShootout.yaml
+++ b/module/purpose/PenaltyShootout/data/config/PenaltyShootout.yaml
@@ -1,9 +1,6 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-# Distance from the ball at which the goalie will act
-ball_action_distance: 1.0
-
 # Delay before the penalty shootout starts
 startup_delay: 2
 

--- a/module/purpose/PenaltyShootout/src/PenaltyShootout.cpp
+++ b/module/purpose/PenaltyShootout/src/PenaltyShootout.cpp
@@ -3,12 +3,10 @@
 #include "extension/Behaviour.hpp"
 #include "extension/Configuration.hpp"
 
-#include "message/actuation/Limbs.hpp"
 #include "message/behaviour/state/Stability.hpp"
 #include "message/behaviour/state/WalkState.hpp"
 #include "message/input/Buttons.hpp"
 #include "message/input/GameState.hpp"
-#include "message/input/Sensors.hpp"
 #include "message/localisation/Ball.hpp"
 #include "message/localisation/Field.hpp"
 #include "message/output/Buzzer.hpp"
@@ -16,27 +14,21 @@
 #include "message/skill/Look.hpp"
 #include "message/skill/Walk.hpp"
 #include "message/strategy/FallRecovery.hpp"
-#include "message/strategy/FindBall.hpp"
 #include "message/strategy/LookAtFeature.hpp"
 #include "message/strategy/WalkToBall.hpp"
 #include "message/support/FieldDescription.hpp"
 
-#include "utility/skill/Script.hpp"
-
 namespace module::purpose {
 
     using extension::Configuration;
-    using utility::skill::load_script;
 
     using Phase = message::input::GameState::Phase;
 
-    using message::actuation::BodySequence;
     using message::behaviour::state::Stability;
     using message::behaviour::state::WalkState;
     using message::input::ButtonMiddleDown;
     using message::input::ButtonMiddleUp;
     using message::input::GameState;
-    using message::input::Sensors;
     using message::localisation::Ball;
     using message::localisation::PenaltyReset;
     using message::output::Buzzer;
@@ -44,7 +36,6 @@ namespace module::purpose {
     using message::skill::Look;
     using message::skill::Walk;
     using message::strategy::FallRecovery;
-    using message::strategy::FindBall;
     using message::strategy::LookAtBall;
     using message::strategy::WalkToKickBall;
     using message::support::FieldDescription;
@@ -57,10 +48,9 @@ namespace module::purpose {
 
         on<Configuration>("PenaltyShootout.yaml").then([this](const Configuration& config) {
             // Use configuration here from file PenaltyShootout.yaml
-            this->log_level          = config["log_level"].as<NUClear::LogLevel>();
-            cfg.ball_action_distance = config["ball_action_distance"].as<double>();
-            cfg.startup_delay        = config["startup_delay"].as<int>();
-            cfg.ball_search_timeout  = duration_cast<NUClear::clock::duration>(
+            this->log_level         = config["log_level"].as<NUClear::LogLevel>();
+            cfg.startup_delay       = config["startup_delay"].as<int>();
+            cfg.ball_search_timeout = duration_cast<NUClear::clock::duration>(
                 std::chrono::duration<double>(config["ball_search_timeout"].as<double>()));
         });
 

--- a/module/purpose/PenaltyShootout/src/PenaltyShootout.cpp
+++ b/module/purpose/PenaltyShootout/src/PenaltyShootout.cpp
@@ -1,0 +1,122 @@
+#include "PenaltyShootout.hpp"
+
+#include "extension/Behaviour.hpp"
+#include "extension/Configuration.hpp"
+
+#include "message/actuation/Limbs.hpp"
+#include "message/behaviour/state/Stability.hpp"
+#include "message/behaviour/state/WalkState.hpp"
+#include "message/input/Buttons.hpp"
+#include "message/input/GameState.hpp"
+#include "message/input/Sensors.hpp"
+#include "message/localisation/Ball.hpp"
+#include "message/localisation/Field.hpp"
+#include "message/output/Buzzer.hpp"
+#include "message/planning/LookAround.hpp"
+#include "message/skill/Look.hpp"
+#include "message/skill/Walk.hpp"
+#include "message/strategy/FallRecovery.hpp"
+#include "message/strategy/FindBall.hpp"
+#include "message/strategy/LookAtFeature.hpp"
+#include "message/strategy/WalkToBall.hpp"
+#include "message/support/FieldDescription.hpp"
+
+#include "utility/skill/Script.hpp"
+
+namespace module::purpose {
+
+    using extension::Configuration;
+    using utility::skill::load_script;
+
+    using Phase = message::input::GameState::Phase;
+
+    using message::actuation::BodySequence;
+    using message::behaviour::state::Stability;
+    using message::behaviour::state::WalkState;
+    using message::input::ButtonMiddleDown;
+    using message::input::ButtonMiddleUp;
+    using message::input::GameState;
+    using message::input::Sensors;
+    using message::localisation::Ball;
+    using message::localisation::PenaltyReset;
+    using message::output::Buzzer;
+    using message::planning::LookAround;
+    using message::skill::Look;
+    using message::skill::Walk;
+    using message::strategy::FallRecovery;
+    using message::strategy::FindBall;
+    using message::strategy::LookAtBall;
+    using message::strategy::WalkToKickBall;
+    using message::support::FieldDescription;
+
+    struct StartPenalty {};
+    struct Play {};
+
+    PenaltyShootout::PenaltyShootout(std::unique_ptr<NUClear::Environment> environment)
+        : BehaviourReactor(std::move(environment)) {
+
+        on<Configuration>("PenaltyShootout.yaml").then([this](const Configuration& config) {
+            // Use configuration here from file PenaltyShootout.yaml
+            this->log_level          = config["log_level"].as<NUClear::LogLevel>();
+            cfg.ball_action_distance = config["ball_action_distance"].as<double>();
+            cfg.startup_delay        = config["startup_delay"].as<int>();
+            cfg.ball_search_timeout  = duration_cast<NUClear::clock::duration>(
+                std::chrono::duration<double>(config["ball_search_timeout"].as<double>()));
+        });
+
+        on<Startup>().then([this] {
+            // At the start of the program, we should be standing
+            // Without these emits, modules that need a Stability and WalkState messages may not run
+            emit(std::make_unique<Stability>(Stability::UNKNOWN));
+            emit(std::make_unique<WalkState>(WalkState::State::STOPPED));
+            // Stand idle
+            emit<Task>(std::make_unique<Walk>(Eigen::Vector3d::Zero()), 0);
+            // Idle look forward if the head isn't doing anything else
+            emit<Task>(std::make_unique<Look>(Eigen::Vector3d::UnitX(), true), 0);
+            // Startup delay to prevent issues with low servo gains at the start
+            emit<Scope::DELAY>(std::make_unique<StartPenalty>(), std::chrono::seconds(cfg.startup_delay));
+        });
+
+        on<Trigger<StartPenalty>>().then([this] {
+            // This emit starts the tree to play the penalty shootout
+            emit<Task>(std::make_unique<Play>(), 1);
+            // The robot should always try to recover from falling, if applicable, regardless of purpose
+            emit<Task>(std::make_unique<FallRecovery>(), 2);
+        });
+
+        on<Provide<Play>,
+           Every<BEHAVIOUR_UPDATE_RATE, Per<std::chrono::seconds>>,
+           With<GameState>,
+           Optional<With<Ball>>,
+           When<Phase, std::equal_to, Phase::PLAYING>>()
+            .then([this](const GameState& game_state, const std::shared_ptr<const Ball>& ball) {
+                // Find the ball first
+                if (ball == nullptr || (NUClear::clock::now() - ball->time_of_measurement) > cfg.ball_search_timeout) {
+                    emit<Task>(std::make_unique<LookAround>());
+                }
+
+                // If our kick off, walk the ball into the goal!
+                if (game_state.our_kick_off) {
+                    emit<Task>(std::make_unique<WalkToKickBall>());
+                    emit<Task>(std::make_unique<LookAtBall>());
+                }
+                // Else do nothing cause the goalie can't move off the line and we don't want to dive and break!
+                else {
+                    emit<Task>(std::make_unique<LookAtBall>(), 1);  // Track the ball
+                }
+            });
+
+        // Middle button resumes the soccer scenario
+        on<Trigger<ButtonMiddleDown>, With<FieldDescription>, With<GameState>>().then(
+            [this](const FieldDescription& fd, const GameState& game_state) {
+                Eigen::Vector3d rRFf =
+                    game_state.our_kick_off
+                        ? Eigen::Vector3d(-fd.dimensions.field_length / 2 + fd.dimensions.penalty_mark_distance, 0, 0)
+                        : Eigen::Vector3d(fd.dimensions.field_length / 2, 0, 0);
+                emit(std::make_unique<PenaltyReset>(rRFf));
+            });
+
+        on<Trigger<ButtonMiddleUp>>().then([this] { emit<Scope::INLINE>(std::make_unique<Buzzer>(0)); });
+    }
+
+}  // namespace module::purpose

--- a/module/purpose/PenaltyShootout/src/PenaltyShootout.hpp
+++ b/module/purpose/PenaltyShootout/src/PenaltyShootout.hpp
@@ -11,12 +11,10 @@ namespace module::purpose {
     private:
         /// @brief Stores configuration values
         struct Config {
-            /// @brief Distance from the ball at which to perform actions
-            double ball_action_distance = 0.5;
             /// @brief Delay before playing
             int startup_delay = 0;
             /// @brief Timeout for searching for the ball
-            NUClear::clock::duration ball_search_timeout = std::chrono::seconds(5);
+            NUClear::clock::duration ball_search_timeout = std::chrono::seconds(0);
         } cfg;
 
         /// @brief A high-level update rate for the director tree

--- a/module/purpose/PenaltyShootout/src/PenaltyShootout.hpp
+++ b/module/purpose/PenaltyShootout/src/PenaltyShootout.hpp
@@ -1,0 +1,32 @@
+#ifndef MODULE_PURPOSE_PENALTYSHOOTOUT_HPP
+#define MODULE_PURPOSE_PENALTYSHOOTOUT_HPP
+
+#include <nuclear>
+
+#include "extension/Behaviour.hpp"
+
+namespace module::purpose {
+
+    class PenaltyShootout : public ::extension::behaviour::BehaviourReactor {
+    private:
+        /// @brief Stores configuration values
+        struct Config {
+            /// @brief Distance from the ball at which to perform actions
+            double ball_action_distance = 0.5;
+            /// @brief Delay before playing
+            int startup_delay = 0;
+            /// @brief Timeout for searching for the ball
+            NUClear::clock::duration ball_search_timeout = std::chrono::seconds(5);
+        } cfg;
+
+        /// @brief A high-level update rate for the director tree
+        static constexpr size_t BEHAVIOUR_UPDATE_RATE = 10;
+
+    public:
+        /// @brief Called by the powerplant to build and setup the PenaltyShootout reactor.
+        explicit PenaltyShootout(std::unique_ptr<NUClear::Environment> environment);
+    };
+
+}  // namespace module::purpose
+
+#endif  // MODULE_PURPOSE_PENALTYSHOOTOUT_HPP

--- a/roles/penaltyshootout.role
+++ b/roles/penaltyshootout.role
@@ -1,0 +1,49 @@
+# This role is used for running a penalty shootout soccer game.
+nuclear_role(
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig # Field description
+  support::configuration::GlobalConfig
+  # Sensors and network (input)
+  input::SensorFilter
+  input::Camera
+  input::GameController
+  # Vision
+  vision::VisualMesh
+  vision::GreenHorizonDetector
+  vision::FieldLineDetector
+  vision::Yolo
+  # Localisation
+  localisation::BallLocalisation
+  localisation::FieldLocalisationNLopt
+  # Director
+  extension::Director
+  # Servos
+  actuation::Kinematics
+  actuation::Servos
+  actuation::FootController
+  # Skills
+  skill::Walk
+  skill::GetUp
+  skill::Look
+  # Planners
+  planning::PlanWalkPath
+  planning::PlanLook
+  planning::GetUpPlanner
+  planning::FallingRelaxPlanner
+  # Strategies
+  strategy::FallRecovery
+  strategy::StandStill
+  strategy::WalkToFieldPosition
+  strategy::StrategiseLook
+  strategy::WalkToBall
+  strategy::FindObject
+  # Purposes
+  purpose::PenaltyShootout
+  # Platform
+  platform::${SUBCONTROLLER}::HardwareIO
+)

--- a/roles/webots/penaltyshootout.role
+++ b/roles/webots/penaltyshootout.role
@@ -1,0 +1,47 @@
+# This role is used for running a penalty shootout soccer game.
+nuclear_role(
+  # FileWatcher, ConsoleLogHandler and Signal Catcher Must Go First
+  extension::FileWatcher # Watches configuration files for changes
+  support::SignalCatcher # Allows for graceful shutdown
+  support::logging::ConsoleLogHandler # `log()` calls show in the console filtered for log level
+  # Configuration
+  actuation::KinematicsConfiguration # Must go early in the role as other modules depend on it
+  support::configuration::SoccerConfig # Field description
+  support::configuration::GlobalConfig
+  # Sensors and network (input)
+  platform::Webots
+  input::SensorFilter
+  input::GameController
+  # Vision
+  vision::VisualMesh
+  vision::GreenHorizonDetector
+  vision::FieldLineDetector
+  vision::Yolo
+  # Localisation
+  localisation::BallLocalisation
+  localisation::FieldLocalisationNLopt
+  # Director
+  extension::Director
+  # Servos
+  actuation::Kinematics
+  actuation::Servos
+  actuation::FootController
+  # Skills
+  skill::Walk
+  skill::GetUp
+  skill::Look
+  # Planners
+  planning::PlanWalkPath
+  planning::PlanLook
+  planning::GetUpPlanner
+  planning::FallingRelaxPlanner
+  # Strategies
+  strategy::FallRecovery
+  strategy::StandStill
+  strategy::WalkToFieldPosition
+  strategy::StrategiseLook
+  strategy::WalkToBall
+  strategy::FindObject
+  # Purposes
+  purpose::PenaltyShootout
+)

--- a/shared/message/localisation/Field.proto
+++ b/shared/message/localisation/Field.proto
@@ -61,3 +61,7 @@ message Field {
 message ResetFieldLocalisation {}
 message UncertaintyResetFieldLocalisation {}
 message FinishReset {}
+message PenaltyReset {
+    /// The penalty kick position in field space
+    vec3 penalty_kick_position = 1;
+}


### PR DESCRIPTION
The PR adds in a new module and roles to run penalty shootouts with GameController. 
When taking a penalty kick, the robot will dribble the ball into the goals. When defending, the robot will stand still, since rules require it to not step off the line. This should be further developed. 
In either state, the idea is to press the middle button to trigger localisation to reset, which uses the field description to figure out suitable position candidates. 