### PR TITLE
Load the extrinsics offsets for the actual robot

### DIFF
--- a/module/input/Camera/data/config/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/Cameras/Left.yaml
@@ -21,7 +21,3 @@ settings:
   AcquisitionFrameRateEnable: true
   AcquisitionFrameRate: 25.00 # Adjusting frame rate can help remove flickering from lighting
   DeviceLinkThroughputLimit: 60000000 # Throughput can limit the framerate
-
-roll_offset: 0.0 * pi / 180
-pitch_offset: -2.550 * pi / 180
-yaw_offset: -2 * pi / 180

--- a/module/input/Camera/src/Camera.cpp
+++ b/module/input/Camera/src/Camera.cpp
@@ -45,6 +45,7 @@ extern "C" {
 
 #include "utility/input/FrameID.hpp"
 #include "utility/input/ServoID.hpp"
+#include "utility/platform/aliases.hpp"
 #include "utility/support/yaml_expression.hpp"
 #include "utility/vision/fourcc.hpp"
 #include "utility/vision/projection.hpp"
@@ -192,11 +193,31 @@ namespace module::input {
                                                                     camera_frame,
                                                                     std::string("head"));
 
-            // Apply roll, pitch, and yaw offsets
-            double roll_offset  = config["roll_offset"].as<Expression>();
-            double pitch_offset = config["pitch_offset"].as<Expression>();
-            double yaw_offset   = config["yaw_offset"].as<Expression>();
-            context.Hpc         = Eigen::AngleAxisd(yaw_offset, Eigen::Vector3d::UnitX()).toRotationMatrix()
+            // Open the config directory for the robot running this module
+            std::string hostname   = utility::support::get_hostname();
+            std::string robot_name = utility::platform::get_robot_alias(hostname);
+
+            auto camera_in_use = config["is_left_camera"].as<bool>() ? "Left" : "Right";
+            auto robot_config  = YAML::LoadFile(fmt::format("config/{}/Cameras/{}.yaml", robot_name, camera_in_use));
+
+            log<INFO>(fmt::format("Applying camera offsets for {}", robot_name));
+
+            // Apply roll, pitch, and yaw offsets using the name of the robot that's running this code
+            double roll_offset  = robot_config["roll_offset"].as<Expression>();
+            double pitch_offset = robot_config["pitch_offset"].as<Expression>();
+            double yaw_offset   = robot_config["yaw_offset"].as<Expression>();
+
+            // Log all the offsets for debugging to compare against the config files
+            log<DEBUG>(
+                fmt::format("Applying camera offsets for {}: roll offset = {:.2f} deg, pitch offset = {:.2f} deg, yaw "
+                            "offset = {:.2f} deg",
+                            robot_name,
+                            roll_offset * 180.0 / M_PI,
+                            pitch_offset * 180.0 / M_PI,
+                            yaw_offset * 180.0 / M_PI));
+
+
+            context.Hpc = Eigen::AngleAxisd(yaw_offset, Eigen::Vector3d::UnitX()).toRotationMatrix()
                           * Eigen::AngleAxisd(pitch_offset, Eigen::Vector3d::UnitZ()).toRotationMatrix()
                           * Eigen::AngleAxisd(roll_offset, Eigen::Vector3d::UnitY()).toRotationMatrix() * Hpc;
 

--- a/module/platform/Webots/data/config/WebotsCameras/left_camera.yaml
+++ b/module/platform/Webots/data/config/WebotsCameras/left_camera.yaml
@@ -35,6 +35,5 @@ settings:
 # Camera kinematics
 urdf_path: "models/robot.urdf"
 
-roll_offset: 0.0 * pi / 180
-
-pitch_offset: 0.0 * pi / 180
+# Whether this is the left camera
+is_left_camera: true

--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -49,6 +49,7 @@
 #include "utility/input/ServoID.hpp"
 #include "utility/math/angle.hpp"
 #include "utility/platform/RawSensors.hpp"
+#include "utility/platform/aliases.hpp"
 #include "utility/support/yaml_expression.hpp"
 #include "utility/vision/fourcc.hpp"
 #include "utility/vision/projection.hpp"
@@ -318,9 +319,18 @@ namespace module::platform {
                                                                     std::string("left_camera"),
                                                                     std::string("head"));
 
-            // Apply roll and pitch offsets
-            double roll_offset  = config["roll_offset"].as<Expression>();
-            double pitch_offset = config["pitch_offset"].as<Expression>();
+            // Open the config directory for the robot running this module
+            std::string hostname   = utility::support::get_hostname();
+            std::string robot_name = utility::platform::get_robot_alias(hostname);
+
+            auto camera_in_use = config["is_left_camera"].as<bool>() ? "Left" : "Right";
+            auto robot_config  = YAML::LoadFile(fmt::format("config/{}/Cameras/{}.yaml", robot_name, camera_in_use));
+
+            log<INFO>(fmt::format("Applying camera offsets for {}", robot_name));
+
+            // Apply roll and pitch offsets using the name of the robot that's running this code
+            double roll_offset  = robot_config["roll_offset"].as<Expression>();
+            double pitch_offset = robot_config["pitch_offset"].as<Expression>();
             context.Hpc         = Eigen::AngleAxisd(pitch_offset, Eigen::Vector3d::UnitZ()).toRotationMatrix()
                           * Eigen::AngleAxisd(roll_offset, Eigen::Vector3d::UnitY()).toRotationMatrix() * Hpc;
 


### PR DESCRIPTION
Tuning the extrinsics currently involves this confusing method of copying a robot's offset configs then pasting it to the higher level `Camera.yaml`, tuning that, then pasting it back to the robot config and using the tuned values for the higher level `Camera.yaml`.

This pull request fixes this issue by loading the actual robot configs instead, and using the robot-specific offsets during runtime.