### PR TITLE
Update robot communication and GameController for 2026 HSL compliance

### DIFF
--- a/module/input/GameController/README.md
+++ b/module/input/GameController/README.md
@@ -4,7 +4,7 @@
 
 Listens for RoboCup GameController UDP broadcast packets, converts them into NUClear messages, and maintains a canonical `message::input::GameState`.
 
-The module also sends periodic and state-dependent reply packets back to the GameController (alive, penalised, unpenalised).
+The module also sends periodic reply packets back to the GameController.
 
 ## Usage
 
@@ -17,7 +17,7 @@ This module is configured by `GameController.yaml` and consumes:
 At runtime it:
 
 - Listens for UDP broadcast packets on `receive_port`
-- Accepts only supported packet version `12`
+- Accepts only supported packet version `19`
 - Optionally filters incoming packets by source IP using `udp_filter_address`
 - Tracks the sender address and sends reply packets to that address on `send_port`
 - Sends `ALIVE` reply packets every 2 seconds
@@ -32,14 +32,12 @@ At runtime it:
 - `message::input::GameEvents::GoalScored`
 - `message::input::GameEvents::Penalisation`
 - `message::input::GameEvents::Unpenalisation`
-- `message::input::GameEvents::CoachMessage`
 - `message::input::GameEvents::HalfTime`
-- `message::input::GameEvents::BallKickedOut`
 - `message::input::GameEvents::KickOffTeam`
 - `message::input::GameEvents::GamePhase`
 - `message::input::GameEvents::GameMode`
 
-Also sends UDP GameController reply packets (`PENALISED`, `UNPENALISED`, `ALIVE`) via `emit<Scope::UDP>(...)`.
+Also sends UDP GameController reply packets via `emit<Scope::UDP>(...)`.
 
 ## Dependencies
 

--- a/module/input/GameController/src/GameController.cpp
+++ b/module/input/GameController/src/GameController.cpp
@@ -236,11 +236,8 @@ namespace module::input {
         log<DEBUG>("GameController message budget remaining:", new_own_team.message_budget);
 
         // Get colours
-        state->team.team_colour =
-            new_own_team.field_player_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
-        state->opponent.team_colour = new_opponent_team.field_player_colour == gamecontroller::TeamColour::BLUE
-                                          ? TeamColour::BLUE
-                                          : TeamColour::RED;
+        state->team.team_colour     = get_team_colour(new_own_team.field_player_colour);
+        state->opponent.team_colour = get_team_colour(new_opponent_team.field_player_colour);
 
         /*******************************************************************************************
          * Process score updates
@@ -400,8 +397,7 @@ namespace module::input {
          * Process our team colour
          ******************************************************************************************/
         if (old_own_team.field_player_colour != new_own_team.field_player_colour) {
-            TeamColour colour = new_own_team.field_player_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE
-                                                                                                     : TeamColour::RED;
+            TeamColour colour = get_team_colour(new_own_team.field_player_colour);
             state_changes.emplace_back([this, colour] { emit(std::make_unique<TeamColour>(colour)); });
         }
 
@@ -638,5 +634,14 @@ namespace module::input {
         std::string addr = inet_ntop(AF_INET, &ip_addr_n, c, sizeof(c));
 
         return addr;
+    }
+
+    GameState::TeamColour::Value GameController::get_team_colour(const gamecontroller::TeamColour& colour) {
+        switch (colour) {
+            case gamecontroller::TeamColour::BLUE: return TeamColour::BLUE;
+            case gamecontroller::TeamColour::RED:  return TeamColour::RED;
+            // TODO: update GameState.proto TeamColour enum to support all v3 colours
+            default: return TeamColour::UNKNOWN;
+        }
     }
 }  // namespace module::input

