### PR TITLE
make sure that script tuner returns the cursor after exit

### DIFF
--- a/module/purpose/ScriptTuner/src/ScriptTuner.cpp
+++ b/module/purpose/ScriptTuner/src/ScriptTuner.cpp
@@ -299,7 +299,10 @@ namespace module::purpose {
         });
 
         // When we shutdown end ncurses
-        on<Shutdown>().then(endwin);
+        on<Shutdown>().then([] {
+            curs_set(1);
+            endwin();
+        });
     }
 
     void ScriptTuner::activate_frame(int frame) {


### PR DESCRIPTION
Things the PR does go here

this bug has been pissing me off for a while now
currently, if you [Ctrl + C] out of scripttuner, it doesn't return the cursor to the terminal meaning you have to run `reset` to get it back.
this PR fixes that bug and makes sure that an exit gives your cursor back :D

### Pre-PR Checklist:

Have you

- [ ] Updated NUbook if necessary (add link to NUbook PR here)
- [ ] Added/updated tests for your changes, including regression tests for bug fixes
- [ ] Updated relevant module READMEs
- [ ] Added/modified [documentation directives](https://nubook.nubots.net/guides/general/code-conventions#documentation) in relevant code
- [ ] Added a descriptive title and relevant labels to the PR

### Optional Headings (delete this heading and the ones you don't use)

### Reviewers, Note

Things the reviewers should keep in mind go here.
Also tell reviewers how to verify/test your code's correctness here.

### Things left to do

- [ ] If you have more things to do
- [ ] Add them here

**If there are many things left to do then consider a [_draft_ PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)**

### Labels Info (delete the rest of this once you have read it)

We use GitHub's Labels to categorise PRs and Issues. Most PRs should have these labels:

- `G-Group-Name`: G for the group(s) associated with or reviewing the PR.
- `L-Language-Name`: L for the language(s) which are used most in the PR.

Less common label categories include:

- `!!-High-Priority-Reason`: A reason this PR is high priority e.g. it's a bug or it's explicitly for RoboCup.
- `-General-Thing`: A general PR thing. These are all case-by-case and don't fit well into the other categories.
- `-D-Difficulty-Level`: The difficulty level of implementing the change. This is mostly used for issues and is usually not applicable to PRs.

A full list of labels is available [here](https://github.com/NUbots/NUbots/labels).
