### PR TITLE
Change nusight robot visualiser to use robot radius, add in radius detector to robot detector

### DIFF
--- a/module/vision/RobotDetector/README.md
+++ b/module/vision/RobotDetector/README.md
@@ -4,7 +4,7 @@
 
 This module uses segmentation information from an image to determine where other robots are in the world.
 
-Clusters of robot detections are each checked to see if they are below or over the field convex hull, if enough points make up the cluster, and if the cluster is fair enough away (as we might classify our own legs/arms and don't want to consider that). Position is determined very basically by taking the closest point to the camera.
+Clusters of robot detections are each checked to see if they are below or over the field convex hull, if enough points make up the cluster, and if the cluster is fair enough away (as we might classify our own legs/arms and don't want to consider that). Position is determined very basically by taking the closest point to the camera. Angular radius of the robot is found using the yaw of the detected robot.
 
 ## Usage
 

--- a/module/vision/RobotDetector/data/config/RobotDetector.yaml
+++ b/module/vision/RobotDetector/data/config/RobotDetector.yaml
@@ -4,4 +4,3 @@ log_level: INFO
 confidence_threshold: 0.8
 cluster_points: 30
 minimum_robot_distance: 0.5
-robot_radius: 0.3

--- a/module/vision/RobotDetector/data/config/RobotDetector.yaml
+++ b/module/vision/RobotDetector/data/config/RobotDetector.yaml
@@ -4,3 +4,4 @@ log_level: INFO
 confidence_threshold: 0.8
 cluster_points: 30
 minimum_robot_distance: 0.5
+radius_cutoff_height: 0.35

--- a/module/vision/RobotDetector/src/RobotDetector.cpp
+++ b/module/vision/RobotDetector/src/RobotDetector.cpp
@@ -151,8 +151,8 @@ namespace module::vision {
                 auto find_yaw   = [](const Eigen::Vector3d v) -> double { return std::atan2(v.y(), v.x()); };
                 auto find_pitch = [](const Eigen::Vector3d v) -> double { return std::atan2(v.z(), v.x()); };
 
-                // If the robot is standing features like outreached hands inflates the detected radius. To avoid this
-                // we cutoff points above stop_pitch to only take the yaw of the robot's bottom part.
+                // Outreached hands can inflate the other robot's detected radius as it uses yaw. To avoid
+                // this we cutoff points above stop_pitch to only take the min/max yaw near the robots feet.
                 double stop_pitch = std::atan2(robot.rRCc.z() + cfg.radius_cutoff_height, robot.rRCc.x());
 
                 auto filtered_cluster = cluster | std::views::filter([&, stop_pitch](int a) {

--- a/module/vision/RobotDetector/src/RobotDetector.cpp
+++ b/module/vision/RobotDetector/src/RobotDetector.cpp
@@ -136,8 +136,6 @@ namespace module::vision {
                 // Transform the point so it is from the camera
                 robot.rRCc = horizon.Hcw * rPWw.col(*closest_element);
 
-                // Eigen::Vector3d closest_point = horizon.Hcw * rPWw.col(*closest_element);
-
                 // Robots that are too close to us are unlikely to be other robots
                 if (robot.rRCc.norm() < cfg.minimum_robot_distance) {
                     log<DEBUG>(fmt::format("Cluster rejected due to distance: {}. Min allowed distance {}.",
@@ -149,15 +147,15 @@ namespace module::vision {
                 // Returns rPCc, vector of point from camera in camera space
                 auto camera_transform = [&](int idx) -> Eigen::Vector3d { return horizon.Hcw * rPWw.col(idx); };
 
+                // Returns yaw in theta, where x is forward, y sideways and z up.
                 auto find_yaw = [](const Eigen::Vector3d v) -> double { return std::atan2(v.y(), v.x()); };
 
                 const auto [min, max] = std::minmax_element(cluster.begin(), cluster.end(), [&](int a, int b) {
                     return find_yaw(camera_transform(a)) < find_yaw(camera_transform(b));
                 });
 
-                double min_yaw = find_yaw(camera_transform(*min));
-                double max_yaw = find_yaw(camera_transform(*max));
-                // double mid_yaw    = (min_yaw + max_yaw) / 2;
+                double min_yaw    = find_yaw(camera_transform(*min));
+                double max_yaw    = find_yaw(camera_transform(*max));
                 double yaw_radius = (max_yaw - min_yaw) / 2;
 
                 log<DEBUG>(fmt::format("Robots yaw radius is {}", yaw_radius));

--- a/module/vision/RobotDetector/src/RobotDetector.cpp
+++ b/module/vision/RobotDetector/src/RobotDetector.cpp
@@ -61,7 +61,6 @@ namespace module::vision {
             cfg.confidence_threshold   = config["confidence_threshold"].as<double>();
             cfg.cluster_points         = config["cluster_points"].as<int>();
             cfg.minimum_robot_distance = config["minimum_robot_distance"].as<double>();
-            cfg.robot_radius           = config["robot_radius"].as<double>();
         });
 
         on<Trigger<GreenHorizon>, Buffer<2>>().then("Visual Mesh", [this](const GreenHorizon& horizon) {

--- a/module/vision/RobotDetector/src/RobotDetector.cpp
+++ b/module/vision/RobotDetector/src/RobotDetector.cpp
@@ -28,7 +28,9 @@
 #include "RobotDetector.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <fmt/format.h>
+#include <limits>
 #include <numeric>
 
 #include "extension/Configuration.hpp"
@@ -134,6 +136,8 @@ namespace module::vision {
                 // Transform the point so it is from the camera
                 robot.rRCc = horizon.Hcw * rPWw.col(*closest_element);
 
+                // Eigen::Vector3d closest_point = horizon.Hcw * rPWw.col(*closest_element);
+
                 // Robots that are too close to us are unlikely to be other robots
                 if (robot.rRCc.norm() < cfg.minimum_robot_distance) {
                     log<DEBUG>(fmt::format("Cluster rejected due to distance: {}. Min allowed distance {}.",
@@ -142,8 +146,24 @@ namespace module::vision {
                     continue;
                 }
 
-                // Should be changed to the average confidence of the robot
-                robot.radius = cfg.robot_radius;
+                // Returns rPCc, vector of point from camera in camera space
+                auto camera_transform = [&](int idx) -> Eigen::Vector3d { return horizon.Hcw * rPWw.col(idx); };
+
+                auto find_yaw = [](const Eigen::Vector3d v) -> double { return std::atan2(v.y(), v.x()); };
+
+                const auto [min, max] = std::minmax_element(cluster.begin(), cluster.end(), [&](int a, int b) {
+                    return find_yaw(camera_transform(a)) < find_yaw(camera_transform(b));
+                });
+
+                double min_yaw = find_yaw(camera_transform(*min));
+                double max_yaw = find_yaw(camera_transform(*max));
+                // double mid_yaw    = (min_yaw + max_yaw) / 2;
+                double yaw_radius = (max_yaw - min_yaw) / 2;
+
+                log<DEBUG>(fmt::format("Robots yaw radius is {}", yaw_radius));
+
+                robot.radius = std::cos(yaw_radius);  // Robot radius is in cos(theta)
+
                 robots->robots.push_back(std::move(robot));
             }
 

--- a/module/vision/RobotDetector/src/RobotDetector.cpp
+++ b/module/vision/RobotDetector/src/RobotDetector.cpp
@@ -30,8 +30,8 @@
 #include <algorithm>
 #include <cmath>
 #include <fmt/format.h>
-#include <limits>
 #include <numeric>
+#include <ranges>
 
 #include "extension/Configuration.hpp"
 
@@ -61,6 +61,7 @@ namespace module::vision {
             cfg.confidence_threshold   = config["confidence_threshold"].as<double>();
             cfg.cluster_points         = config["cluster_points"].as<int>();
             cfg.minimum_robot_distance = config["minimum_robot_distance"].as<double>();
+            cfg.radius_cutoff_height   = config["radius_cutoff_height"].as<double>();
         });
 
         on<Trigger<GreenHorizon>, Buffer<2>>().then("Visual Mesh", [this](const GreenHorizon& horizon) {
@@ -146,18 +147,28 @@ namespace module::vision {
                 // Returns rPCc, vector of point from camera in camera space
                 auto camera_transform = [&](int idx) -> Eigen::Vector3d { return horizon.Hcw * rPWw.col(idx); };
 
-                // Returns yaw in theta, where x is forward, y sideways and z up.
-                auto find_yaw = [](const Eigen::Vector3d v) -> double { return std::atan2(v.y(), v.x()); };
+                // Where x is forward, y sideways and z up.
+                auto find_yaw   = [](const Eigen::Vector3d v) -> double { return std::atan2(v.y(), v.x()); };
+                auto find_pitch = [](const Eigen::Vector3d v) -> double { return std::atan2(v.z(), v.x()); };
 
-                const auto [min, max] = std::minmax_element(cluster.begin(), cluster.end(), [&](int a, int b) {
-                    return find_yaw(camera_transform(a)) < find_yaw(camera_transform(b));
-                });
+                // If the robot is standing features like outreached hands inflates the detected radius. To avoid this
+                // we cutoff points above stop_pitch to only take the yaw of the robot's bottom part.
+                double stop_pitch = std::atan2(robot.rRCc.z() + cfg.radius_cutoff_height, robot.rRCc.x());
+
+                auto filtered_cluster = cluster | std::views::filter([&, stop_pitch](int a) {
+                                            return find_pitch(camera_transform(a)) < stop_pitch;
+                                        });
+
+                const auto [min, max] =
+                    std::ranges::minmax_element(filtered_cluster.begin(), filtered_cluster.end(), [&](int a, int b) {
+                        return find_yaw(camera_transform(a)) < find_yaw(camera_transform(b));
+                    });
 
                 double min_yaw    = find_yaw(camera_transform(*min));
                 double max_yaw    = find_yaw(camera_transform(*max));
                 double yaw_radius = (max_yaw - min_yaw) / 2;
 
-                log<DEBUG>(fmt::format("Robots yaw radius is {}", yaw_radius));
+                log<DEBUG>(fmt::format("Robot's detected radius is {}", yaw_radius));
 
                 robot.radius = std::cos(yaw_radius);  // Robot radius is in cos(theta)
 

--- a/module/vision/RobotDetector/src/RobotDetector.hpp
+++ b/module/vision/RobotDetector/src/RobotDetector.hpp
@@ -42,8 +42,6 @@ namespace module::vision {
             int cluster_points = 0;
             /// @brief The minimum distance a robot can be to be considered a robot, to exclude the self robot
             double minimum_robot_distance = 0.0;
-            /// @brief Assumed radius of robots
-            double robot_radius = 0.0;
         } cfg;
 
     public:

--- a/module/vision/RobotDetector/src/RobotDetector.hpp
+++ b/module/vision/RobotDetector/src/RobotDetector.hpp
@@ -42,6 +42,8 @@ namespace module::vision {
             int cluster_points = 0;
             /// @brief The minimum distance a robot can be to be considered a robot, to exclude the self robot
             double minimum_robot_distance = 0.0;
+            /// @brief The cutoff height in m for points that are considered when detecting a robot's radius
+            double radius_cutoff_height = 0.0;
         } cfg;
 
     public:

--- a/module/vision/RobotDetector/src/RobotDetector.hpp
+++ b/module/vision/RobotDetector/src/RobotDetector.hpp
@@ -42,7 +42,7 @@ namespace module::vision {
             int cluster_points = 0;
             /// @brief The minimum distance a robot can be to be considered a robot, to exclude the self robot
             double minimum_robot_distance = 0.0;
-            /// @brief The cutoff height in m for points that are considered when detecting a robot's radius
+            /// @brief The cutoff height in m for points considered when detecting a robot's radius
             double radius_cutoff_height = 0.0;
         } cfg;
 

--- a/nusight2/src/client/components/camera/objects/line_projection.ts
+++ b/nusight2/src/client/components/camera/objects/line_projection.ts
@@ -4,6 +4,7 @@ import { Vector2 } from "../../../../shared/math/vector2";
 import { Vector3 } from "../../../../shared/math/vector3";
 import { Vector4 } from "../../../../shared/math/vector4";
 import { mesh } from "../../three/builders";
+import { group } from "../../three/builders";
 import { planeGeometry } from "../../three/builders";
 import { rawShader } from "../../three/builders";
 import { shaderMaterial } from "../../three/builders";
@@ -64,6 +65,32 @@ export class LineProjection {
     const start = Vector3.fromThree(axis.toThree().applyAxisAngle(orth.toThree(), Math.acos(radius)));
     return this.coneSegment({ axis, start, end: start, color, lineWidth });
   }
+
+  // Draw a closed loop by connecting successive rays with projected great-circle arcs
+  readonly rayLoop = group(({ rays, color, lineWidth }: { rays: Vector3[]; color: Vector4; lineWidth: number}) => {
+    if (rays.length < 2) {
+      return undefined;
+    }
+
+    const segmentCount = rays.length;
+
+    // For each sequential ray create an arc between them
+    const children = new Array(segmentCount).fill(0).map((_, i) => {
+      const start = rays[i];
+      const end = rays[(i + 1) % segmentCount];
+
+      const cross = new THREE.Vector3().crossVectors(start.toThree(), end.toThree());
+      // If the start and end are nearly collinear then segment plane is ill defined.
+      if (cross.lengthSq() < 1e-12) {
+        return false;
+      }
+
+      const axis = Vector3.fromThree(cross.normalize());
+      return this.coneSegment({ axis, start, end, color, lineWidth});
+    });
+
+    return { children };
+  });
 
   readonly coneSegment = mesh((segment: ConeSegment) => ({
     geometry: LineProjection.geometry(),

--- a/nusight2/src/client/components/camera/objects/line_projection.ts
+++ b/nusight2/src/client/components/camera/objects/line_projection.ts
@@ -67,7 +67,7 @@ export class LineProjection {
   }
 
   // Draw a closed loop by connecting successive rays with projected great-circle arcs
-  readonly rayLoop = group(({ rays, color, lineWidth }: { rays: Vector3[]; color: Vector4; lineWidth: number}) => {
+  readonly rayLoop = group(({ rays, color, lineWidth }: { rays: Vector3[]; color: Vector4; lineWidth: number }) => {
     if (rays.length < 2) {
       return undefined;
     }
@@ -86,7 +86,7 @@ export class LineProjection {
       }
 
       const axis = Vector3.fromThree(cross.normalize());
-      return this.coneSegment({ axis, start, end, color, lineWidth});
+      return this.coneSegment({ axis, start, end, color, lineWidth });
     });
 
     return { children };

--- a/nusight2/src/client/components/vision/network.ts
+++ b/nusight2/src/client/components/vision/network.ts
@@ -132,6 +132,7 @@ export class VisionNetwork {
       timestamp: TimestampObject.toSeconds(timestamp),
       Hcw: Matrix4.from(Hcw),
       rRCc: Vector3.from(robot.rRCc),
+      radius: robot.radius ?? 0.9999,
     }));
   }
 

--- a/nusight2/src/client/components/vision/vision_camera/other_robots.ts
+++ b/nusight2/src/client/components/vision/vision_camera/other_robots.ts
@@ -15,6 +15,7 @@ export interface OtherRobotsModel {
   readonly timestamp: number;
   readonly Hcw: Matrix4;
   readonly rRCc: Vector3;
+  readonly radius: number;
 }
 
 export class OtherRobotsViewModel {
@@ -45,14 +46,35 @@ export class OtherRobotsViewModel {
     const Hwc = new THREE.Matrix4().copy(m.Hcw.toThree()).invert();
     const Hcc = Matrix4.fromThree(this.params.Hcw.toThree().multiply(Hwc));
 
-    // Transform the axis so that it is in the perspective of the latest camera image.
-    const axis = Vector3.fromThree(m.rRCc.toThree().applyMatrix4(Hcc.toThree())).normalize();
+    // Transform the robot centre so it is in the perspective of the latest camera image.
+    const rRCc = Vector3.fromThree(m.rRCc.toThree().applyMatrix4(Hcc.toThree()));
+    const Rcw = new THREE.Matrix3().setFromMatrix4(this.params.Hcw.toThree());
 
-    return this.lineProjection.cone({
-      axis,
-      radius: 0.999,
+    // We get normal to ground in world space, then view the normal to ground in camera space
+    const groundNormalC = new THREE.Vector3(0, 0, 1).applyMatrix3(Rcw).normalize();
+
+    // Build an orthonormal basis, spanning the ground plane in camera coordinates.
+    const basisSeed = Math.abs(groundNormalC.x) < 0.9 ? new THREE.Vector3(1, 0, 0) : new THREE.Vector3(0, 1, 0);
+    const u = new THREE.Vector3().crossVectors(groundNormalC, basisSeed).normalize();
+    const v = new THREE.Vector3().crossVectors(groundNormalC, u).normalize();
+
+    // Sample points on a 3D circle (robots footprint)
+    const raySamples = 16;
+    const angleDelta = (2 * Math.PI) / raySamples;
+    const centre = rRCc.normalize().toThree();
+    const rays = new Array(raySamples).fill(0).map((_, i) => {
+      const t = i * angleDelta;
+      const pointC = centre
+        .clone()
+        .add(u.clone().multiplyScalar(Math.acos(m.radius) * Math.cos(t)))
+        .add(v.clone().multiplyScalar(Math.acos(m.radius) * Math.sin(t)));
+      return Vector3.fromThree(pointC.normalize());
+    });
+
+    return this.lineProjection.rayLoop({
+      rays,
       color: ROBOT_COLOUR,
-      lineWidth: 8,
+      lineWidth: 4,
     });
   });
 }

--- a/nusight2/src/client/components/vision/vision_camera/other_robots.ts
+++ b/nusight2/src/client/components/vision/vision_camera/other_robots.ts
@@ -59,7 +59,7 @@ export class OtherRobotsViewModel {
     const v = new THREE.Vector3().crossVectors(groundNormalC, u).normalize();
 
     // Sample points on a 3D circle (robots footprint)
-    const raySamples = 16;
+    const raySamples = 32;
     const angleDelta = (2 * Math.PI) / raySamples;
     const centre = rRCc.normalize().toThree();
     const rays = new Array(raySamples).fill(0).map((_, i) => {

--- a/nusight2/src/client/components/vision/vision_camera/other_robots.ts
+++ b/nusight2/src/client/components/vision/vision_camera/other_robots.ts
@@ -72,7 +72,7 @@ export class OtherRobotsViewModel {
     });
 
     return this.lineProjection.rayLoop({
-      rays,
+      rays: rays,
       color: ROBOT_COLOUR,
       lineWidth: 4,
     });


### PR DESCRIPTION
Previously the angular radius of robots outputted from RobotDetector used a hardcoded cos(robot_radius_in_degrees) = 0.3 (~70 degrees) which hasn't lead to bugs yet since robot radius isn't actually used for anything yet. This adds a robot radius detector and changes nusight to show the "footprint" of a detected robot. nusight currently shows a circle from the cameras view with a hardcoded radius, where axis is the point detection of the robot. Not too useful right now but should help with later stuff.

Image with the yolo robot detection, can see the added circle. 
<img width="761" height="559" alt="pasted file" src="https://github.com/user-attachments/assets/e90d64b3-a84e-4a27-a5c5-02b214a8be32" />

Image with the RobotDetector (visual mesh) point and radius detection. Is considering the robots extended arm so looks big
<img width="315" height="233" alt="pasted file2" src="https://github.com/user-attachments/assets/d338331d-a79d-4c60-8f03-8a0cd5720411" />

### Pre-PR Checklist:

Have you

- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [ ] Added a descriptive title and relevant labels to the PR

### Reviewers, Note

Probably a good idea to change the point estimate for robot detection, can see its kindof iffy for both since it uses the front of the detection but thats probably a job for a later pr