--- a/module/input/GameController/src/GameController.cpp
+++ b/module/input/GameController/src/GameController.cpp
@@ -54,14 +54,7 @@ namespace module::input {
     using TeamColour     = GameState::TeamColour::Value;
 
     GameController::GameController(std::unique_ptr<NUClear::Environment> environment)
-        : Reactor(std::move(environment))
-        , receive_port(0)
-        , send_port(0)
-        , TEAM_ID(0)
-        , PLAYER_ID(0)
-        , packet()
-        , game_phase()
-        , set_play() {
+        : Reactor(std::move(environment)) {
 
         // Configure
         on<Configuration, Trigger<GlobalConfig>>("GameController.yaml")

--- a/module/input/GameController/src/GameController.cpp
+++ b/module/input/GameController/src/GameController.cpp
@@ -48,13 +48,20 @@ namespace module::input {
     using Unpenalisation = GameEvents::Unpenalisation;
     using HalfTime       = GameEvents::HalfTime;
     using KickOffTeam    = GameEvents::KickOffTeam;
-    using GameEventPhase      = GameEvents::GamePhase;
+    using GameEventPhase = GameEvents::GamePhase;
     using GameMode       = GameEvents::GameMode;
     using PenaltyReason  = GameState::PenaltyReason;
     using TeamColour     = GameState::TeamColour::Value;
 
     GameController::GameController(std::unique_ptr<NUClear::Environment> environment)
-        : Reactor(std::move(environment)), receive_port(0), send_port(0), TEAM_ID(0), PLAYER_ID(0), packet(), game_phase(), set_play() {
+        : Reactor(std::move(environment))
+        , receive_port(0)
+        , send_port(0)
+        , TEAM_ID(0)
+        , PLAYER_ID(0)
+        , packet()
+        , game_phase()
+        , set_play() {
 
         // Configure
         on<Configuration, Trigger<GlobalConfig>>("GameController.yaml")
@@ -127,8 +134,7 @@ namespace module::input {
                       reset_state();
                   });
 
-        on<Every<2, Per<std::chrono::seconds>>>().then("GameController Reply",
-                                                       [this] { send_reply_message(); });
+        on<Every<2, Per<std::chrono::seconds>>>().then("GameController Reply", [this] { send_reply_message(); });
     }
 
     void GameController::send_reply_message() {
@@ -143,13 +149,13 @@ namespace module::input {
 
         // fallen, pose, ball_age and ball should be optional to be sent to the GameController
         // TODO: wire up from localisation if required in the future
-        packet->fallen  = self_penalised ? 1 : 0;
-        packet->pose[0] = 0.f;
-        packet->pose[1] = 0.f;
-        packet->pose[2] = 0.f;
+        packet->fallen   = self_penalised ? 1 : 0;
+        packet->pose[0]  = 0.f;
+        packet->pose[1]  = 0.f;
+        packet->pose[2]  = 0.f;
         packet->ball_age = -1.f;
-        packet->ball[0] = 0.f;
-        packet->ball[1] = 0.f;
+        packet->ball[0]  = 0.f;
+        packet->ball[1]  = 0.f;
 
         if (game_controller_address != "") {
             emit<Scope::UDP>(packet, game_controller_address, send_port);
@@ -159,7 +165,7 @@ namespace module::input {
     void GameController::reset_state() {
 
         game_phase = static_cast<gamecontroller::GamePhase>(-1);
-        set_play = static_cast<gamecontroller::SetPlay>(-1);
+        set_play   = static_cast<gamecontroller::SetPlay>(-1);
 
         std::copy(std::begin(gamecontroller::RECEIVE_HEADER),
                   std::end(gamecontroller::RECEIVE_HEADER),
@@ -169,18 +175,18 @@ namespace module::input {
         packet.players_per_team = PLAYERS_PER_TEAM;
         packet.state            = static_cast<gamecontroller::State>(-1);
         packet.first_half       = true;
-        packet.kicking_team  = 0;
+        packet.kicking_team     = 0;
         packet.game_phase       = static_cast<gamecontroller::GamePhase>(-1);
         packet.set_play         = static_cast<gamecontroller::SetPlay>(-1);
         packet.secs_remaining   = 0;
         packet.secondary_time   = 0;
         for (uint i = 0; i < NUM_TEAMS; i++) {
-            auto& own_team        = packet.teams[i];
-            own_team.team_id      = (i == 0 ? TEAM_ID : 0);
+            auto& own_team               = packet.teams[i];
+            own_team.team_id             = (i == 0 ? TEAM_ID : 0);
             own_team.field_player_colour = static_cast<gamecontroller::TeamColour>(-1);
-            own_team.score        = 0;
-            own_team.penalty_shot = 0;
-            own_team.single_shots = 0;
+            own_team.score               = 0;
+            own_team.penalty_shot        = 0;
+            own_team.single_shots        = 0;
             for (uint i = 0; i < gamecontroller::MAX_NUM_PLAYERS; i++) {
                 auto& player = own_team.players[i];
                 if (i <= ACTIVE_PLAYERS_PER_TEAM) {
@@ -232,8 +238,9 @@ namespace module::input {
         // Get colours
         state->team.team_colour =
             new_own_team.field_player_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
-        state->opponent.team_colour =
-            new_opponent_team.field_player_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
+        state->opponent.team_colour = new_opponent_team.field_player_colour == gamecontroller::TeamColour::BLUE
+                                          ? TeamColour::BLUE
+                                          : TeamColour::RED;
 
         /*******************************************************************************************
          * Process score updates
@@ -393,8 +400,8 @@ namespace module::input {
          * Process our team colour
          ******************************************************************************************/
         if (old_own_team.field_player_colour != new_own_team.field_player_colour) {
-            TeamColour colour =
-                new_own_team.field_player_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
+            TeamColour colour = new_own_team.field_player_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE
+                                                                                                     : TeamColour::RED;
             state_changes.emplace_back([this, colour] { emit(std::make_unique<TeamColour>(colour)); });
         }
 
@@ -403,7 +410,8 @@ namespace module::input {
          * Process game phase changes
          ******************************************************************************************/
 
-        if (old_packet.game_phase != gamecontroller::GamePhase::TIMEOUT && new_packet.game_phase == gamecontroller::GamePhase::TIMEOUT) {
+        if (old_packet.game_phase != gamecontroller::GamePhase::TIMEOUT
+            && new_packet.game_phase == gamecontroller::GamePhase::TIMEOUT) {
 
             // Change the game state to timeout
             auto time = NUClear::clock::now() + std::chrono::seconds(new_packet.secondary_time);
@@ -584,18 +592,18 @@ namespace module::input {
     PenaltyReason GameController::get_penalty_reason(const gamecontroller::PenaltyState& penalty_state) {
         // ugly incoming
         switch (penalty_state) {
-            case gamecontroller::PenaltyState::UNPENALISED:         return PenaltyReason::UNPENALISED;
+            case gamecontroller::PenaltyState::UNPENALISED: return PenaltyReason::UNPENALISED;
             case gamecontroller::PenaltyState::ILLEGAL_POSITIONING: return PenaltyReason::ILLEGAL_DEFENSE;
-            case gamecontroller::PenaltyState::MOTION_IN_SET:       return PenaltyReason::PHYSICAL_CONTACT;
-            case gamecontroller::PenaltyState::LOCAL_GAME_STUCK:    return PenaltyReason::MANUAL;
-            case gamecontroller::PenaltyState::INCAPABLE_ROBOT:     return PenaltyReason::REQUEST_FOR_PICKUP;
-            case gamecontroller::PenaltyState::PICK_UP:             return PenaltyReason::REQUEST_FOR_PICKUP;
-            case gamecontroller::PenaltyState::BALL_HOLDING:        return PenaltyReason::BALL_MANIPULATION;
-            case gamecontroller::PenaltyState::LEAVING_THE_FIELD:   return PenaltyReason::REQUEST_FOR_SERVICE;
+            case gamecontroller::PenaltyState::MOTION_IN_SET: return PenaltyReason::PHYSICAL_CONTACT;
+            case gamecontroller::PenaltyState::LOCAL_GAME_STUCK: return PenaltyReason::MANUAL;
+            case gamecontroller::PenaltyState::INCAPABLE_ROBOT: return PenaltyReason::REQUEST_FOR_PICKUP;
+            case gamecontroller::PenaltyState::PICK_UP: return PenaltyReason::REQUEST_FOR_PICKUP;
+            case gamecontroller::PenaltyState::BALL_HOLDING: return PenaltyReason::BALL_MANIPULATION;
+            case gamecontroller::PenaltyState::LEAVING_THE_FIELD: return PenaltyReason::REQUEST_FOR_SERVICE;
             case gamecontroller::PenaltyState::PLAYING_WITH_ARMS_HANDS: return PenaltyReason::ILLEGAL_ATTACK;
-            case gamecontroller::PenaltyState::PLAYER_PUSHING:      return PenaltyReason::PHYSICAL_CONTACT;
-            case gamecontroller::PenaltyState::SENT_OFF:            return PenaltyReason::MANUAL;
-            case gamecontroller::PenaltyState::SUBSTITUTE:          return PenaltyReason::SUBSTITUTE;
+            case gamecontroller::PenaltyState::PLAYER_PUSHING: return PenaltyReason::PHYSICAL_CONTACT;
+            case gamecontroller::PenaltyState::SENT_OFF: return PenaltyReason::MANUAL;
+            case gamecontroller::PenaltyState::SUBSTITUTE: return PenaltyReason::SUBSTITUTE;
             default: throw std::runtime_error("Invalid Penalty State");
         }
     }

--- a/module/input/GameController/src/GameController.cpp
+++ b/module/input/GameController/src/GameController.cpp
@@ -38,7 +38,6 @@ namespace module::input {
     using extension::Configuration;
     using gamecontroller::GameControllerPacket;
     using gamecontroller::GameControllerReplyPacket;
-    using gamecontroller::ReplyMessage;
     using gamecontroller::Team;
     using message::input::GameEvents;
     using message::input::GameState;
@@ -47,17 +46,15 @@ namespace module::input {
     using GoalScored     = GameEvents::GoalScored;
     using Penalisation   = GameEvents::Penalisation;
     using Unpenalisation = GameEvents::Unpenalisation;
-    using Coach_message  = GameEvents::CoachMessage;
     using HalfTime       = GameEvents::HalfTime;
-    using BallKickedOut  = GameEvents::BallKickedOut;
     using KickOffTeam    = GameEvents::KickOffTeam;
-    using GamePhase      = GameEvents::GamePhase;
+    using GameEventPhase      = GameEvents::GamePhase;
     using GameMode       = GameEvents::GameMode;
     using PenaltyReason  = GameState::PenaltyReason;
     using TeamColour     = GameState::TeamColour::Value;
 
     GameController::GameController(std::unique_ptr<NUClear::Environment> environment)
-        : Reactor(std::move(environment)), receive_port(0), send_port(0), TEAM_ID(0), PLAYER_ID(0), packet(), mode() {
+        : Reactor(std::move(environment)), receive_port(0), send_port(0), TEAM_ID(0), PLAYER_ID(0), packet(), game_phase(), set_play() {
 
         // Configure
         on<Configuration, Trigger<GlobalConfig>>("GameController.yaml")
@@ -131,10 +128,10 @@ namespace module::input {
                   });
 
         on<Every<2, Per<std::chrono::seconds>>>().then("GameController Reply",
-                                                       [this] { send_reply_message(ReplyMessage::ALIVE); });
+                                                       [this] { send_reply_message(); });
     }
 
-    void GameController::send_reply_message(const ReplyMessage& message) {
+    void GameController::send_reply_message() {
         auto packet     = std::make_unique<GameControllerReplyPacket>();
         packet->header  = {gamecontroller::RETURN_HEADER[0],
                            gamecontroller::RETURN_HEADER[1],
@@ -143,7 +140,16 @@ namespace module::input {
         packet->version = gamecontroller::RETURN_VERSION;
         packet->team    = TEAM_ID;
         packet->player  = PLAYER_ID;
-        packet->message = message;
+
+        // fallen, pose, ball_age and ball should be optional to be sent to the GameController
+        // TODO: wire up from localisation if required in the future
+        packet->fallen  = self_penalised ? 1 : 0;
+        packet->pose[0] = 0.f;
+        packet->pose[1] = 0.f;
+        packet->pose[2] = 0.f;
+        packet->ball_age = -1.f;
+        packet->ball[0] = 0.f;
+        packet->ball[1] = 0.f;
 
         if (game_controller_address != "") {
             emit<Scope::UDP>(packet, game_controller_address, send_port);
@@ -152,7 +158,8 @@ namespace module::input {
 
     void GameController::reset_state() {
 
-        mode = static_cast<gamecontroller::Mode>(-1);
+        game_phase = static_cast<gamecontroller::GamePhase>(-1);
+        set_play = static_cast<gamecontroller::SetPlay>(-1);
 
         std::copy(std::begin(gamecontroller::RECEIVE_HEADER),
                   std::end(gamecontroller::RECEIVE_HEADER),
@@ -162,23 +169,18 @@ namespace module::input {
         packet.players_per_team = PLAYERS_PER_TEAM;
         packet.state            = static_cast<gamecontroller::State>(-1);
         packet.first_half       = true;
-        packet.kick_off_team    = -1;
-        packet.mode             = static_cast<gamecontroller::Mode>(-1);
-        packet.drop_in_team     = static_cast<gamecontroller::TeamColour>(-1);
-        packet.drop_in_time     = -1;
+        packet.kicking_team  = 0;
+        packet.game_phase       = static_cast<gamecontroller::GamePhase>(-1);
+        packet.set_play         = static_cast<gamecontroller::SetPlay>(-1);
         packet.secs_remaining   = 0;
         packet.secondary_time   = 0;
         for (uint i = 0; i < NUM_TEAMS; i++) {
             auto& own_team        = packet.teams[i];
             own_team.team_id      = (i == 0 ? TEAM_ID : 0);
-            own_team.team_colour  = static_cast<gamecontroller::TeamColour>(-1);
+            own_team.field_player_colour = static_cast<gamecontroller::TeamColour>(-1);
             own_team.score        = 0;
             own_team.penalty_shot = 0;
             own_team.single_shots = 0;
-            own_team.coach_message.fill(0);
-            auto& coach               = own_team.coach;
-            coach.penalty_state       = gamecontroller::PenaltyState::UNPENALISED;
-            coach.penalised_time_left = 0;
             for (uint i = 0; i < gamecontroller::MAX_NUM_PLAYERS; i++) {
                 auto& player = own_team.players[i];
                 if (i <= ACTIVE_PLAYERS_PER_TEAM) {
@@ -224,11 +226,14 @@ namespace module::input {
         const auto& old_opponent_team = get_opponent_team(old_packet);
         const auto& new_opponent_team = get_opponent_team(new_packet);
 
+        // Log message budget for cross-checking against local counter
+        log<DEBUG>("GameController message budget remaining:", new_own_team.message_budget);
+
         // Get colours
         state->team.team_colour =
-            new_own_team.team_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
+            new_own_team.field_player_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
         state->opponent.team_colour =
-            new_opponent_team.team_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
+            new_opponent_team.field_player_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
 
         /*******************************************************************************************
          * Process score updates
@@ -282,7 +287,7 @@ namespace module::input {
                 GameState::Robot(player_id,
                                  get_penalty_reason(new_own_player.penalty_state),
                                  NUClear::clock::now() + std::chrono::seconds(new_own_player.penalised_time_left),
-                                 new_own_player.goal_keeper);
+                                 new_own_team.goalkeeper == player_id);
             state->team.players.push_back(own_player);
             if (player_id == PLAYER_ID) {
                 state->self = own_player;
@@ -305,7 +310,7 @@ namespace module::input {
                         // Self penalised :@
                         emit(std::make_unique<Penalisation>(
                             Penalisation{GameEvents::Context::Value::SELF, player_id, unpenalised_time, reason}));
-                        send_reply_message(ReplyMessage::PENALISED);
+                        send_reply_message();
                         self_penalised = true;
                     }
                     else {
@@ -322,7 +327,7 @@ namespace module::input {
                         // Self unpenalised :)
                         emit(std::make_unique<Unpenalisation>(
                             Unpenalisation{GameEvents::Context::Value::SELF, player_id}));
-                        send_reply_message(ReplyMessage::UNPENALISED);
+                        send_reply_message();
                         self_penalised = false;
                     }
                     else {
@@ -354,35 +359,6 @@ namespace module::input {
             }
         }
 
-
-        /*******************************************************************************************
-         * Process coach messages
-         ******************************************************************************************/
-        if (old_own_team.coach_message != new_own_team.coach_message) {
-
-            // Update the coach message in the state
-            state->team.coach_message = new_own_team.coach_message.data();
-
-            // Listen to the coach? o_O
-            state_changes.emplace_back([this, new_own_team] {
-                emit(std::make_unique<Coach_message>(
-                    Coach_message{GameEvents::Context::Value::TEAM, new_own_team.coach_message.data()}));
-            });
-        }
-
-        if (old_opponent_team.coach_message != new_opponent_team.coach_message) {
-
-            // Update the opponent coach message in the state
-            state->opponent.coach_message = new_opponent_team.coach_message.data();
-
-            // Listen in on the enemy! >:D
-            state_changes.emplace_back([this, new_opponent_team] {
-                emit(std::make_unique<Coach_message>(
-                    Coach_message{GameEvents::Context::Value::OPPONENT, new_opponent_team.coach_message.data()}));
-            });
-        }
-
-
         /*******************************************************************************************
          * Process half changes
          ******************************************************************************************/
@@ -397,45 +373,15 @@ namespace module::input {
         }
 
         /*******************************************************************************************
-         * Process ball kicked out
-         ******************************************************************************************/
-        // Woo boolean algebra!
-        if ((new_packet.drop_in_time != -1
-             && ((new_packet.drop_in_time < old_packet.drop_in_time) == (old_packet.drop_in_time != -1)))
-            || new_packet.drop_in_team != old_packet.drop_in_team) {
-
-            // Ball was kicked out by drop_in_team
-            auto time = NUClear::clock::now() - std::chrono::seconds(new_packet.drop_in_time);
-
-            // Update the ball kicked out time and player in the state
-            state->kicked_out_by_us = new_packet.drop_in_team == new_own_team.team_colour;
-            state->kicked_out_time  = time;
-
-            if (new_packet.drop_in_team == new_own_team.team_colour) {
-                // We kicked the ball out :S
-                state_changes.emplace_back([this, time] {
-                    emit(std::make_unique<BallKickedOut>(BallKickedOut{GameEvents::Context::Value::TEAM, time}));
-                });
-            }
-            else {
-                // They kicked the ball out! ^_^
-                state_changes.emplace_back([this, time] {
-                    emit(std::make_unique<BallKickedOut>(BallKickedOut{GameEvents::Context::Value::OPPONENT, time}));
-                });
-            }
-        }
-
-
-        /*******************************************************************************************
          * Process kick off team
          ******************************************************************************************/
-        if (old_packet.kick_off_team != new_packet.kick_off_team) {
+        if (old_packet.kicking_team != new_packet.kicking_team) {
 
             // Update the kickoff team (us or them)
-            state->our_kick_off = new_packet.kick_off_team == new_own_team.team_id;
+            state->our_kick_off = new_packet.kicking_team == new_own_team.team_id;
 
             // Get the new kick off team to emit the team change
-            GameEvents::Context team = new_packet.kick_off_team == new_own_team.team_id
+            GameEvents::Context team = new_packet.kicking_team == new_own_team.team_id
                                            ? GameEvents::Context::Value::TEAM
                                            : GameEvents::Context::Value::OPPONENT;
 
@@ -446,88 +392,18 @@ namespace module::input {
         /*******************************************************************************************
          * Process our team colour
          ******************************************************************************************/
-        if (old_own_team.team_colour != new_own_team.team_colour) {
+        if (old_own_team.field_player_colour != new_own_team.field_player_colour) {
             TeamColour colour =
-                new_own_team.team_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
+                new_own_team.field_player_colour == gamecontroller::TeamColour::BLUE ? TeamColour::BLUE : TeamColour::RED;
             state_changes.emplace_back([this, colour] { emit(std::make_unique<TeamColour>(colour)); });
         }
 
 
         /*******************************************************************************************
-         * Process state/mode changes
+         * Process game phase changes
          ******************************************************************************************/
 
-        if (new_packet.mode != mode && old_packet.mode != gamecontroller::Mode::TIMEOUT
-            && new_packet.mode != gamecontroller::Mode::TIMEOUT) {
-
-            mode = new_packet.mode;
-
-            // Changed modes but not to timeout
-            switch (new_packet.mode) {
-                case gamecontroller::Mode::NORMAL:
-                    state->mode = GameState::Mode::NORMAL;
-                    state_changes.emplace_back(
-                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::NORMAL)); });
-                    break;
-                case gamecontroller::Mode::PENALTY_SHOOTOUT:
-                    state->mode = GameState::Mode::PENALTY_SHOOTOUT;
-                    state_changes.emplace_back(
-                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::PENALTY_SHOOTOUT)); });
-                    break;
-                case gamecontroller::Mode::OVERTIME:
-                    state->mode = GameState::Mode::OVERTIME;
-                    state_changes.emplace_back(
-                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::OVERTIME)); });
-                    break;
-                case gamecontroller::Mode::DIRECT_FREEKICK:
-                    state->mode = GameState::Mode::DIRECT_FREEKICK;
-                    state_changes.emplace_back(
-                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::DIRECT_FREEKICK)); });
-                    break;
-                case gamecontroller::Mode::INDIRECT_FREEKICK:
-                    state->mode = GameState::Mode::INDIRECT_FREEKICK;
-                    state_changes.emplace_back(
-                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::INDIRECT_FREEKICK)); });
-                    break;
-                case gamecontroller::Mode::PENALTYKICK:
-                    state->mode = GameState::Mode::PENALTYKICK;
-                    state_changes.emplace_back(
-                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::PENALTYKICK)); });
-                    break;
-                case gamecontroller::Mode::CORNER_KICK:
-                    state->mode = GameState::Mode::CORNER_KICK;
-                    state_changes.emplace_back(
-                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::CORNER_KICK)); });
-                    break;
-                case gamecontroller::Mode::GOAL_KICK:
-                    state->mode = GameState::Mode::GOAL_KICK;
-                    state_changes.emplace_back(
-                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::GOAL_KICK)); });
-                    break;
-                case gamecontroller::Mode::THROW_IN:
-                    state->mode = GameState::Mode::THROW_IN;
-                    state_changes.emplace_back(
-                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::THROW_IN)); });
-                    break;
-                default:
-                    throw std::runtime_error("Invalid mode change");
-                    emit(std::make_unique<GameState::Mode>(state->mode));
-            }
-        }
-
-        if ((state->mode != GameState::Mode::NORMAL && state->mode != GameState::Mode::PENALTY_SHOOTOUT
-             && state->mode != GameState::Mode::OVERTIME)
-            && (new_packet.secondary_state_info[0] != state->secondary_state.team_performing
-                || new_packet.secondary_state_info[1] != state->secondary_state.sub_mode)
-            && new_packet.secondary_state_info[0] != 0) {
-            if (new_packet.secondary_state_info[1] != state->secondary_state.sub_mode) {
-                state_changes.emplace_back([] {});
-            }
-            state->secondary_state.team_performing = new_packet.secondary_state_info[0];
-            state->secondary_state.sub_mode        = new_packet.secondary_state_info[1];
-        }
-
-        if (old_packet.mode != gamecontroller::Mode::TIMEOUT && new_packet.mode == gamecontroller::Mode::TIMEOUT) {
+        if (old_packet.game_phase != gamecontroller::GamePhase::TIMEOUT && new_packet.game_phase == gamecontroller::GamePhase::TIMEOUT) {
 
             // Change the game state to timeout
             auto time = NUClear::clock::now() + std::chrono::seconds(new_packet.secondary_time);
@@ -536,15 +412,15 @@ namespace module::input {
             state->secondary_time = time;
 
             state_changes.emplace_back([this, time] {
-                auto msg   = std::make_unique<GamePhase>();
+                auto msg   = std::make_unique<GameEventPhase>();
                 msg->phase = GameState::Phase::Value::TIMEOUT;
                 msg->ends  = time;
                 emit(msg);
             });
         }
         else if (old_packet.state != new_packet.state
-                 || (old_packet.mode == gamecontroller::Mode::TIMEOUT
-                     && new_packet.mode != gamecontroller::Mode::TIMEOUT)) {
+                 || (old_packet.game_phase == gamecontroller::GamePhase::TIMEOUT
+                     && new_packet.game_phase != gamecontroller::GamePhase::TIMEOUT)) {
 
             // State has changed, process it
             switch (new_packet.state) {
@@ -553,7 +429,7 @@ namespace module::input {
                     state->phase = GameState::Phase::Value::INITIAL;
 
                     state_changes.emplace_back([this] {
-                        auto msg   = std::make_unique<GamePhase>();
+                        auto msg   = std::make_unique<GameEventPhase>();
                         msg->phase = GameState::Phase::Value::INITIAL;
                         emit(msg);
                     });
@@ -573,7 +449,7 @@ namespace module::input {
                     state->secondary_time = time;
 
                     state_changes.emplace_back([this, time] {
-                        auto msg        = std::make_unique<GamePhase>();
+                        auto msg        = std::make_unique<GameEventPhase>();
                         msg->phase      = GameState::Phase::Value::READY;
                         msg->ready_time = time;
                         emit(msg);
@@ -585,7 +461,7 @@ namespace module::input {
                     state->phase = GameState::Phase::Value::SET;
 
                     state_changes.emplace_back([this] {
-                        auto msg   = std::make_unique<GamePhase>();
+                        auto msg   = std::make_unique<GameEventPhase>();
                         msg->phase = GameState::Phase::Value::SET;
                         emit(msg);
                     });
@@ -600,7 +476,7 @@ namespace module::input {
                     state->phase          = GameState::Phase::Value::PLAYING;
 
                     state_changes.emplace_back([this, end_half, ball_free] {
-                        auto msg       = std::make_unique<GamePhase>();
+                        auto msg       = std::make_unique<GameEventPhase>();
                         msg->phase     = GameState::Phase::Value::PLAYING;
                         msg->end_half  = end_half;
                         msg->ball_free = ball_free;
@@ -616,7 +492,7 @@ namespace module::input {
                     state->phase        = GameState::Phase::Value::FINISHED;
 
                     state_changes.emplace_back([this, next_half] {
-                        auto msg       = std::make_unique<GamePhase>();
+                        auto msg       = std::make_unique<GameEventPhase>();
                         msg->phase     = GameState::Phase::Value::FINISHED;
                         msg->next_half = next_half;
                         emit(msg);
@@ -626,6 +502,72 @@ namespace module::input {
             }
 
             emit(std::make_unique<GameState::Phase>(state->phase));
+        }
+
+        /*******************************************************************************************
+         * Process set play changes
+         ******************************************************************************************/
+        if (old_packet.set_play != new_packet.set_play) {
+            set_play = new_packet.set_play;
+            switch (new_packet.set_play) {
+                case gamecontroller::SetPlay::DIRECT_FREE_KICK:
+                    state->mode = GameState::Mode::DIRECT_FREEKICK;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::DIRECT_FREEKICK)); });
+                    break;
+                case gamecontroller::SetPlay::INDIRECT_FREE_KICK:
+                    state->mode = GameState::Mode::INDIRECT_FREEKICK;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::INDIRECT_FREEKICK)); });
+                    break;
+                case gamecontroller::SetPlay::PENALTY_KICK:
+                    state->mode = GameState::Mode::PENALTYKICK;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::PENALTYKICK)); });
+                    break;
+                case gamecontroller::SetPlay::CORNER_KICK:
+                    state->mode = GameState::Mode::CORNER_KICK;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::CORNER_KICK)); });
+                    break;
+                case gamecontroller::SetPlay::GOAL_KICK:
+                    state->mode = GameState::Mode::GOAL_KICK;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::GOAL_KICK)); });
+                    break;
+                case gamecontroller::SetPlay::THROW_IN:
+                    state->mode = GameState::Mode::THROW_IN;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::THROW_IN)); });
+                    break;
+                case gamecontroller::SetPlay::NONE:
+                    state->mode = GameState::Mode::NORMAL;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::NORMAL)); });
+                    break;
+            }
+        }
+
+        if (old_packet.game_phase != new_packet.game_phase) {
+            game_phase = new_packet.game_phase;
+            switch (new_packet.game_phase) {
+                case gamecontroller::GamePhase::PENALTY_SHOOTOUT:
+                    state->mode = GameState::Mode::PENALTY_SHOOTOUT;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::PENALTY_SHOOTOUT)); });
+                    break;
+                case gamecontroller::GamePhase::EXTRA_TIME:
+                    state->mode = GameState::Mode::OVERTIME;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::OVERTIME)); });
+                    break;
+                case gamecontroller::GamePhase::NORMAL:
+                    state->mode = GameState::Mode::NORMAL;
+                    state_changes.emplace_back(
+                        [this] { emit(std::make_unique<GameMode>(GameState::Mode::Value::NORMAL)); });
+                    break;
+                default: break;
+            }
         }
 
         if (!state_changes.empty()) {
@@ -642,16 +584,18 @@ namespace module::input {
     PenaltyReason GameController::get_penalty_reason(const gamecontroller::PenaltyState& penalty_state) {
         // ugly incoming
         switch (penalty_state) {
-            case gamecontroller::PenaltyState::UNPENALISED: return PenaltyReason::UNPENALISED;
-            case gamecontroller::PenaltyState::BALL_MANIPULATION: return PenaltyReason::BALL_MANIPULATION;
-            case gamecontroller::PenaltyState::PHYSICAL_CONTACT: return PenaltyReason::PHYSICAL_CONTACT;
-            case gamecontroller::PenaltyState::ILLEGAL_ATTACK: return PenaltyReason::ILLEGAL_ATTACK;
-            case gamecontroller::PenaltyState::ILLEGAL_DEFENSE: return PenaltyReason::ILLEGAL_DEFENSE;
-            case gamecontroller::PenaltyState::REQUEST_FOR_PICKUP: return PenaltyReason::REQUEST_FOR_PICKUP;
-            case gamecontroller::PenaltyState::REQUEST_FOR_SERVICE: return PenaltyReason::REQUEST_FOR_SERVICE;
-            case gamecontroller::PenaltyState::SUBSTITUTE: return PenaltyReason::SUBSTITUTE;
-            case gamecontroller::PenaltyState::MANUAL: return PenaltyReason::MANUAL;
-            case gamecontroller::PenaltyState::PLAYER_PUSHING: return PenaltyReason::PLAYER_PUSHING;
+            case gamecontroller::PenaltyState::UNPENALISED:         return PenaltyReason::UNPENALISED;
+            case gamecontroller::PenaltyState::ILLEGAL_POSITIONING: return PenaltyReason::ILLEGAL_DEFENSE;
+            case gamecontroller::PenaltyState::MOTION_IN_SET:       return PenaltyReason::PHYSICAL_CONTACT;
+            case gamecontroller::PenaltyState::LOCAL_GAME_STUCK:    return PenaltyReason::MANUAL;
+            case gamecontroller::PenaltyState::INCAPABLE_ROBOT:     return PenaltyReason::REQUEST_FOR_PICKUP;
+            case gamecontroller::PenaltyState::PICK_UP:             return PenaltyReason::REQUEST_FOR_PICKUP;
+            case gamecontroller::PenaltyState::BALL_HOLDING:        return PenaltyReason::BALL_MANIPULATION;
+            case gamecontroller::PenaltyState::LEAVING_THE_FIELD:   return PenaltyReason::REQUEST_FOR_SERVICE;
+            case gamecontroller::PenaltyState::PLAYING_WITH_ARMS_HANDS: return PenaltyReason::ILLEGAL_ATTACK;
+            case gamecontroller::PenaltyState::PLAYER_PUSHING:      return PenaltyReason::PHYSICAL_CONTACT;
+            case gamecontroller::PenaltyState::SENT_OFF:            return PenaltyReason::MANUAL;
+            case gamecontroller::PenaltyState::SUBSTITUTE:          return PenaltyReason::SUBSTITUTE;
             default: throw std::runtime_error("Invalid Penalty State");
         }
     }

--- a/module/input/GameController/src/GameController.cpp
+++ b/module/input/GameController/src/GameController.cpp
@@ -632,7 +632,7 @@ namespace module::input {
     GameState::TeamColour::Value GameController::get_team_colour(const gamecontroller::TeamColour& colour) {
         switch (colour) {
             case gamecontroller::TeamColour::BLUE: return TeamColour::BLUE;
-            case gamecontroller::TeamColour::RED:  return TeamColour::RED;
+            case gamecontroller::TeamColour::RED: return TeamColour::RED;
             // TODO: update GameState.proto TeamColour enum to support all v3 colours
             default: return TeamColour::UNKNOWN;
         }

--- a/module/input/GameController/src/GameController.hpp
+++ b/module/input/GameController/src/GameController.hpp
@@ -77,9 +77,10 @@ namespace module::input {
         [[nodiscard]] const gamecontroller::Team& get_own_team(const gamecontroller::GameControllerPacket& state) const;
         [[nodiscard]] const gamecontroller::Team& get_opponent_team(
             const gamecontroller::GameControllerPacket& state) const;
+        [[nodiscard]] static GameState::TeamColour::Value get_team_colour(
+            const gamecontroller::TeamColour& colour);
         [[nodiscard]] static message::input::GameState::PenaltyReason get_penalty_reason(
             const gamecontroller::PenaltyState& penalty_state);
-
         [[nodiscard]] static std::string ip_address_int_to_string(const uint32_t& ip_addr);
 
     public:

--- a/module/input/GameController/src/GameController.hpp
+++ b/module/input/GameController/src/GameController.hpp
@@ -92,8 +92,8 @@ namespace module::input {
 
         /// @brief Processes a new GameController packet and emits state changes
         void process(const message::input::GameState& old_game_state,
-                    const gamecontroller::GameControllerPacket& old_packet,
-                    const gamecontroller::GameControllerPacket& new_packet);
+                     const gamecontroller::GameControllerPacket& old_packet,
+                     const gamecontroller::GameControllerPacket& new_packet);
 
         /// @brief Sends a reply packet to the GameController
         void send_reply_message();
@@ -106,8 +106,7 @@ namespace module::input {
             const gamecontroller::GameControllerPacket& state) const;
 
         /// @brief Converts a gamecontroller::TeamColour to a GameState::TeamColour::Value
-        [[nodiscard]] static GameState::TeamColour::Value get_team_colour(
-            const gamecontroller::TeamColour& colour);
+        [[nodiscard]] static GameState::TeamColour::Value get_team_colour(const gamecontroller::TeamColour& colour);
 
         /// @brief Converts a gamecontroller::PenaltyState to a GameState::PenaltyReason
         [[nodiscard]] static message::input::GameState::PenaltyReason get_penalty_reason(

--- a/module/input/GameController/src/GameController.hpp
+++ b/module/input/GameController/src/GameController.hpp
@@ -51,39 +51,73 @@ namespace module::input {
         static constexpr const uint ACTIVE_PLAYERS_PER_TEAM = 4;
         static constexpr const uint NUM_TEAMS               = 2;
 
-        uint receive_port;
-        uint send_port;
-        uint TEAM_ID;
-        uint PLAYER_ID;
+        /// @brief Port to receive GameController packets on
+        uint receive_port{0};
+
+        /// @brief Port to send reply packets to the GameController on
+        uint send_port{0};
+
+        /// @brief Team ID of the robot's team
+        uint TEAM_ID{0};
+
+        /// @brief Player ID of this robot
+        uint PLAYER_ID{0};
 
         /// @brief The address to use to send reply packets back to game controller (unicast)
-        std::string game_controller_address = "";
+        std::string game_controller_address{};
 
-        std::string udp_filter_address = "";
+        /// @brief Optional IP address to filter incoming packets by source, ignoring all others if set
+        std::string udp_filter_address{};
+
+        /// @brief Set of IP addresses that have been ignored due to not matching the udp_filter_address
         std::set<std::string> ignored_ip_addresses{};
 
-        bool self_penalised = true;
+        /// @brief Indicates if the current player is penalised
+        bool self_penalised{true};
+
+        /// @brief Handle for our registered UDP receive callback
         ReactionHandle listen_handle;
 
-        gamecontroller::GameControllerPacket packet;
-        gamecontroller::GamePhase game_phase;
-        gamecontroller::SetPlay set_play;
+        /// @brief Latest packet received from the GameController
+        gamecontroller::GameControllerPacket packet{};
 
+        /// @brief Current game phase from the GameController packet
+        gamecontroller::GamePhase game_phase{};
+
+        /// @brief Current set play from the GameController packet
+        gamecontroller::SetPlay set_play{};
+
+        /// @brief Resets the game state to initial values
         void reset_state();
+
+        /// @brief Processes a new GameController packet and emits state changes
         void process(const message::input::GameState& old_game_state,
-                     const gamecontroller::GameControllerPacket& old_packet,
-                     const gamecontroller::GameControllerPacket& new_packet);
+                    const gamecontroller::GameControllerPacket& old_packet,
+                    const gamecontroller::GameControllerPacket& new_packet);
+
+        /// @brief Sends a reply packet to the GameController
         void send_reply_message();
+
+        /// @brief Returns the team from the packet that matches our team ID
         [[nodiscard]] const gamecontroller::Team& get_own_team(const gamecontroller::GameControllerPacket& state) const;
+
+        /// @brief Returns the team from the packet that does not match our team ID
         [[nodiscard]] const gamecontroller::Team& get_opponent_team(
             const gamecontroller::GameControllerPacket& state) const;
+
+        /// @brief Converts a gamecontroller::TeamColour to a GameState::TeamColour::Value
         [[nodiscard]] static GameState::TeamColour::Value get_team_colour(
             const gamecontroller::TeamColour& colour);
+
+        /// @brief Converts a gamecontroller::PenaltyState to a GameState::PenaltyReason
         [[nodiscard]] static message::input::GameState::PenaltyReason get_penalty_reason(
             const gamecontroller::PenaltyState& penalty_state);
+
+        /// @brief Converts an integer IP address to a string
         [[nodiscard]] static std::string ip_address_int_to_string(const uint32_t& ip_addr);
 
     public:
+        /// @brief Called by the powerplant to build and setup the GameController reactor
         explicit GameController(std::unique_ptr<NUClear::Environment> environment);
     };
 }  // namespace module::input

--- a/module/input/GameController/src/GameController.hpp
+++ b/module/input/GameController/src/GameController.hpp
@@ -46,7 +46,7 @@ namespace module::input {
      */
     class GameController : public NUClear::Reactor {
     private:
-        static constexpr const uint SUPPORTED_VERSION       = 12;
+        static constexpr const uint SUPPORTED_VERSION       = 19;
         static constexpr const uint PLAYERS_PER_TEAM        = 6;
         static constexpr const uint ACTIVE_PLAYERS_PER_TEAM = 4;
         static constexpr const uint NUM_TEAMS               = 2;
@@ -66,13 +66,14 @@ namespace module::input {
         ReactionHandle listen_handle;
 
         gamecontroller::GameControllerPacket packet;
-        gamecontroller::Mode mode;
+        gamecontroller::GamePhase game_phase;
+        gamecontroller::SetPlay set_play;
 
         void reset_state();
         void process(const message::input::GameState& old_game_state,
                      const gamecontroller::GameControllerPacket& old_packet,
                      const gamecontroller::GameControllerPacket& new_packet);
-        void send_reply_message(const gamecontroller::ReplyMessage& message);
+        void send_reply_message();
         [[nodiscard]] const gamecontroller::Team& get_own_team(const gamecontroller::GameControllerPacket& state) const;
         [[nodiscard]] const gamecontroller::Team& get_opponent_team(
             const gamecontroller::GameControllerPacket& state) const;

--- a/module/input/GameController/src/GameController.hpp
+++ b/module/input/GameController/src/GameController.hpp
@@ -106,7 +106,8 @@ namespace module::input {
             const gamecontroller::GameControllerPacket& state) const;
 
         /// @brief Converts a gamecontroller::TeamColour to a GameState::TeamColour::Value
-        [[nodiscard]] static GameState::TeamColour::Value get_team_colour(const gamecontroller::TeamColour& colour);
+        [[nodiscard]] static message::input::GameState::TeamColour::Value get_team_colour(
+            const gamecontroller::TeamColour& colour);
 
         /// @brief Converts a gamecontroller::PenaltyState to a GameState::PenaltyReason
         [[nodiscard]] static message::input::GameState::PenaltyReason get_penalty_reason(

--- a/module/input/GameController/src/GameControllerData.hpp
+++ b/module/input/GameController/src/GameControllerData.hpp
@@ -29,131 +29,124 @@
 #define MODULES_INPUT_GAMECONTROLLERDATA_HPP
 
 namespace module::input::gamecontroller {
-    constexpr const size_t MAX_NUM_PLAYERS        = 11;
-    constexpr const size_t SPL_COACH_MESSAGE_SIZE = 253;
+    constexpr const size_t MAX_NUM_PLAYERS        = 20;
     constexpr const char RECEIVE_HEADER[4]        = {'R', 'G', 'm', 'e'};
     constexpr const char RETURN_HEADER[4]         = {'R', 'G', 'r', 't'};
-    constexpr const size_t RETURN_VERSION         = 2;
+    constexpr const size_t RETURN_VERSION         = 4;
 
 #pragma pack(push, 1)
     enum class State : uint8_t { INITIAL = 0, READY = 1, SET = 2, PLAYING = 3, FINISHED = 4 };
 
-    enum class Mode : uint8_t {
+    enum class GamePhase : uint8_t {
         NORMAL            = 0,
         PENALTY_SHOOTOUT  = 1,
-        OVERTIME          = 2,
+        EXTRA_TIME        = 2,
         TIMEOUT           = 3,
-        DIRECT_FREEKICK   = 4,
-        INDIRECT_FREEKICK = 5,
-        PENALTYKICK       = 6,
-        CORNER_KICK       = 7,
-        GOAL_KICK         = 8,
-        THROW_IN          = 9,
     };
 
-    enum class GameType : uint8_t { ROUND_ROBIN = 0, PLAYOFF = 1, DROPIN = 2 };
+    enum class SetPlay : uint8_t {
+        NONE              = 0,
+        DIRECT_FREE_KICK  = 1,
+        INDIRECT_FREE_KICK = 2,
+        PENALTY_KICK      = 3,
+        THROW_IN          = 4,
+        GOAL_KICK         = 5,
+        CORNER_KICK       = 6,
+    };
 
-    enum class TeamColour : uint8_t { BLUE = 0, RED = 1, DROPBALL = 255 };
-
-    enum class ReplyMessage : uint8_t { PENALISED = 0, UNPENALISED = 1, ALIVE = 2 };
+    enum class TeamColour : uint8_t {
+        BLUE   = 0,
+        RED    = 1,
+        YELLOW = 2,
+        BLACK  = 3,
+        WHITE  = 4,
+        GREEN  = 5,
+        ORANGE = 6,
+        PURPLE = 7,
+        BROWN  = 8,
+        GRAY   = 9,
+    };
 
     enum class PenaltyState : uint8_t {
-        // General??
-        UNPENALISED = 0,
-
-        // SPL
-        ILLEGAL_BALL_CONTACT   = 1,
-        PLAYER_PUSHING         = 2,
-        ILLEGAL_MOTION_IN_SET  = 3,
-        INACTIVE_PLAYER        = 4,
-        ILLEGAL_DEFENDER       = 5,
-        LEAVING_THE_FIELD      = 6,
-        KICK_OFF_GOAL          = 7,
-        SPL_REQUEST_FOR_PICKUP = 8,
-        COACH_MOTION           = 9,
-
-        // General??
-        SUBSTITUTE = 14,
-        MANUAL     = 15,
-
-        // HL
-        BALL_MANIPULATION   = 30,
-        PHYSICAL_CONTACT    = 31,
-        ILLEGAL_ATTACK      = 32,
-        ILLEGAL_DEFENSE     = 33,
-        REQUEST_FOR_PICKUP  = 34,
-        REQUEST_FOR_SERVICE = 35,
-
-        // General??
-        UNKNOWN = 255
+        UNPENALISED            = 0,
+        ILLEGAL_POSITIONING    = 1,
+        MOTION_IN_SET          = 2,
+        LOCAL_GAME_STUCK       = 3,
+        INCAPABLE_ROBOT        = 4,
+        PICK_UP                = 5,
+        BALL_HOLDING           = 6,
+        LEAVING_THE_FIELD      = 7,
+        PLAYING_WITH_ARMS_HANDS = 8,
+        PLAYER_PUSHING         = 9,
+        SENT_OFF               = 10,
+        SUBSTITUTE             = 11,
     };
 
     struct Robot {
         PenaltyState penalty_state;   // penalty state of the player
         uint8_t penalised_time_left;  // estimate of time till unpenalised (seconds)
-        uint8_t number_of_warnings;   // number of warnings
-        uint8_t yellow_card_count;    // number of yellow cards
-        uint8_t red_card_count;       // number of red cards
-        bool goal_keeper;             // flags if robot is goal keeper
+        uint8_t warnings;             // number of warnings
+        uint8_t cautions;             // number of cautions (yellow cards)
     };
 
     struct Team {
-        uint8_t team_id;                                         // unique team number
-        TeamColour team_colour;                                  // colour of the team
-        uint8_t score;                                           // team's score
-        uint8_t penalty_shot;                                    // penalty shot counter
-        uint16_t single_shots;                                   // bits represent penalty shot success
-        uint8_t coach_sequence;                                  // sequence number of the coach's message
-        std::array<char, SPL_COACH_MESSAGE_SIZE> coach_message;  // the coach's message to the team
-        Robot coach;                                             // the coach
-        std::array<Robot, MAX_NUM_PLAYERS> players;              // the team's players
+        uint8_t team_id;                            // unique team number
+        TeamColour field_player_colour;             // colour of the field players (TEAM_BLUE, etc)
+        TeamColour goalkeeper_colour;               // colour of the goalkeeper (TEAM_BLUE, etc)
+        uint8_t goalkeeper;                         // player number of the goalkeeper (0-MAX_NUM_PLAYERS)
+        uint8_t score;                              // team's score
+        uint8_t penalty_shot;                       // penalty shot counter
+        uint16_t single_shots;                      // bits represent penalty shot success
+        uint16_t message_budget;                    // remaining team message budget.
+        std::array<Robot, MAX_NUM_PLAYERS> players; // the team's players
     };
 
     struct GameControllerPacket {
-        std::array<char, 4> header;  // header to identify the structure
-        uint16_t version;            // version of the data structure
-        uint8_t packet_number;       // number incremented with each packet sent (with wraparound)
-        uint8_t players_per_team;    // the number of players on a team
-        GameType game_type;          // type of the game (GAME_ROUNDROBIN, GAME_PLAYOFF, GAME_DROPIN)
-        State state;                 // state of the game (STATE_READY, STATE_PLAYING, etc)
-        bool first_half;             // 1 = game in first half, 0 otherwise
-        uint8_t kick_off_team;       // the team number of the next team to kick off or DROPBALL
-        Mode mode;                   // extra state information - (STATE2_NORMAL, STATE2_PENALTYSHOOT, etc)
-        std::array<uint8_t, 4> secondary_state_info;  // Extra info on the secondary state
-        TeamColour drop_in_team;                      // number of team that caused last drop in
-        int16_t drop_in_time;     // number of seconds passed since the last drop in. -1 (0xffff) before first dropin
-        uint16_t secs_remaining;  // estimate of number of seconds remaining in the half
-        uint16_t secondary_time;  // number of seconds shown as secondary time (remaining ready, until free ball, etc)
+        std::array<char, 4> header;   // header to identify the structure
+        uint8_t version;              // version of the data structure
+        uint8_t packet_number;        // number incremented with each packet sent
+        uint8_t players_per_team;     // the number of players on a team
+        uint8_t competition_type;     // type of the competition (small/middle/large)
+        uint8_t stopped;              // 1 = play is currently stopped, 0 otherwise
+        GamePhase game_phase;         // phase of the game
+        State state;                  // state of the game
+        SetPlay set_play;             // active set play
+        bool first_half;              // 1 = game in first half, 0 otherwise
+        uint8_t kicking_team;         // team number of the next team to kick off/free kick
+        int16_t secs_remaining;       // estimate of seconds remaining in the half
+        int16_t secondary_time;       // seconds shown as secondary time
         std::array<Team, 2> teams;
     };
 
     struct GameControllerReplyPacket {
-        std::array<char, 4> header;
-        uint8_t version;
-        uint8_t team;          // team number
-        uint8_t player;        // player number starts with 1
-        ReplyMessage message;  // one of the three messages defined above
+        std::array<char, 4> header;  // "RGrt"
+        uint8_t version;             // RETURN_VERSION
+        uint8_t player;              // player number starts with 1
+        uint8_t team;                // team number
+        uint8_t fallen;              // 1 = fallen, 0 = upright
+        float pose[3];               // x, y, theta in millimeters/radians
+        float ball_age;              // seconds since ball last seen, -1 if never
+        float ball[2];               // ball position relative to robot in millimeters
     };
 #pragma pack(pop)
 
     inline std::ostream& operator<<(std::ostream& os, const Robot& robot) {
         os << "\t\tPenalty state......: " << uint(robot.penalty_state) << std::endl
            << "\t\tPenalised time left: " << uint(robot.penalised_time_left) << std::endl
-           << "\t\tNumber of warnings: " << uint(robot.number_of_warnings) << std::endl
-           << "\t\tYellow Card Count..: " << uint(robot.yellow_card_count) << std::endl
-           << "\t\tRed Card Count.....: " << uint(robot.red_card_count) << std::endl
-           << "\t\tGoalkeeper: " << std::boolalpha << robot.goal_keeper << std::endl;
+           << "\t\tNumber of warnings: " << uint(robot.warnings) << std::endl
+           << "\t\tYellow Card Count..: " << uint(robot.cautions) << std::endl;
         return os;
     }
 
     inline std::ostream& operator<<(std::ostream& os, const Team& team) {
         os << "Team id: " << uint(team.team_id) << std::endl
-           << "\tTeam colour...: " << uint(team.team_colour) << std::endl
-           << "\tScore.........: " << uint(team.score) << std::endl
-           << "\tPenalty shot..: " << uint(team.penalty_shot) << std::endl
-           << "\tSingle shots..: " << uint(team.single_shots) << std::endl
-           << "\tCoach Sequence: " << uint(team.coach_sequence) << std::endl
-           << "\tCoach message.: " << std::string(team.coach_message.data()) << std::endl;
+        << "\tField player colour: " << uint(team.field_player_colour) << std::endl
+        << "\tGoalkeeper colour..: " << uint(team.goalkeeper_colour) << std::endl
+        << "\tGoalkeeper.........: " << uint(team.goalkeeper) << std::endl
+        << "\tScore..............: " << uint(team.score) << std::endl
+        << "\tPenalty shot.......: " << uint(team.penalty_shot) << std::endl
+        << "\tSingle shots.......: " << uint(team.single_shots) << std::endl
+        << "\tMessage budget.....: " << uint(team.message_budget) << std::endl;
 
         for (uint i = 0; i < team.players.size(); i++) {
             os << "\tRobot " << i + 1 << ":" << std::endl << team.players[i] << std::endl;
@@ -163,21 +156,19 @@ namespace module::input::gamecontroller {
 
     inline std::ostream& operator<<(std::ostream& os, const GameControllerPacket& packet) {
         os << "Version.............: " << uint(packet.version) << std::endl
-           << "Packet number.......: " << uint(packet.packet_number) << std::endl
-           << "Players per team....: " << uint(packet.players_per_team) << std::endl
-           << "Game Type...........: " << uint(packet.game_type) << std::endl
-           << "State...............: " << uint(packet.state) << std::endl
-           << "First half..........: " << std::boolalpha << packet.first_half << std::endl
-           << "Kick off team.......: " << uint(packet.kick_off_team) << std::endl
-           << "Mode................: " << uint(packet.mode) << std::endl
-           << "Secondary State Info: "
-           << std::string(packet.secondary_state_info.begin(), packet.secondary_state_info.end()) << std::endl
-           << "Drop in team........: " << uint(packet.drop_in_team) << std::endl
-           << "Drop in time........: " << uint(packet.drop_in_time) << std::endl
-           << "Seconds remaining...: " << uint(packet.secs_remaining) << std::endl
-           << "Secondary time......: " << uint(packet.secondary_time) << std::endl
-           << packet.teams[0] << std::endl
-           << packet.teams[1] << std::endl;
+        << "Packet number.......: " << uint(packet.packet_number) << std::endl
+        << "Players per team....: " << uint(packet.players_per_team) << std::endl
+        << "Competition type....: " << uint(packet.competition_type) << std::endl
+        << "Stopped.............: " << uint(packet.stopped) << std::endl
+        << "Game phase..........: " << uint(packet.game_phase) << std::endl
+        << "State...............: " << uint(packet.state) << std::endl
+        << "Set play............: " << uint(packet.set_play) << std::endl
+        << "First half..........: " << std::boolalpha << packet.first_half << std::endl
+        << "Kicking team........: " << uint(packet.kicking_team) << std::endl
+        << "Seconds remaining...: " << uint(packet.secs_remaining) << std::endl
+        << "Secondary time......: " << uint(packet.secondary_time) << std::endl
+        << packet.teams[0] << std::endl
+        << packet.teams[1] << std::endl;
         return os;
     }
 }  // namespace module::input::gamecontroller

--- a/module/input/GameController/src/GameControllerData.hpp
+++ b/module/input/GameController/src/GameControllerData.hpp
@@ -29,29 +29,29 @@
 #define MODULES_INPUT_GAMECONTROLLERDATA_HPP
 
 namespace module::input::gamecontroller {
-    constexpr const size_t MAX_NUM_PLAYERS        = 20;
-    constexpr const char RECEIVE_HEADER[4]        = {'R', 'G', 'm', 'e'};
-    constexpr const char RETURN_HEADER[4]         = {'R', 'G', 'r', 't'};
-    constexpr const size_t RETURN_VERSION         = 4;
+    constexpr const size_t MAX_NUM_PLAYERS = 20;
+    constexpr const char RECEIVE_HEADER[4] = {'R', 'G', 'm', 'e'};
+    constexpr const char RETURN_HEADER[4]  = {'R', 'G', 'r', 't'};
+    constexpr const size_t RETURN_VERSION  = 4;
 
 #pragma pack(push, 1)
     enum class State : uint8_t { INITIAL = 0, READY = 1, SET = 2, PLAYING = 3, FINISHED = 4 };
 
     enum class GamePhase : uint8_t {
-        NORMAL            = 0,
-        PENALTY_SHOOTOUT  = 1,
-        EXTRA_TIME        = 2,
-        TIMEOUT           = 3,
+        NORMAL           = 0,
+        PENALTY_SHOOTOUT = 1,
+        EXTRA_TIME       = 2,
+        TIMEOUT          = 3,
     };
 
     enum class SetPlay : uint8_t {
-        NONE              = 0,
-        DIRECT_FREE_KICK  = 1,
+        NONE               = 0,
+        DIRECT_FREE_KICK   = 1,
         INDIRECT_FREE_KICK = 2,
-        PENALTY_KICK      = 3,
-        THROW_IN          = 4,
-        GOAL_KICK         = 5,
-        CORNER_KICK       = 6,
+        PENALTY_KICK       = 3,
+        THROW_IN           = 4,
+        GOAL_KICK          = 5,
+        CORNER_KICK        = 6,
     };
 
     enum class TeamColour : uint8_t {
@@ -68,18 +68,18 @@ namespace module::input::gamecontroller {
     };
 
     enum class PenaltyState : uint8_t {
-        UNPENALISED            = 0,
-        ILLEGAL_POSITIONING    = 1,
-        MOTION_IN_SET          = 2,
-        LOCAL_GAME_STUCK       = 3,
-        INCAPABLE_ROBOT        = 4,
-        PICK_UP                = 5,
-        BALL_HOLDING           = 6,
-        LEAVING_THE_FIELD      = 7,
+        UNPENALISED             = 0,
+        ILLEGAL_POSITIONING     = 1,
+        MOTION_IN_SET           = 2,
+        LOCAL_GAME_STUCK        = 3,
+        INCAPABLE_ROBOT         = 4,
+        PICK_UP                 = 5,
+        BALL_HOLDING            = 6,
+        LEAVING_THE_FIELD       = 7,
         PLAYING_WITH_ARMS_HANDS = 8,
-        PLAYER_PUSHING         = 9,
-        SENT_OFF               = 10,
-        SUBSTITUTE             = 11,
+        PLAYER_PUSHING          = 9,
+        SENT_OFF                = 10,
+        SUBSTITUTE              = 11,
     };
 
     struct Robot {
@@ -90,31 +90,31 @@ namespace module::input::gamecontroller {
     };
 
     struct Team {
-        uint8_t team_id;                            // unique team number
-        TeamColour field_player_colour;             // colour of the field players (TEAM_BLUE, etc)
-        TeamColour goalkeeper_colour;               // colour of the goalkeeper (TEAM_BLUE, etc)
-        uint8_t goalkeeper;                         // player number of the goalkeeper (0-MAX_NUM_PLAYERS)
-        uint8_t score;                              // team's score
-        uint8_t penalty_shot;                       // penalty shot counter
-        uint16_t single_shots;                      // bits represent penalty shot success
-        uint16_t message_budget;                    // remaining team message budget.
-        std::array<Robot, MAX_NUM_PLAYERS> players; // the team's players
+        uint8_t team_id;                             // unique team number
+        TeamColour field_player_colour;              // colour of the field players (TEAM_BLUE, etc)
+        TeamColour goalkeeper_colour;                // colour of the goalkeeper (TEAM_BLUE, etc)
+        uint8_t goalkeeper;                          // player number of the goalkeeper (0-MAX_NUM_PLAYERS)
+        uint8_t score;                               // team's score
+        uint8_t penalty_shot;                        // penalty shot counter
+        uint16_t single_shots;                       // bits represent penalty shot success
+        uint16_t message_budget;                     // remaining team message budget.
+        std::array<Robot, MAX_NUM_PLAYERS> players;  // the team's players
     };
 
     struct GameControllerPacket {
-        std::array<char, 4> header;   // header to identify the structure
-        uint8_t version;              // version of the data structure
-        uint8_t packet_number;        // number incremented with each packet sent
-        uint8_t players_per_team;     // the number of players on a team
-        uint8_t competition_type;     // type of the competition (small/middle/large)
-        uint8_t stopped;              // 1 = play is currently stopped, 0 otherwise
-        GamePhase game_phase;         // phase of the game
-        State state;                  // state of the game
-        SetPlay set_play;             // active set play
-        bool first_half;              // 1 = game in first half, 0 otherwise
-        uint8_t kicking_team;         // team number of the next team to kick off/free kick
-        int16_t secs_remaining;       // estimate of seconds remaining in the half
-        int16_t secondary_time;       // seconds shown as secondary time
+        std::array<char, 4> header;  // header to identify the structure
+        uint8_t version;             // version of the data structure
+        uint8_t packet_number;       // number incremented with each packet sent
+        uint8_t players_per_team;    // the number of players on a team
+        uint8_t competition_type;    // type of the competition (small/middle/large)
+        uint8_t stopped;             // 1 = play is currently stopped, 0 otherwise
+        GamePhase game_phase;        // phase of the game
+        State state;                 // state of the game
+        SetPlay set_play;            // active set play
+        bool first_half;             // 1 = game in first half, 0 otherwise
+        uint8_t kicking_team;        // team number of the next team to kick off/free kick
+        int16_t secs_remaining;      // estimate of seconds remaining in the half
+        int16_t secondary_time;      // seconds shown as secondary time
         std::array<Team, 2> teams;
     };
 
@@ -140,13 +140,13 @@ namespace module::input::gamecontroller {
 
     inline std::ostream& operator<<(std::ostream& os, const Team& team) {
         os << "Team id: " << uint(team.team_id) << std::endl
-        << "\tField player colour: " << uint(team.field_player_colour) << std::endl
-        << "\tGoalkeeper colour..: " << uint(team.goalkeeper_colour) << std::endl
-        << "\tGoalkeeper.........: " << uint(team.goalkeeper) << std::endl
-        << "\tScore..............: " << uint(team.score) << std::endl
-        << "\tPenalty shot.......: " << uint(team.penalty_shot) << std::endl
-        << "\tSingle shots.......: " << uint(team.single_shots) << std::endl
-        << "\tMessage budget.....: " << uint(team.message_budget) << std::endl;
+           << "\tField player colour: " << uint(team.field_player_colour) << std::endl
+           << "\tGoalkeeper colour..: " << uint(team.goalkeeper_colour) << std::endl
+           << "\tGoalkeeper.........: " << uint(team.goalkeeper) << std::endl
+           << "\tScore..............: " << uint(team.score) << std::endl
+           << "\tPenalty shot.......: " << uint(team.penalty_shot) << std::endl
+           << "\tSingle shots.......: " << uint(team.single_shots) << std::endl
+           << "\tMessage budget.....: " << uint(team.message_budget) << std::endl;
 
         for (uint i = 0; i < team.players.size(); i++) {
             os << "\tRobot " << i + 1 << ":" << std::endl << team.players[i] << std::endl;
@@ -156,19 +156,19 @@ namespace module::input::gamecontroller {
 
     inline std::ostream& operator<<(std::ostream& os, const GameControllerPacket& packet) {
         os << "Version.............: " << uint(packet.version) << std::endl
-        << "Packet number.......: " << uint(packet.packet_number) << std::endl
-        << "Players per team....: " << uint(packet.players_per_team) << std::endl
-        << "Competition type....: " << uint(packet.competition_type) << std::endl
-        << "Stopped.............: " << uint(packet.stopped) << std::endl
-        << "Game phase..........: " << uint(packet.game_phase) << std::endl
-        << "State...............: " << uint(packet.state) << std::endl
-        << "Set play............: " << uint(packet.set_play) << std::endl
-        << "First half..........: " << std::boolalpha << packet.first_half << std::endl
-        << "Kicking team........: " << uint(packet.kicking_team) << std::endl
-        << "Seconds remaining...: " << uint(packet.secs_remaining) << std::endl
-        << "Secondary time......: " << uint(packet.secondary_time) << std::endl
-        << packet.teams[0] << std::endl
-        << packet.teams[1] << std::endl;
+           << "Packet number.......: " << uint(packet.packet_number) << std::endl
+           << "Players per team....: " << uint(packet.players_per_team) << std::endl
+           << "Competition type....: " << uint(packet.competition_type) << std::endl
+           << "Stopped.............: " << uint(packet.stopped) << std::endl
+           << "Game phase..........: " << uint(packet.game_phase) << std::endl
+           << "State...............: " << uint(packet.state) << std::endl
+           << "Set play............: " << uint(packet.set_play) << std::endl
+           << "First half..........: " << std::boolalpha << packet.first_half << std::endl
+           << "Kicking team........: " << uint(packet.kicking_team) << std::endl
+           << "Seconds remaining...: " << uint(packet.secs_remaining) << std::endl
+           << "Secondary time......: " << uint(packet.secondary_time) << std::endl
+           << packet.teams[0] << std::endl
+           << packet.teams[1] << std::endl;
         return os;
     }
 }  // namespace module::input::gamecontroller

--- a/module/network/RobotCommunication/README.md
+++ b/module/network/RobotCommunication/README.md
@@ -11,13 +11,16 @@ UDP messages that have been emitted by the receiving robot are filtered out.
 
 The information that has been received over UDP is then emitted locally.
 
+Team messages are sent on port `10000 + team_number` with a maximum payload size of 512 bytes. Messages are counted only during
+Ready, Set, and Playing game states toward the 12000 message budget per game.
+
 ## Usage
 
 Add this module to get information about other robots.
 
 ## Consumes
 
-- `message::input::RoboCup` which contains data about the robot, including its state, current position, projected position and its view of the other robots.
+- `message::input::RoboCup` which contains data about the robot, including its state, current position and projected position.
 - `message::behaviour::state::WalkState` which contains data about the robot's current movement.
 - `message::input::GameState` which contains the current state of the game and penalised robots.
 - `message::input::Sensors` which contains data from the robot's sensors, used to calculate its world position.

--- a/module/network/RobotCommunication/data/config/RobotCommunication.yaml
+++ b/module/network/RobotCommunication/data/config/RobotCommunication.yaml
@@ -3,7 +3,9 @@ log_level: INFO
 startup_delay: 3
 ball_timeout: 3
 
-send_port: 10012
-receive_port: 10012
+# Team messages must be sent on port 10000 + team number assigned by TC at competition
+# NUbots team_id is 1 by default in config/teams.yaml of the GameController app, so port is 10001
+send_port: 10001
+receive_port: 10001
 broadcast_ip: "10.1.255.255"
 udp_filter_address: ""

--- a/module/network/RobotCommunication/data/config/RobotCommunication.yaml
+++ b/module/network/RobotCommunication/data/config/RobotCommunication.yaml
@@ -3,7 +3,7 @@ log_level: INFO
 startup_delay: 3
 ball_timeout: 3
 
-send_port: 3737
-receive_port: 3737
+send_port: 10012
+receive_port: 10012
 broadcast_ip: "10.1.255.255"
 udp_filter_address: ""

--- a/module/network/RobotCommunication/data/config/RobotCommunication.yaml
+++ b/module/network/RobotCommunication/data/config/RobotCommunication.yaml
@@ -9,3 +9,9 @@ send_port: 0
 receive_port: 0
 broadcast_ip: "10.1.255.255"
 udp_filter_address: ""
+
+# Maximum payload size in bytes per message
+max_message_size: 512
+
+# Maximum number of team messages per game
+max_messages_per_game: 12000

--- a/module/network/RobotCommunication/data/config/RobotCommunication.yaml
+++ b/module/network/RobotCommunication/data/config/RobotCommunication.yaml
@@ -3,9 +3,9 @@ log_level: INFO
 startup_delay: 3
 ball_timeout: 3
 
-# Team messages must be sent on port 10000 + team number assigned by TC at competition
-# NUbots team_id is 1 by default in config/teams.yaml of the GameController app, so port is 10001
-send_port: 10001
-receive_port: 10001
+# Team message port. Set to 0 to auto-compute as 10000 + team_id from GlobalConfig
+# Override with a specific value if TC assigns a different team number at competition
+send_port: 0
+receive_port: 0
 broadcast_ip: "10.1.255.255"
 udp_filter_address: ""

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -72,14 +72,15 @@ namespace module::network {
                 // Ball timeout to use the ball position
                 cfg.ball_timeout = std::chrono::seconds(config["ball_timeout"].as<int>());
                 // Maximum message size and count
-                cfg.max_message_size     = config["max_message_size"].as<uint>();
+                cfg.max_message_size      = config["max_message_size"].as<uint>();
                 cfg.max_messages_per_game = config["max_messages_per_game"].as<uint>();
 
                 // Compute ports as 10000 + team_id unless overridden in config
                 const uint configured_send_port = config["send_port"].as<uint>();
                 cfg.send_port = (configured_send_port != 0) ? configured_send_port : 10000 + global_config.team_id;
                 const uint configured_receive_port = config["receive_port"].as<uint>();
-                const uint new_receive_port = (configured_receive_port != 0) ? configured_receive_port : 10000 + global_config.team_id;
+                const uint new_receive_port =
+                    (configured_receive_port != 0) ? configured_receive_port : 10000 + global_config.team_id;
 
                 // Need to determine broadcast ip
                 cfg.broadcast_ip = config["broadcast_ip"].as<std::string>("");
@@ -294,7 +295,11 @@ namespace module::network {
                 // Check serialised size before sending
                 auto payload = NUClear::util::serialise::Serialise<RoboCup>::serialise(*msg);
                 if (payload.size() > cfg.max_message_size) {
-                    log<WARN>("RoboCup message size", payload.size(), "bytes exceeds", cfg.max_message_size, "byte limit");
+                    log<WARN>("RoboCup message size",
+                              payload.size(),
+                              "bytes exceeds",
+                              cfg.max_message_size,
+                              "byte limit");
                 }
                 else {
                     log<DEBUG>("RoboCup message size:", payload.size(), "bytes");

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -75,22 +75,26 @@ namespace module::network {
                 // Ball timeout to use the ball position
                 cfg.ball_timeout = std::chrono::seconds(config["ball_timeout"].as<int>());
 
-                // Need to determine send and receive ports
-                cfg.send_port = config["send_port"].as<uint>();
+                // Compute ports as 10000 + team_id unless overridden in config
+                const uint configured_send_port = config["send_port"].as<uint>();
+                cfg.send_port = (configured_send_port != 0) ? configured_send_port : 10000 + global_config.team_id;
+                const uint configured_receive_port = config["receive_port"].as<uint>();
+                const uint new_receive_port = (configured_receive_port != 0) ? configured_receive_port : 10000 + global_config.team_id;
+
                 // Need to determine broadcast ip
                 cfg.broadcast_ip = config["broadcast_ip"].as<std::string>("");
                 // Need to determine optional filtering packets
                 cfg.udp_filter_address = config["udp_filter_address"].as<std::string>("");
 
                 // If we are changing ports (the port starts at 0 so this should start it the first time)
-                if (config["receive_port"].as<uint>() != cfg.receive_port) {
+                if (new_receive_port != cfg.receive_port) {
                     // If we have an old binding, then unbind it
                     // The port starts at 0 so this should work
                     if (cfg.receive_port != 0) {
                         listen_handle.unbind();
                     }
 
-                    cfg.receive_port = config["receive_port"].as<uint>();
+                    cfg.receive_port = new_receive_port;
 
                     // Bind our new handle
                     std::tie(listen_handle, std::ignore, std::ignore) =

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -37,7 +37,6 @@
 #include "message/input/Sensors.hpp"
 #include "message/localisation/Ball.hpp"
 #include "message/localisation/Field.hpp"
-#include "message/localisation/Robot.hpp"
 #include "message/planning/WalkPath.hpp"
 #include "message/purpose/Purpose.hpp"
 #include "message/skill/Kick.hpp"
@@ -53,10 +52,8 @@ namespace module::network {
     using message::input::Sensors;
     using message::localisation::Ball;
     using message::localisation::Field;
-    using message::localisation::Robots;
     using message::planning::WalkTo;
     using message::purpose::Purpose;
-    using message::purpose::SoccerPosition;
     using message::skill::Kick;
     using message::support::GlobalConfig;
     using utility::math::euler::mat_to_rpy_intrinsic;
@@ -179,7 +176,6 @@ namespace module::network {
            Optional<With<GameState>>,
            Optional<With<Purpose>>,
            Optional<With<WalkTo>>,
-           Optional<With<Robots>>,
            With<GlobalConfig>>()
             .then([this](const std::shared_ptr<const Ball>& loc_ball,
                          const std::shared_ptr<const WalkState>& walk_state,
@@ -189,7 +185,6 @@ namespace module::network {
                          const std::shared_ptr<const GameState>& game_state,
                          const std::shared_ptr<const Purpose>& purpose,
                          const std::shared_ptr<const WalkTo>& walk_to,
-                         // const std::shared_ptr<const Robots>& robot_localisation,
                          const GlobalConfig& config) {
                 auto msg = std::make_unique<RoboCup>();
 

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -74,6 +74,9 @@ namespace module::network {
                 cfg.startup_delay = config["startup_delay"].as<int>();
                 // Ball timeout to use the ball position
                 cfg.ball_timeout = std::chrono::seconds(config["ball_timeout"].as<int>());
+                // Maximum message size and count
+                cfg.max_message_size     = config["max_message_size"].as<uint>();
+                cfg.max_messages_per_game = config["max_messages_per_game"].as<uint>();
 
                 // Compute ports as 10000 + team_id unless overridden in config
                 const uint configured_send_port = config["send_port"].as<uint>();
@@ -286,47 +289,6 @@ namespace module::network {
                     msg->ball.velocity = (loc_ball->vBw).cast<float>();
                 }
 
-                // // Where the robot thinks the other robots are.
-                // if (robot_localisation && field) {
-
-                //     // Iterate through robots detected by localisation
-                //     for (const auto& local_bot : robot_localisation->robots) {
-                //         // Create new robot message
-                //         message::input::Robot rc_robot;
-
-                //         // Assign player ID from purpose
-                //         rc_robot.player_id = local_bot.purpose.player_id;
-
-                //         // Convert world to field coords
-                //         Eigen::Vector3d rRFf = field->Hfw * local_bot.rRWw;
-
-                //         // Store 2D position (x, y) and set (z) to 0
-                //         rc_robot.position     = rRFf.cast<float>();
-                //         rc_robot.position.z() = 0.0f;
-
-                //         // Check if covariance matrix is valid
-                //         // Initialise with zeros
-                //         rc_robot.covariance = Eigen::Matrix3f::Zero();
-                //         if (local_bot.covariance.rows() >= 2 && local_bot.covariance.cols() >= 2) {
-                //             rc_robot.covariance.block<2, 2>(0, 0) =
-                //                 local_bot.covariance.block<2, 2>(0, 0).cast<float>();
-                //         }
-
-                //         if (local_bot.teammate) {
-                //             rc_robot.team = msg->current_pose.team;
-                //         }
-                //         else {
-                //             rc_robot.team = msg->current_pose.team == message::input::Team::BLUE
-                //                                 ? message::input::Team::RED
-                //                                 : message::input::Team::BLUE;
-                //         }
-
-                //         // Add robot information to list of other robots in message
-                //         msg->others.push_back(std::move(rc_robot));
-                //     }
-                // }
-
-
                 // Current purpose (soccer position) of the Robot
                 if (purpose) {
                     msg->purpose = *purpose;
@@ -336,21 +298,25 @@ namespace module::network {
 
                 // Check serialised size before sending
                 auto payload = NUClear::util::serialise::Serialise<RoboCup>::serialise(*msg);
-                if (payload.size() > 512) {
-                    log<WARN>("RoboCup message size", payload.size(), "bytes exceeds 512 byte limit");
+                if (payload.size() > cfg.max_message_size) {
+                    log<WARN>("RoboCup message size", payload.size(), "bytes exceeds", cfg.max_message_size, "byte limit");
                 }
                 else {
                     log<DEBUG>("RoboCup message size:", payload.size(), "bytes");
                 }
 
-                // Only count messages during Ready, Set, and Playing states per 2026 rules
+                // Only count messages during Ready, Set, and Playing states
                 if (game_state) {
                     const bool is_counting_state = game_state->phase == GameState::Phase::READY
                                                    || game_state->phase == GameState::Phase::SET
                                                    || game_state->phase == GameState::Phase::PLAYING;
                     if (is_counting_state) {
+                        if (messages_sent >= cfg.max_messages_per_game) {
+                            log<WARN>("Message budget exhausted, dropping packet");
+                            return;
+                        }
                         messages_sent++;
-                        log<DEBUG>("Messages sent this game:", messages_sent, "/ 12000");
+                        log<DEBUG>("Messages sent this game:", messages_sent, "/ ", cfg.max_messages_per_game);
                     }
                 }
 

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -152,6 +152,16 @@ namespace module::network {
             emit<Scope::DELAY>(std::make_unique<StartupDelay>(), std::chrono::seconds(cfg.startup_delay));
         });
 
+        on<Trigger<GameState>>().then([this](const GameState& game_state) {
+            // Reset message counter when a new game ends
+            if (game_state.phase == GameState::Phase::FINISHED) {
+                if (messages_sent > 0) {
+                    log<INFO>("Game ended. Total messages sent:", messages_sent);
+                    messages_sent = 0;
+                }
+            }
+        });
+
         on<Every<2, Per<std::chrono::seconds>>,
            With<StartupDelay>,
            Optional<With<Ball>>,
@@ -172,7 +182,7 @@ namespace module::network {
                          const std::shared_ptr<const GameState>& game_state,
                          const std::shared_ptr<const Purpose>& purpose,
                          const std::shared_ptr<const WalkTo>& walk_to,
-                         const std::shared_ptr<const Robots>& robot_localisation,
+                         // const std::shared_ptr<const Robots>& robot_localisation,
                          const GlobalConfig& config) {
                 auto msg = std::make_unique<RoboCup>();
 
@@ -272,45 +282,45 @@ namespace module::network {
                     msg->ball.velocity = (loc_ball->vBw).cast<float>();
                 }
 
-                // Where the robot thinks the other robots are.
-                if (robot_localisation && field) {
+                // // Where the robot thinks the other robots are.
+                // if (robot_localisation && field) {
 
-                    // Iterate through robots detected by localisation
-                    for (const auto& local_bot : robot_localisation->robots) {
-                        // Create new robot message
-                        message::input::Robot rc_robot;
+                //     // Iterate through robots detected by localisation
+                //     for (const auto& local_bot : robot_localisation->robots) {
+                //         // Create new robot message
+                //         message::input::Robot rc_robot;
 
-                        // Assign player ID from purpose
-                        rc_robot.player_id = local_bot.purpose.player_id;
+                //         // Assign player ID from purpose
+                //         rc_robot.player_id = local_bot.purpose.player_id;
 
-                        // Convert world to field coords
-                        Eigen::Vector3d rRFf = field->Hfw * local_bot.rRWw;
+                //         // Convert world to field coords
+                //         Eigen::Vector3d rRFf = field->Hfw * local_bot.rRWw;
 
-                        // Store 2D position (x, y) and set (z) to 0
-                        rc_robot.position     = rRFf.cast<float>();
-                        rc_robot.position.z() = 0.0f;
+                //         // Store 2D position (x, y) and set (z) to 0
+                //         rc_robot.position     = rRFf.cast<float>();
+                //         rc_robot.position.z() = 0.0f;
 
-                        // Check if covariance matrix is valid
-                        // Initialise with zeros
-                        rc_robot.covariance = Eigen::Matrix3f::Zero();
-                        if (local_bot.covariance.rows() >= 2 && local_bot.covariance.cols() >= 2) {
-                            rc_robot.covariance.block<2, 2>(0, 0) =
-                                local_bot.covariance.block<2, 2>(0, 0).cast<float>();
-                        }
+                //         // Check if covariance matrix is valid
+                //         // Initialise with zeros
+                //         rc_robot.covariance = Eigen::Matrix3f::Zero();
+                //         if (local_bot.covariance.rows() >= 2 && local_bot.covariance.cols() >= 2) {
+                //             rc_robot.covariance.block<2, 2>(0, 0) =
+                //                 local_bot.covariance.block<2, 2>(0, 0).cast<float>();
+                //         }
 
-                        if (local_bot.teammate) {
-                            rc_robot.team = msg->current_pose.team;
-                        }
-                        else {
-                            rc_robot.team = msg->current_pose.team == message::input::Team::BLUE
-                                                ? message::input::Team::RED
-                                                : message::input::Team::BLUE;
-                        }
+                //         if (local_bot.teammate) {
+                //             rc_robot.team = msg->current_pose.team;
+                //         }
+                //         else {
+                //             rc_robot.team = msg->current_pose.team == message::input::Team::BLUE
+                //                                 ? message::input::Team::RED
+                //                                 : message::input::Team::BLUE;
+                //         }
 
-                        // Add robot information to list of other robots in message
-                        msg->others.push_back(std::move(rc_robot));
-                    }
-                }
+                //         // Add robot information to list of other robots in message
+                //         msg->others.push_back(std::move(rc_robot));
+                //     }
+                // }
 
 
                 // Current purpose (soccer position) of the Robot
@@ -319,6 +329,26 @@ namespace module::network {
                 }
                 // Override the player ID in the purpose message to be consistent, and in case purpose is not set
                 msg->purpose.player_id = config.player_id;
+
+                // Check serialised size before sending
+                auto payload = NUClear::util::serialise::Serialise<RoboCup>::serialise(*msg);
+                if (payload.size() > 512) {
+                    log<WARN>("RoboCup message size", payload.size(), "bytes exceeds 512 byte limit");
+                }
+                else {
+                    log<DEBUG>("RoboCup message size:", payload.size(), "bytes");
+                }
+
+                // Only count messages during Ready, Set, and Playing states per 2026 rules
+                if (game_state) {
+                    const bool is_counting_state = game_state->phase == GameState::Phase::READY
+                                                   || game_state->phase == GameState::Phase::SET
+                                                   || game_state->phase == GameState::Phase::PLAYING;
+                    if (is_counting_state) {
+                        messages_sent++;
+                        log<DEBUG>("Messages sent this game:", messages_sent, "/ 12000");
+                    }
+                }
 
                 emit<Scope::UDP>(msg, cfg.broadcast_ip, cfg.send_port);
             });

--- a/module/network/RobotCommunication/src/RobotCommunication.hpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.hpp
@@ -56,6 +56,9 @@ namespace module::network {
         /// @brief Handle for incoming UDP message. This will be bound/unbound during (re)connection
         ReactionHandle listen_handle;
 
+        /// @brief Count of messages sent during current game (Ready/Set/Playing states only)
+        uint32_t messages_sent = 0;
+
     public:
         /// @brief Called by the powerplant to build and setup the RobotCommunication reactor.
         explicit RobotCommunication(std::unique_ptr<NUClear::Environment> environment);

--- a/module/network/RobotCommunication/src/RobotCommunication.hpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.hpp
@@ -36,9 +36,9 @@ namespace module::network {
     private:
         /// @brief Stores configuration values
         struct Config {
-            /// @brief The port to communicate over
+            /// @brief The port to send team messages, 0 to auto-compute as 10000 + team_id
             uint send_port = 0;
-            /// @brief The port to communicate over (should match receive port)
+            /// @brief The port to receive team messages, 0 to auto-compute as 10000 + team_id
             uint receive_port = 0;
             /// @brief The IP address used for broadcasting data
             std::string broadcast_ip = "";
@@ -48,6 +48,10 @@ namespace module::network {
             int startup_delay = 0;
             /// @brief The timeout for the ball position to be used
             std::chrono::seconds ball_timeout{0};
+            /// @brief Maximum payload size in bytes per team message
+            uint max_message_size = 512;
+            /// @brief Maximum number of team messages per game (Ready/Set/Playing states)
+            uint max_messages_per_game = 12000;
         } cfg;
 
         /// @brief ignore packets from these IP addresses


### PR DESCRIPTION
This PR implements 2026 HSL communication rule compliance across RobotCommunication and GameController modules.
 
#### RobotCommunication:
- Comment out unused `others` field that was causing packet sizes up to ~800 bytes, exceeding the 512 byte limit
- Add serialised packet size check with WARN log before emit
- Add message counter tracking sends during READY/SET/PLAYING states only, with reset and total log on game FINISHED
- Update team message send/receive port to `10000 + team_number` per 2026 rules
 
#### GameController:
- Migrate from `HlRoboCupGameControlData` version 12 to `RoboCupGameControlData` version 19 to support the 2026 GameController ([release v6.0.0](https://github.com/RoboCup-HumanoidSoccerLeague/GameController/releases/tag/v6.0.0), [header definition](https://github.com/RoboCup-HumanoidSoccerLeague/GameController/blob/v6.0.0/game_controller_msgs/headers/RoboCupGameControlData.h))
- Split old `Mode` enum into `GamePhase` and `SetPlay` to match the new protocol structure
- Remap penalty codes to the new 2026 values
- Remove `coach` message and `drop-in` handling, which were removed from the 2026 protocol
- Update return struct to version 4
- Add `messageBudget` logging for cross-checking against the GC counter

### Pre-PR Checklist:

Have you

- [x] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [x] Updated relevant module READMEs
- [x] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [x] Added a descriptive title and relevant labels to the PR

### Reviewers, Note

Tested with NUWebots (4 robots) and the new 2026 GameController. Robot connects and shows up in GC interface, no 512 byte packet size warnings, message counter matches GC budget countdown, and total messages well under 12000 for a full game.

### Things left to do

- [ ] Update team colour handling: extend `GameState.proto` TeamColour enum for all v3 colours and review team-based filtering in `RobotCommunication` given port-per-team rule
- [ ] Further penalty and set play behaviour testing
- [ ] Update NUbook GameController setup page for 2026 GC
- [ ] Wire up `fallen`, `pose`, `ball` fields in return struct from localisation if required