### PR TITLE
Added variable for NUClear port in NUsight server

### DIFF
--- a/nusight2/src/server/dev.ts
+++ b/nusight2/src/server/dev.ts
@@ -17,6 +17,7 @@ const args = minimist(process.argv.slice(2));
 
 const withVirtualRobots = args["virtual-robots"] || false;
 const nuclearnetAddress = args.address || "239.226.152.162";
+const nuclearnetPort = args.port || "7447";
 
 async function main() {
   const app = express();
@@ -26,7 +27,7 @@ async function main() {
   // Initialize socket.io namespace immediately to catch reconnections.
   NUsightServer.of(WebSocketServer.of(sioNetwork.of("/nuclearnet")), {
     fakeNetworking: withVirtualRobots,
-    connectionOpts: { name: "nusight", address: nuclearnetAddress },
+    connectionOpts: { name: "nusight", address: nuclearnetAddress, port: nuclearnetPort },
   });
 
   const viteDevServer = await createViteServer({

--- a/nusight2/src/server/prod.ts
+++ b/nusight2/src/server/prod.ts
@@ -16,6 +16,7 @@ import { WebSocketServer } from "./web_socket/web_socket_server";
 const args = minimist(process.argv.slice(2));
 const withVirtualRobots = args["virtual-robots"] || false;
 const nuclearnetAddress = args.address || "239.226.152.162";
+const nuclearnetPort = args.port || "7447";
 
 const app = express();
 const server = http.createServer(app);
@@ -46,5 +47,5 @@ if (withVirtualRobots) {
 
 NUsightServer.of(WebSocketServer.of(sioNetwork.of("/nuclearnet")), {
   fakeNetworking: withVirtualRobots,
-  connectionOpts: { name: "nusight", address: nuclearnetAddress },
+  connectionOpts: { name: "nusight", address: nuclearnetAddress, port: nuclearnetPort },
 });


### PR DESCRIPTION
This is a minor QoL change; something I noticed with NUsight while developing for the K1 is that while it defaults to port 7447 (as part of NUClearNet.js), it doesn't have the option to set the port yourself. As a result, changing the announce port in the NUClearNet config makes any NUbots binaries undiscoverable to NUsight (port 7447 is unfortunately already bound to an RPC service in the K1, so this was me finding a solution haha)

No need to update `./b yarn`, as its argparse just takes in a single 'args' argument.

NUbook PR [here](https://github.com/NUbots/NUbook/pull/347)

### Things left to do

- [x] Update documentation in NUbook (where necessary)
