### PR TITLE
Merge onboarding task to main onboarding branch

### DIFF
--- a/module/onboarding/Ping/README.md
+++ b/module/onboarding/Ping/README.md
@@ -2,15 +2,10 @@
 
 ## Description
 
-
 ## Usage
-
 
 ## Consumes
 
-
 ## Emits
 
-
 ## Dependencies
-

--- a/module/onboarding/Ping/README.md
+++ b/module/onboarding/Ping/README.md
@@ -2,10 +2,20 @@
 
 ## Description
 
+This module is one half of a pair of modules that receive a message containing a counter, increment the counter, and send a response message with the new counter.
+
 ## Usage
+
+Include onboarding::Ping as well as onboarding::Pong in your role.
 
 ## Consumes
 
+- `message::onboarding::Pong` Pong message containing a counter
+
 ## Emits
 
+- `message::onboarding::Ping` Response to Pong module containing the received counter incremented by 1
+
 ## Dependencies
+
+Depends on complementary onboarding::Pong module.

--- a/module/onboarding/Ping/src/Ping.cpp
+++ b/module/onboarding/Ping/src/Ping.cpp
@@ -25,7 +25,7 @@ namespace module::onboarding {
 
         on<Trigger<Pong>>().then([this](const Pong& pong_msg) {
             auto ping_msg = std::make_unique<Ping>();
-            log<NUClear::INFO>("Ping");
+            log<INFO>("Ping");
             emit(ping_msg);
         });
     }

