### PR TITLE
Add NUSense Fan Controller functionality

### DIFF
--- a/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
+++ b/module/platform/NUSense/HardwareIO/src/HardwareIO.cpp
@@ -191,6 +191,10 @@ namespace module::platform::NUSense {
                 // Battery data
                 sensors->battery = 0;  // not yet implemented
 
+                // Fan data
+                sensors->fan_warning.fan1_warning = data.fan_warnings.fan1_warning;
+                sensors->fan_warning.fan2_warning = data.fan_warnings.fan2_warning;  // Fan warning status
+
                 // Servo data
                 for (const auto& [key, val] : data.servo_map) {
                     // Get a reference to the servo we are populating

--- a/shared/message/platform/NUSenseData.proto
+++ b/shared/message/platform/NUSenseData.proto
@@ -96,6 +96,9 @@ message Buttons {
     bool middle = 2;
 }
 
+// These two bools hold the warning status of the two fans (J401 & J402) on NUSense.
+// These two fan warnings are triggered by a fan dropping below the threshold speed.
+// (that threshold speed is defined in the NUSense firmware)
 message FanWarning {
     bool fan1_warning = 1;
     bool fan2_warning = 2;

--- a/shared/message/platform/NUSenseData.proto
+++ b/shared/message/platform/NUSenseData.proto
@@ -96,6 +96,11 @@ message Buttons {
     bool middle = 2;
 }
 
+message FanWarning {
+    bool fan1_warning = 1;
+    bool fan2_warning = 2;
+}
+
 message NUSense {
     /* INDEX MAPPING
      *  0  : r_shoulder_pitch
@@ -122,6 +127,7 @@ message NUSense {
     map<uint32, Servo> servo_map = 1;
     IMU                imu       = 2;
     Buttons            buttons   = 3;
+    FanWarning         fan_warnings = 4;
 }
 
 message ServoConfiguration {

--- a/shared/message/platform/NUSenseData.proto
+++ b/shared/message/platform/NUSenseData.proto
@@ -124,9 +124,9 @@ message NUSense {
      *  18 : head_yaw
      *  19 : head_pitch
      */
-    map<uint32, Servo> servo_map = 1;
-    IMU                imu       = 2;
-    Buttons            buttons   = 3;
+    map<uint32, Servo> servo_map    = 1;
+    IMU                imu          = 2;
+    Buttons            buttons      = 3;
     FanWarning         fan_warnings = 4;
 }
 

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -185,7 +185,7 @@ message RawSensors {
 
     /// Ground truth from a simulator
     webots.RobotPoseGroundTruth robot_pose_ground_truth = 12;
-    NUSenseData.FanWarning      fan_warning             = 13;
+    FanWarning                  fan_warning             = 13;
 }
 
 // Reset sensors and servo targets in Webots

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -189,7 +189,7 @@ message RawSensors {
 
     /// Ground truth from a simulator
     webots.RobotPoseGroundTruth robot_pose_ground_truth = 12;
-    FanWarning fan_warning = 13;
+    FanWarning                  fan_warning             = 13;
 }
 
 // Reset sensors and servo targets in Webots

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -28,6 +28,7 @@ syntax = "proto3";
 package message.platform;
 
 import "message/platform/webots/messages.proto";
+import "message/platform/NUSenseData.proto";
 import "google/protobuf/timestamp.proto";
 
 import "Vector.proto";
@@ -97,11 +98,6 @@ message RawSensors {
         float x = 1;
         float y = 2;
         float z = 3;
-    }
-
-    message FanWarning {
-        bool fan1_warning = 1;
-        bool fan2_warning = 2;
     }
 
     /// The robot has Force Sensitive Resistors on its feet to detect whether a foot is down.
@@ -189,7 +185,7 @@ message RawSensors {
 
     /// Ground truth from a simulator
     webots.RobotPoseGroundTruth robot_pose_ground_truth = 12;
-    FanWarning                  fan_warning             = 13;
+    NUSenseData.FanWarning      fan_warning             = 13;
 }
 
 // Reset sensors and servo targets in Webots

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -189,6 +189,7 @@ message RawSensors {
 
     /// Ground truth from a simulator
     webots.RobotPoseGroundTruth robot_pose_ground_truth = 12;
+    FanWarning fan_warning = 13;
 }
 
 // Reset sensors and servo targets in Webots

--- a/shared/message/platform/RawSensors.proto
+++ b/shared/message/platform/RawSensors.proto
@@ -99,6 +99,11 @@ message RawSensors {
         float z = 3;
     }
 
+    message FanWarning {
+        bool fan1_warning = 1;
+        bool fan2_warning = 2;
+    }
+
     /// The robot has Force Sensitive Resistors on its feet to detect whether a foot is down.
     /// There are four FSRs per foot, so this message is for one foot
     message FSR {


### PR DESCRIPTION
This PR is linked to functionality on [NUController PR#38](https://github.com/NUbots/NUcontroller/pull/38)

This PR adds a message to the NUSense IO ProtoBuf framework that reports whether the fans driven by NUSense are spinning fast enough. Use of this error state is not yet implemented, but could be used to throw a warning log in future.

This message, namely, `FanWarning` has two booleans; `fan1_warning` and `fan2_warning` whereby a `false` represents a **functional** fan, spinning fast enough. A `true` would represent a fan that is spinning fast enough. A fan that isn't plugged in will report a fan warning of `true`.