### PR TITLE
Update team colour handling 

### DIFF
--- a/module/input/GameController/src/GameController.cpp
+++ b/module/input/GameController/src/GameController.cpp
@@ -633,7 +633,14 @@ namespace module::input {
         switch (colour) {
             case gamecontroller::TeamColour::BLUE: return TeamColour::BLUE;
             case gamecontroller::TeamColour::RED: return TeamColour::RED;
-            // TODO: update GameState.proto TeamColour enum to support all v3 colours
+            case gamecontroller::TeamColour::YELLOW: return TeamColour::YELLOW;
+            case gamecontroller::TeamColour::BLACK: return TeamColour::BLACK;
+            case gamecontroller::TeamColour::WHITE: return TeamColour::WHITE;
+            case gamecontroller::TeamColour::GREEN: return TeamColour::GREEN;
+            case gamecontroller::TeamColour::ORANGE: return TeamColour::ORANGE;
+            case gamecontroller::TeamColour::PURPLE: return TeamColour::PURPLE;
+            case gamecontroller::TeamColour::BROWN: return TeamColour::BROWN;
+            case gamecontroller::TeamColour::GRAY: return TeamColour::GRAY;
             default: return TeamColour::UNKNOWN;
         }
     }

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -126,23 +126,9 @@ namespace module::network {
                                 bool own_player_message =
                                     global_config.player_id == incoming_msg.current_pose.player_id;
 
-                                // If there is game state information, get the colour
-                                message::input::Team team_colour = message::input::Team::UNKNOWN_TEAM;
-                                if (game_state) {
-                                    switch (int(game_state->team.team_colour)) {
-                                        case GameState::TeamColour::BLUE:
-                                            team_colour = message::input::Team::BLUE;
-                                            break;
-                                        case GameState::TeamColour::RED: team_colour = message::input::Team::RED; break;
-                                        default: team_colour = message::input::Team::UNKNOWN_TEAM;
-                                    }
-                                }
-
-                                // Check if the incoming message is from the same team
-                                bool own_team_message = team_colour == incoming_msg.current_pose.team;
-
-                                // Filter out messages from ourselves and from other teams
-                                if (!own_player_message && own_team_message) {
+                                // Port-per-team ensures only teammates broadcast on this port
+                                // Filter out messages from ourselves only
+                                if (!own_player_message) {
                                     log<DEBUG>("Message received from teammate ID",
                                                incoming_msg.current_pose.player_id);
                                     emit(std::make_unique<RoboCup>(std::move(incoming_msg)));

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -99,9 +99,8 @@ namespace module::network {
 
                     // Bind our new handle
                     std::tie(listen_handle, std::ignore, std::ignore) =
-                        on<UDP::Broadcast, Optional<With<GameState>>, Single>(cfg.receive_port)
-                            .then([this, &global_config](const UDP::Packet& p,
-                                                         const std::shared_ptr<const GameState>& game_state) {
+                        on<UDP::Broadcast, Single>(cfg.receive_port)
+                            .then([this, &global_config](const UDP::Packet& p) {
                                 std::string remote_addr = p.remote.address;
 
                                 // Apply filtering of packets if udp_filter_address is set in config
@@ -206,6 +205,14 @@ namespace module::network {
                     switch (int(game_state->team.team_colour)) {
                         case GameState::TeamColour::BLUE: msg->current_pose.team = message::input::Team::BLUE; break;
                         case GameState::TeamColour::RED: msg->current_pose.team = message::input::Team::RED; break;
+                        case GameState::TeamColour::YELLOW:msg->current_pose.team = message::input::Team::YELLOW; break;
+                        case GameState::TeamColour::BLACK:msg->current_pose.team = message::input::Team::BLACK; break;
+                        case GameState::TeamColour::WHITE:msg->current_pose.team = message::input::Team::WHITE; break;
+                        case GameState::TeamColour::GREEN:msg->current_pose.team = message::input::Team::GREEN; break;
+                        case GameState::TeamColour::ORANGE:msg->current_pose.team = message::input::Team::ORANGE; break;
+                        case GameState::TeamColour::PURPLE:msg->current_pose.team = message::input::Team::PURPLE; break;
+                        case GameState::TeamColour::BROWN:msg->current_pose.team = message::input::Team::BROWN; break;
+                        case GameState::TeamColour::GRAY:msg->current_pose.team = message::input::Team::GRAY; break;
                         default: msg->current_pose.team = message::input::Team::UNKNOWN_TEAM;
                     }
                 }

--- a/module/network/RobotCommunication/src/RobotCommunication.cpp
+++ b/module/network/RobotCommunication/src/RobotCommunication.cpp
@@ -99,41 +99,37 @@ namespace module::network {
 
                     // Bind our new handle
                     std::tie(listen_handle, std::ignore, std::ignore) =
-                        on<UDP::Broadcast, Single>(cfg.receive_port)
-                            .then([this, &global_config](const UDP::Packet& p) {
-                                std::string remote_addr = p.remote.address;
+                        on<UDP::Broadcast, Single>(cfg.receive_port).then([this, &global_config](const UDP::Packet& p) {
+                            std::string remote_addr = p.remote.address;
 
-                                // Apply filtering of packets if udp_filter_address is set in config
-                                if (!cfg.udp_filter_address.empty() && remote_addr != cfg.udp_filter_address) {
-                                    if (std::find(ignored_ip_addresses.begin(), ignored_ip_addresses.end(), remote_addr)
-                                        == ignored_ip_addresses.end()) {
-                                        ignored_ip_addresses.insert(remote_addr);
-                                        log<INFO>("Ignoring UDP packet from",
-                                                  remote_addr,
-                                                  "as it doesn't match configured filter address",
-                                                  cfg.udp_filter_address);
-                                    }
-
-                                    return;
+                            // Apply filtering of packets if udp_filter_address is set in config
+                            if (!cfg.udp_filter_address.empty() && remote_addr != cfg.udp_filter_address) {
+                                if (std::find(ignored_ip_addresses.begin(), ignored_ip_addresses.end(), remote_addr)
+                                    == ignored_ip_addresses.end()) {
+                                    ignored_ip_addresses.insert(remote_addr);
+                                    log<INFO>("Ignoring UDP packet from",
+                                              remote_addr,
+                                              "as it doesn't match configured filter address",
+                                              cfg.udp_filter_address);
                                 }
 
-                                // Deserialise the incoming RoboCup message
-                                const std::vector<unsigned char>& payload = p.payload;
-                                RoboCup incoming_msg =
-                                    NUClear::util::serialise::Serialise<RoboCup>::deserialise(payload);
+                                return;
+                            }
 
-                                // Check if the incoming message is from the same player
-                                bool own_player_message =
-                                    global_config.player_id == incoming_msg.current_pose.player_id;
+                            // Deserialise the incoming RoboCup message
+                            const std::vector<unsigned char>& payload = p.payload;
+                            RoboCup incoming_msg = NUClear::util::serialise::Serialise<RoboCup>::deserialise(payload);
 
-                                // Port-per-team ensures only teammates broadcast on this port
-                                // Filter out messages from ourselves only
-                                if (!own_player_message) {
-                                    log<DEBUG>("Message received from teammate ID",
-                                               incoming_msg.current_pose.player_id);
-                                    emit(std::make_unique<RoboCup>(std::move(incoming_msg)));
-                                }
-                            });
+                            // Check if the incoming message is from the same player
+                            bool own_player_message = global_config.player_id == incoming_msg.current_pose.player_id;
+
+                            // Port-per-team ensures only teammates broadcast on this port
+                            // Filter out messages from ourselves only
+                            if (!own_player_message) {
+                                log<DEBUG>("Message received from teammate ID", incoming_msg.current_pose.player_id);
+                                emit(std::make_unique<RoboCup>(std::move(incoming_msg)));
+                            }
+                        });
                 }
             });
 
@@ -191,14 +187,20 @@ namespace module::network {
                     switch (int(game_state->team.team_colour)) {
                         case GameState::TeamColour::BLUE: msg->current_pose.team = message::input::Team::BLUE; break;
                         case GameState::TeamColour::RED: msg->current_pose.team = message::input::Team::RED; break;
-                        case GameState::TeamColour::YELLOW:msg->current_pose.team = message::input::Team::YELLOW; break;
-                        case GameState::TeamColour::BLACK:msg->current_pose.team = message::input::Team::BLACK; break;
-                        case GameState::TeamColour::WHITE:msg->current_pose.team = message::input::Team::WHITE; break;
-                        case GameState::TeamColour::GREEN:msg->current_pose.team = message::input::Team::GREEN; break;
-                        case GameState::TeamColour::ORANGE:msg->current_pose.team = message::input::Team::ORANGE; break;
-                        case GameState::TeamColour::PURPLE:msg->current_pose.team = message::input::Team::PURPLE; break;
-                        case GameState::TeamColour::BROWN:msg->current_pose.team = message::input::Team::BROWN; break;
-                        case GameState::TeamColour::GRAY:msg->current_pose.team = message::input::Team::GRAY; break;
+                        case GameState::TeamColour::YELLOW:
+                            msg->current_pose.team = message::input::Team::YELLOW;
+                            break;
+                        case GameState::TeamColour::BLACK: msg->current_pose.team = message::input::Team::BLACK; break;
+                        case GameState::TeamColour::WHITE: msg->current_pose.team = message::input::Team::WHITE; break;
+                        case GameState::TeamColour::GREEN: msg->current_pose.team = message::input::Team::GREEN; break;
+                        case GameState::TeamColour::ORANGE:
+                            msg->current_pose.team = message::input::Team::ORANGE;
+                            break;
+                        case GameState::TeamColour::PURPLE:
+                            msg->current_pose.team = message::input::Team::PURPLE;
+                            break;
+                        case GameState::TeamColour::BROWN: msg->current_pose.team = message::input::Team::BROWN; break;
+                        case GameState::TeamColour::GRAY: msg->current_pose.team = message::input::Team::GRAY; break;
                         default: msg->current_pose.team = message::input::Team::UNKNOWN_TEAM;
                     }
                 }

--- a/shared/message/input/GameState.proto
+++ b/shared/message/input/GameState.proto
@@ -35,6 +35,14 @@ message GameState {
         UNKNOWN = 0;
         BLUE    = 1;
         RED     = 2;
+        YELLOW  = 3;
+        BLACK   = 4;
+        WHITE   = 5;
+        GREEN   = 6;
+        ORANGE  = 7;
+        PURPLE  = 8;
+        BROWN   = 9;
+        GRAY    = 10;
     };
 
     enum Mode {

--- a/shared/message/input/RoboCup.proto
+++ b/shared/message/input/RoboCup.proto
@@ -37,6 +37,14 @@ enum Team {
     UNKNOWN_TEAM = 0;
     BLUE         = 1;
     RED          = 2;
+    YELLOW       = 3;
+    BLACK        = 4;
+    WHITE        = 5;
+    GREEN        = 6;
+    ORANGE       = 7;
+    PURPLE       = 8;
+    BROWN        = 9;
+    GRAY         = 10;
 }
 
 message Robot {


### PR DESCRIPTION
This PR:
- Extend `GameState.proto` and `RoboCup.proto` colour enums to support all GameController colours
- Update `get_team_colour()` in `GameController` and team colour switch in `RobotCommunication` to map all colours
- Remove colour-based team filtering from receive handler where port-per-team isolation should be sufficient

### Pre-PR Checklist:
- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [x] Added a descriptive title and relevant labels to the PR

### Reviewers, Note
Team colour is stored in `Purpose` but looks like not yet consumed downstream. This sets the groundwork for future vision-based teammate identification using colours. Robot behaviour is unaffected for now because port isolation handles team separation.