--- a/module/onboarding/Ping/src/Ping.cpp
+++ b/module/onboarding/Ping/src/Ping.cpp
@@ -24,7 +24,7 @@ namespace module::onboarding {
         });
 
         on<Trigger<Pong>>().then([this](const Pong& pong_msg) {
-            auto ping_msg = std::make_unique<Ping>();
+            auto ping_msg   = std::make_unique<Ping>();
             ping_msg->count = pong_msg.count + 1;
             log<INFO>("Ping");
             log<INFO>(ping_msg->count);

--- a/module/onboarding/Ping/src/Ping.cpp
+++ b/module/onboarding/Ping/src/Ping.cpp
@@ -26,8 +26,9 @@ namespace module::onboarding {
         on<Trigger<Pong>>().then([this](const Pong& pong_msg) {
             auto ping_msg   = std::make_unique<Ping>();
             ping_msg->count = pong_msg.count + 1;
-            log<INFO>("Ping");
-            log<INFO>(ping_msg->count);
+
+            log<INFO>("Ping:", ping_msg->count);
+
             emit(ping_msg);
         });
     }

--- a/module/onboarding/Ping/src/Ping.cpp
+++ b/module/onboarding/Ping/src/Ping.cpp
@@ -25,7 +25,9 @@ namespace module::onboarding {
 
         on<Trigger<Pong>>().then([this](const Pong& pong_msg) {
             auto ping_msg = std::make_unique<Ping>();
+            ping_msg->count = pong_msg.count + 1;
             log<INFO>("Ping");
+            log<INFO>(ping_msg->count);
             emit(ping_msg);
         });
     }

--- a/module/onboarding/Ping/src/Ping.hpp
+++ b/module/onboarding/Ping/src/Ping.hpp
@@ -5,16 +5,16 @@
 
 namespace module::onboarding {
 
-class Ping : public NUClear::Reactor {
-private:
-    /// @brief Stores configuration values
-    struct Config {
-    } cfg;
+    class Ping : public NUClear::Reactor {
+    private:
+        /// @brief Stores configuration values
+        struct Config {
+        } cfg;
 
-public:
-    /// @brief Called by the powerplant to build and setup the Ping reactor.
-    explicit Ping(std::unique_ptr<NUClear::Environment> environment);
-};
+    public:
+        /// @brief Called by the powerplant to build and setup the Ping reactor.
+        explicit Ping(std::unique_ptr<NUClear::Environment> environment);
+    };
 
 }  // namespace module::onboarding
 

--- a/module/onboarding/Pong/CMakeLists.txt
+++ b/module/onboarding/Pong/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Build our NUClear module
+nuclear_module()

--- a/module/onboarding/Pong/README.md
+++ b/module/onboarding/Pong/README.md
@@ -1,0 +1,16 @@
+# Pong
+
+## Description
+
+
+## Usage
+
+
+## Consumes
+
+
+## Emits
+
+
+## Dependencies
+

--- a/module/onboarding/Pong/README.md
+++ b/module/onboarding/Pong/README.md
@@ -2,15 +2,10 @@
 
 ## Description
 
-
 ## Usage
-
 
 ## Consumes
 
-
 ## Emits
 
-
 ## Dependencies
-

--- a/module/onboarding/Pong/README.md
+++ b/module/onboarding/Pong/README.md
@@ -2,10 +2,20 @@
 
 ## Description
 
+This module is one half of a pair of modules that receive a message containing a counter, increment the counter, and send a response message with the new counter.
+
 ## Usage
+
+Include onboarding::Pong as well as onboarding::Ping in your role.
 
 ## Consumes
 
+- `message::onboarding::Ping` Ping message containing a counter
+
 ## Emits
 
+- `message::onboarding::Pong` Response, and initial message, to Ping module containing the received counter incremented by 1
+
 ## Dependencies
+
+Depends on complementary onboarding::Ping module.

--- a/module/onboarding/Pong/data/config/Pong.yaml
+++ b/module/onboarding/Pong/data/config/Pong.yaml
@@ -1,0 +1,2 @@
+# Controls the minimum log level that NUClear log will display
+log_level: INFO

--- a/module/onboarding/Pong/src/Pong.cpp
+++ b/module/onboarding/Pong/src/Pong.cpp
@@ -28,13 +28,9 @@ namespace module::onboarding {
         on<Trigger<Ping>>().then([this](const Ping& ping_msg) {
             auto pong_msg   = std::make_unique<Pong>();
             pong_msg->count = ping_msg.count + 1;
-            // TODO: Log a INFO level message with the text "Pong"
-            // done
-            log<INFO>("Pong");
-            log<INFO>(pong_msg->count);
 
-            // TODO: Emit a Pong message
-            // done
+            log<INFO>("Pong:", pong_msg->count);
+
             emit(pong_msg);
         });
     }

--- a/module/onboarding/Pong/src/Pong.cpp
+++ b/module/onboarding/Pong/src/Pong.cpp
@@ -26,13 +26,15 @@ namespace module::onboarding {
         });
 
         on<Trigger<Ping>>().then([this](const Ping& ping_msg) {
+            auto pong_msg = std::make_unique<Pong>();
+            pong_msg->count = ping_msg.count + 1;
             // TODO: Log a INFO level message with the text "Pong"
             // done
             log<INFO>("Pong");
+            log<INFO>(pong_msg->count);
 
             // TODO: Emit a Pong message
             // done
-            auto pong_msg = std::make_unique<Pong>();
             emit(pong_msg);
         });
     }

--- a/module/onboarding/Pong/src/Pong.cpp
+++ b/module/onboarding/Pong/src/Pong.cpp
@@ -1,0 +1,40 @@
+#include "Pong.hpp"
+
+#include "extension/Configuration.hpp"
+
+#include "message/onboarding/Ping.hpp"
+#include "message/onboarding/Pong.hpp"
+
+namespace module::onboarding {
+
+    using extension::Configuration;
+
+    Pong::Pong(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
+
+        using message::onboarding::Ping;
+        using message::onboarding::Pong;
+
+        on<Configuration>("Pong.yaml").then([this](const Configuration& config) {
+            // Use configuration here from file Pong.yaml
+            this->log_level = config["log_level"].as<NUClear::LogLevel>();
+        });
+
+        on<Startup>().then([this] {
+            // Start the ping pong chain
+            auto pong_msg = std::make_unique<Pong>();
+            emit(pong_msg);
+        });
+
+        on<Trigger<Ping>>().then([this](const Ping& ping_msg) {
+            // TODO: Log a INFO level message with the text "Pong"
+            // done
+            log<INFO>("Pong");
+
+            // TODO: Emit a Pong message
+            // done
+            auto pong_msg = std::make_unique<Pong>();
+            emit(pong_msg);
+        });
+    }
+
+}  // namespace module::onboarding

