### PR TITLE
[NUsight] Fix svg path generation for lines rendering

### DIFF
--- a/nusight2/src/client/render2d/svg/path.tsx
+++ b/nusight2/src/client/render2d/svg/path.tsx
@@ -11,8 +11,14 @@ type Props = { model: Shape<PathGeometry> };
 export const Path = observer(({ model: { geometry, appearance, eventHandlers } }: Props) => {
   const transforms = useContext(rendererTransformsContext);
   const start = geometry.points[0];
-  const path = `M${start.x},${start.y}` + geometry.points.map((p) => `L${p.x},${p.y}`);
-
+  const path =
+    geometry.points.length === 0
+      ? ""
+      : `M${start.x},${start.y} ` +
+        geometry.points
+          .slice(1)
+          .map((p) => `L${p.x},${p.y}`)
+          .join(" ");
   return (
     <path d={path} {...toSvgAppearance(appearance)} {...toSvgEventHandlers(eventHandlers, transforms)} fill="none" />
   );


### PR DESCRIPTION
This PR fixes chart lines not rendering due to an invalid SVG path string.

The path was previously built by concatenating an array, creating invalid output. This change correctly joins segments and avoids duplicating the first point.

### Pre-PR Checklist:

Have you

- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [x] Added a descriptive title and relevant labels to the PR

### Reviewers, Note

The change is motivated by chart rendering in nusight. This path component also may be used elsewhere.