--- a/module/onboarding/Pong/src/Pong.cpp
+++ b/module/onboarding/Pong/src/Pong.cpp
@@ -26,7 +26,7 @@ namespace module::onboarding {
         });
 
         on<Trigger<Ping>>().then([this](const Ping& ping_msg) {
-            auto pong_msg = std::make_unique<Pong>();
+            auto pong_msg   = std::make_unique<Pong>();
             pong_msg->count = ping_msg.count + 1;
             // TODO: Log a INFO level message with the text "Pong"
             // done

--- a/module/onboarding/Pong/src/Pong.hpp
+++ b/module/onboarding/Pong/src/Pong.hpp
@@ -1,0 +1,21 @@
+#ifndef MODULE_ONBOARDING_PONG_HPP
+#define MODULE_ONBOARDING_PONG_HPP
+
+#include <nuclear>
+
+namespace module::onboarding {
+
+class Pong : public NUClear::Reactor {
+private:
+    /// @brief Stores configuration values
+    struct Config {
+    } cfg;
+
+public:
+    /// @brief Called by the powerplant to build and setup the Pong reactor.
+    explicit Pong(std::unique_ptr<NUClear::Environment> environment);
+};
+
+}  // namespace module::onboarding
+
+#endif  // MODULE_ONBOARDING_PONG_HPP

--- a/module/onboarding/Pong/src/Pong.hpp
+++ b/module/onboarding/Pong/src/Pong.hpp
@@ -5,16 +5,16 @@
 
 namespace module::onboarding {
 
-class Pong : public NUClear::Reactor {
-private:
-    /// @brief Stores configuration values
-    struct Config {
-    } cfg;
+    class Pong : public NUClear::Reactor {
+    private:
+        /// @brief Stores configuration values
+        struct Config {
+        } cfg;
 
-public:
-    /// @brief Called by the powerplant to build and setup the Pong reactor.
-    explicit Pong(std::unique_ptr<NUClear::Environment> environment);
-};
+    public:
+        /// @brief Called by the powerplant to build and setup the Pong reactor.
+        explicit Pong(std::unique_ptr<NUClear::Environment> environment);
+    };
 
 }  // namespace module::onboarding
 

--- a/roles/test/onboarding.role
+++ b/roles/test/onboarding.role
@@ -12,4 +12,5 @@ nuclear_role(
   actuation::Kinematics
   actuation::Servos
   onboarding::Ping
+  onboarding::Pong
 )

--- a/shared/message/onboarding/Ping.proto
+++ b/shared/message/onboarding/Ping.proto
@@ -3,4 +3,5 @@ syntax = "proto3";
 package message.onboarding;
 
 message Ping{
+    int32 count = 1;
 }

--- a/shared/message/onboarding/Ping.proto
+++ b/shared/message/onboarding/Ping.proto
@@ -2,6 +2,6 @@ syntax = "proto3";
 
 package message.onboarding;
 
-message Ping{
+message Ping {
     int32 count = 1;
 }

--- a/shared/message/onboarding/Pong.proto
+++ b/shared/message/onboarding/Pong.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package message.onboarding;
+
+message Pong {
+}

--- a/shared/message/onboarding/Pong.proto
+++ b/shared/message/onboarding/Pong.proto
@@ -3,4 +3,5 @@ syntax = "proto3";
 package message.onboarding;
 
 message Pong {
+    int32 count = 1;
 }


### PR DESCRIPTION
This PR would merge the branch containing my onboarding task commits with the main montano/onboarding branch.
My branch implements a Pong message to complement the already-existing Ping message and adds counters to each.
It also sends Ping and Pong messages between the two modules, incrementing and then sending back the counter each time.