### PR TITLE
Add popouts/windows infrastructure for NUsight

### DIFF
--- a/nusight2/src/client/base/best_fit_columns.ts
+++ b/nusight2/src/client/base/best_fit_columns.ts
@@ -1,0 +1,33 @@
+import { getObjectFit } from "./object_fit";
+
+/**
+ * Given a container of a set size and a number of items, find the number of columns that will best fit
+ * the items in the available space, taking into account the aspect ratio of the items.
+ */
+export function bestFitColumns(opts: {
+  container: { width: number; height: number };
+  itemAspectRatio: number;
+  numItems: number;
+}) {
+  const { container, itemAspectRatio, numItems } = opts;
+  const arr = [];
+  for (let cols = 1; cols <= numItems; cols++) {
+    const rows = Math.ceil(numItems / cols);
+    const { width, height } = getObjectFit(
+      {
+        width: container.width / cols,
+        height: container.height / rows,
+      },
+      {
+        type: "contain",
+        aspect: itemAspectRatio,
+      },
+    );
+    arr.push({
+      cols,
+      coverage: (width * height * numItems) / (container.height * container.width),
+    });
+  }
+  arr.sort((a, b) => b.coverage - a.coverage);
+  return arr[0].cols;
+}

--- a/nusight2/src/client/base/object_fit.ts
+++ b/nusight2/src/client/base/object_fit.ts
@@ -1,0 +1,32 @@
+/** Based on the object-fit CSS property: https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit */
+export type ObjectFit =
+  // Stretch content to fill entire container.
+  | { type: "fill" }
+  // Either cover the container with content, or contain the content in the container, while maintaining aspect ratio.
+  | { type: "contain" | "cover"; aspect: number };
+
+/** Given a container size and an object fit mode, get a width and height that will apply the object fit mode */
+export function getObjectFit(
+  container: { width: number; height: number },
+  objectFit: ObjectFit,
+): { width: number; height: number } {
+  switch (objectFit.type) {
+    case "fill":
+      return { width: container.width, height: container.height };
+    case "contain":
+    case "cover": {
+      const containerAspect = container.width / container.height;
+      const ratio = containerAspect / objectFit.aspect;
+
+      if (objectFit.type === "contain" ? ratio < 1 : ratio >= 1) {
+        // Take entire container width, scale the height
+        return { width: container.width, height: Math.ceil(container.width / objectFit.aspect) };
+      } else {
+        // Take entire container height, scale the width
+        return { width: Math.ceil(container.height * objectFit.aspect), height: container.height };
+      }
+    }
+    default:
+      throw new Error(`unknown object fit mode: ${objectFit}`);
+  }
+}

--- a/nusight2/src/client/popouts/messaging.ts
+++ b/nusight2/src/client/popouts/messaging.ts
@@ -1,0 +1,23 @@
+export const popoutBroadcastChannel = new BroadcastChannel("nusight/popout");
+
+export class PopoutParentRendered {
+  static type = "popout/parent-rendered";
+
+  /** The name of the popout parent-child pair */
+  name: string;
+
+  constructor(opts: { name: string }) {
+    this.name = opts.name;
+  }
+}
+
+export class PopoutChildRendered {
+  static type = "popout/child-rendered";
+
+  /** The name of the popout parent-child pair */
+  name: string;
+
+  constructor(opts: { name: string }) {
+    this.name = opts.name;
+  }
+}

--- a/nusight2/src/client/popouts/popout.ts
+++ b/nusight2/src/client/popouts/popout.ts
@@ -1,10 +1,8 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { action, computed, IObservableArray, observable } from "mobx";
-
-import { zip } from "@shared/array/zip";
-
 import { bestFitWindowsOnScreen, ChildWindow, ChildWindowOpts, WindowLayout } from "@client/windows/child_window";
 import { CrossWindowMessenger } from "@client/windows/cross_window_messenger";
+import { zip } from "@shared/array/zip";
+import { action, computed, IObservableArray, observable } from "mobx";
 
 import { popoutBroadcastChannel, PopoutChildRendered, PopoutParentRendered } from "./messaging";
 

--- a/nusight2/src/client/popouts/popout.ts
+++ b/nusight2/src/client/popouts/popout.ts
@@ -1,0 +1,281 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { action, computed, IObservableArray, observable } from "mobx";
+
+import { zip } from "@shared/array/zip";
+
+import { bestFitWindowsOnScreen, ChildWindow, ChildWindowOpts, WindowLayout } from "@client/windows/child_window";
+import { CrossWindowMessenger } from "@client/windows/cross_window_messenger";
+
+import { popoutBroadcastChannel, PopoutChildRendered, PopoutParentRendered } from "./messaging";
+
+export interface UsePopoutParentOpts {
+  /**
+   * The name of this popout, used to connect the parent to its child.
+   * Should be unique for a specific parent-child, e.g.`vision-camera/CentreWide`.
+   */
+  name: string;
+
+  /** Called when the popout child has rendered and established a connection */
+  onChildRendered: (message: PopoutChildRendered, source: Window) => void;
+}
+
+export function usePopoutParent(opts: UsePopoutParentOpts) {
+  const { name, onChildRendered } = opts;
+
+  // Create a messenger to communicate with child windows
+  const messenger = usePopoutMessenger();
+
+  // Listen for messages from child windows
+  useEffect(() => {
+    return messenger.on(PopoutChildRendered, (message, source) => {
+      if (!source) {
+        console.warn("Received a PopoutChildRendered message without a source window", { message, source });
+        return;
+      }
+
+      if (message.name === name) {
+        onChildRendered(message, source as Window);
+      }
+    });
+  }, [messenger, name, onChildRendered]);
+
+  // On render, notify potential child windows to establish a connection
+  useEffect(() => {
+    messenger.send(new PopoutParentRendered({ name }));
+  }, [messenger, name]);
+}
+
+interface UsePopoutChildOpts {
+  /** Called when the popout parent has rendered and established a connection */
+  onParentRendered?: (message: PopoutParentRendered) => void;
+}
+
+/** Setup a popout child to communicate with its parent */
+export function usePopoutChild(opts: UsePopoutChildOpts = {}) {
+  const { onParentRendered } = opts;
+
+  // Create a messenger to communicate with parent windows
+  const messenger = usePopoutMessenger();
+
+  // Listen for messages from parent windows
+  useEffect(() => {
+    // `window.name` should have been set by the parent window when it opened this window
+    if (!window.name) {
+      return;
+    }
+
+    return messenger.on(PopoutParentRendered, (message) => {
+      if (message.name === window.name) {
+        // Notify the parent window that we are rendered
+        messenger.sendToParent(new PopoutChildRendered({ name: window.name }));
+
+        // Notify our parent component that our parent window has rendered
+        onParentRendered?.(message);
+      }
+    });
+  }, [messenger, window.name, onParentRendered]);
+
+  // Notify potential parent windows that a child has rendered
+  useEffect(() => {
+    // `window.name` should have been set by the parent window when it opened this window
+    if (!window.name) {
+      return;
+    }
+
+    messenger.sendToParent(new PopoutChildRendered({ name: window.name }));
+  }, [messenger, window.name]);
+}
+
+export function usePopoutMessenger() {
+  const messenger = useMemo(() => new CrossWindowMessenger(popoutBroadcastChannel), []);
+
+  // Destroy the messenger when it's recreated or this component is unmounted
+  useEffect(() => () => messenger.destroy(), [messenger]);
+
+  return messenger;
+}
+
+export const PopoutGroupContext = createContext<PopoutGroup | undefined>(undefined);
+
+/** Holds a child window and provides methods to open, focus, and close it */
+export class Popout {
+  /** The options used to create the child window */
+  @observable.ref windowOpts: ChildWindowOpts;
+
+  /** A reference to the child window, if open */
+  @observable.ref childWindow: ChildWindow | null = null;
+
+  constructor(windowOpts: ChildWindowOpts) {
+    this.windowOpts = windowOpts;
+  }
+
+  /** Whether the popout child window is open */
+  @computed
+  get isOpen() {
+    return this.childWindow !== null;
+  }
+
+  /** Attach the given child window to this popout */
+  @action.bound
+  attachChildWindow(child: ChildWindow) {
+    child.onClose(
+      action(() => {
+        this.childWindow = null;
+      }),
+    );
+    this.childWindow = child;
+  }
+
+  /** Open the popout child window, or focus it if already open */
+  @action.bound
+  open(layout?: WindowLayout) {
+    if (this.childWindow) {
+      this.childWindow.focus();
+      return;
+    }
+
+    const child = ChildWindow.open(this.windowOpts, layout);
+    if (!child) {
+      console.warn("Failed to open popout window", this.windowOpts.name);
+      return;
+    }
+
+    this.attachChildWindow(child);
+  }
+
+  /** Focus the popout child window if open */
+  @action.bound
+  focus() {
+    this.childWindow?.focus();
+  }
+
+  /** Close the popout child window if open */
+  @action.bound
+  close() {
+    this.childWindow?.close();
+  }
+}
+
+/** Create a popout instance to manage a child window */
+export function usePopout(
+  windowOpts: ChildWindowOpts,
+  opts?: {
+    onChildRendered?: (message: PopoutChildRendered, source: Window) => void;
+  },
+): Popout {
+  const [popout] = useState<Popout>(() => new Popout(windowOpts));
+
+  // Update the popout window options if they change
+  useEffect(() => {
+    popout.windowOpts = windowOpts;
+  }, [popout, windowOpts?.name, windowOpts.url, windowOpts.size, windowOpts.aspectRatio]);
+
+  const onChildRendered = useCallback(
+    (message: PopoutChildRendered, source: Window) => {
+      if (message.name === windowOpts.name) {
+        // Attach the child window if it's not already attached to the popout
+        if (popout.childWindow?.window !== source) {
+          popout.attachChildWindow(new ChildWindow(source));
+        }
+
+        // Notify the parent component that the child has rendered
+        opts?.onChildRendered?.(message, source);
+      }
+    },
+    [popout, windowOpts.name, opts?.onChildRendered],
+  );
+
+  // Add this popout to the closest group in context if there's one
+  const group = useContext(PopoutGroupContext);
+  useEffect(() => group?.addPopout(popout), [group, popout]);
+
+  // Setup communication between the parent and child windows
+  usePopoutParent({ name: windowOpts.name, onChildRendered });
+
+  return popout;
+}
+
+/** Holds a collection of popouts and allows for opening and closing them together */
+export class PopoutGroup {
+  /**
+   * The popouts in this group, mapped into individual lists of popouts that share a name.
+   * Each popout name can have multiple popout instances. For example, if the same camera is
+   * rendered as a thumbnail and a full view, there'll be two popouts with the same name.
+   */
+  @observable
+  private popoutsByName: Map<string, IObservableArray<Popout>> = new Map();
+
+  /** The first popout of each name in this group, used to open and close all popouts */
+  @computed
+  private get popoutsFirstPerName(): Popout[] {
+    return Array.from(this.popoutsByName.values()).map((popouts) => popouts[0]);
+  }
+
+  /** The number of uniquely named popouts in this group */
+  @computed
+  get count() {
+    return this.popoutsByName.size;
+  }
+
+  /** The number of uniquely named popouts that are open in this group */
+  @computed
+  get countOpen() {
+    let count = 0;
+
+    for (const group of this.popoutsByName.values()) {
+      if (group.some((popout) => popout.isOpen)) {
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  /** Add a popout to this group. Returns a function to remove the popout. */
+  @action.bound
+  addPopout(child: Popout) {
+    const popouts = this.popoutsByName.get(child.windowOpts.name) ?? observable.array<Popout>([]);
+    popouts.push(child);
+
+    this.popoutsByName.set(child.windowOpts.name, popouts);
+
+    return action(() => {
+      popouts.remove(child);
+
+      if (popouts.length === 0) {
+        this.popoutsByName.delete(child.windowOpts.name);
+      }
+    });
+  }
+
+  /** Open all popouts in this group */
+  @action.bound
+  openAll() {
+    if (this.popoutsByName.size === 0) {
+      return;
+    }
+
+    // Open the first popout of each name. Other popouts of the same name
+    // will detect when the first one opens and set themselves as open.
+    const popouts = this.popoutsFirstPerName;
+
+    const windowLayouts = bestFitWindowsOnScreen({
+      numItems: popouts.length,
+      itemAspectRatio: popouts[0].windowOpts.aspectRatio ?? 1,
+    });
+
+    for (const [popout, layout] of zip(popouts, windowLayouts)) {
+      popout.open(layout);
+    }
+  }
+
+  /** Close all popouts in this group */
+  @action.bound
+  closeAll() {
+    // Close the first popout of each name. Other popouts of the same name
+    // will detect when the first one closes and set themselves as closed.
+    for (const popout of this.popoutsFirstPerName) {
+      popout.close();
+    }
+  }
+}

--- a/nusight2/src/client/windows/child_window.ts
+++ b/nusight2/src/client/windows/child_window.ts
@@ -1,0 +1,220 @@
+import { zip } from "@shared/array/zip";
+
+import { bestFitColumns } from "@client/base/best_fit_columns";
+
+/** A size value, either in pixels or as a percentage */
+type Size = `${number}px` | `${number}%`;
+
+export interface ChildWindowOpts {
+  /** The absolute URL to open in the child window */
+  url: string;
+  /**
+   * The name of the child window. If there's an existing window with the same name,
+   * it will be reloaded with the new URL.
+   */
+  name: string;
+
+  /** The width and height of the child window, overrides `aspectRatio` if set */
+  size?: { width: Size; height: Size };
+
+  /** The aspect ratio of the child window, used for best fit positioning when opening multiple windows */
+  aspectRatio?: number;
+}
+
+function getPixelSize(windowSize: Size, containerPixels: number) {
+  if (windowSize.endsWith("px")) {
+    return Number(windowSize.replace("px", ""));
+  }
+
+  const percent = Number(windowSize.replace("%", ""));
+  return containerPixels * (percent / 100);
+}
+
+/**
+ * A wrapper class for managing child popup windows opened by a parent window.
+ * Provides methods for opening and positioning one or more child windows,
+ * focusing, closing, and listening for close events.
+ */
+export class ChildWindow {
+  /** A reference to the browser window for the child */
+  window: Window;
+
+  /** Whether the window is closed */
+  closed = false;
+
+  /** The ID of the timeout used to check if the child window has closed */
+  private childCloseTimeout: number;
+
+  /** Listeners to run when the child window closes */
+  private onCloseListeners = new Set<() => void>();
+
+  /** Create a new `ChildWindow` wrapper for the given browser window */
+  constructor(win: Window) {
+    this.window = win;
+    this.childCloseTimeout = window.setTimeout(this.checkForClose, 1000);
+  }
+
+  /** Open a single `ChildWindow` positioned with the given layout or at the center of the screen */
+  static open(window: ChildWindowOpts, layout?: WindowLayout) {
+    const win = openWindow(window.url, window.name, layout ?? centerWindow(window));
+    return win ? new ChildWindow(win) : null;
+  }
+
+  /** Open multiple `ChildWindow`s positioned in a best-fit grid layout */
+  static openInGrid(windows: Omit<ChildWindowOpts, "size">[]) {
+    // When opening multiple child windows, we position them in a grid layout for best fit
+    const windowLayouts = bestFitWindowsOnScreen({
+      numItems: windows.length,
+      itemAspectRatio: windows[0].aspectRatio ?? 1,
+    });
+
+    return zip(windows, windowLayouts).map(([winOpts, layout]) => {
+      const win = openWindow(winOpts.url, winOpts.name, layout);
+      return win ? new ChildWindow(win) : null;
+    });
+  }
+
+  /** Focus the child window */
+  focus() {
+    this.window.focus();
+  }
+
+  /** Close the child window and dispose resources */
+  close() {
+    if (this.closed) {
+      return;
+    }
+
+    this.window.close();
+  }
+
+  /** Add a listener to run when the child window closes */
+  onClose(listener: () => void) {
+    this.onCloseListeners.add(listener);
+  }
+
+  /** Check if the child window has closed, and run the closed handler */
+  private checkForClose = () => {
+    if (this.closed) {
+      return;
+    }
+
+    if (this.window.closed) {
+      this.handleWindowClosed();
+    } else {
+      this.childCloseTimeout = window.setTimeout(this.checkForClose, 1000);
+    }
+  };
+
+  /** Handle the child window closing */
+  private handleWindowClosed = () => {
+    window.clearTimeout(this.childCloseTimeout);
+
+    this.closed = true;
+
+    for (const listener of this.onCloseListeners) {
+      listener();
+    }
+  };
+}
+
+export interface WindowLayout {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Calculate the best fit grid layout for the given number of items and aspect ratio.
+ * Returns an array of window layouts (one for each item), ordered left to right, top to bottom.
+ */
+export function bestFitWindowsOnScreen(opts: { numItems: number; itemAspectRatio: number }): WindowLayout[] {
+  const container = { width: screen.availWidth ?? screen.width, height: screen.availHeight ?? screen.height };
+
+  const cols = bestFitColumns({
+    container,
+    itemAspectRatio: opts.itemAspectRatio,
+    numItems: opts.numItems,
+  });
+
+  const rows = Math.ceil(opts.numItems / cols);
+
+  const xGap = 24;
+  const yGap = 24;
+  const totalXGap = xGap * (cols - 1);
+  const totalYGap = yGap * (rows - 1);
+  const itemWidth = (container.width - totalXGap) / cols;
+  const itemHeight = (container.height - totalYGap) / rows;
+
+  return new Array(opts.numItems).fill(null).map((_, index) => {
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+
+    return {
+      left: col * itemWidth + xGap * col,
+      top: row * itemHeight + yGap * row,
+      width: itemWidth,
+      height: itemHeight,
+    };
+  });
+}
+
+/** Calculate a layout that will place a window with the given options at the center of the screen */
+function centerWindow(opts: Pick<ChildWindowOpts, "size" | "aspectRatio">): WindowLayout {
+  let width = 0;
+  let height = 0;
+
+  // If there is a size specified, use it
+  if (opts.size) {
+    width = getPixelSize(opts.size.width, screen.availWidth);
+    height = getPixelSize(opts.size.height, screen.availHeight);
+  }
+  // Otherwise use a height of 80% of the screen height and a width calculated from the aspect ratio
+  else {
+    height = screen.availHeight * 0.8;
+    width = height * (opts.aspectRatio ?? 1);
+  }
+
+  return {
+    width,
+    height,
+    // Position the window roughly at the center of the screen
+    left: (screen.availWidth - width) / 2,
+    top: (screen.availHeight - height) / 2,
+  };
+}
+
+/** Open and position a new popup window */
+function openWindow(url: string, name: string, layout: WindowLayout) {
+  // Open at 0, 0 so we can read the screenLeft and screenTop values.
+  // This is necessary to properly position the window when there are multiple screens.
+  // We will move the window to the correct position after it loads.
+  const params = `top=0,left=0,width=${layout.width},height=${layout.height}`;
+
+  // Add the `isChild` query param to the URL so the child knows it's a child window
+  const urlObj = new URL(url, window.location.href);
+  urlObj.searchParams.delete("isChild");
+  urlObj.searchParams.append("isChild", "true");
+
+  const childWindow = window.open(urlObj.toString(), name, params);
+
+  // Position the window only on the first load
+  // Note: this is only necessary because we might call `window.open()` with the window name of an existing window,
+  // and don't want the existing window's position and size to be changed. In the future this check for `isLoaded` could
+  // be removed by keeping track of existing windows and not calling `window.open()` if we already have a window
+  // with the same name. Those windows could just be focused instead, with their URLs changed if necessary.
+  if (childWindow && !childWindow.sessionStorage.getItem("isLoaded")) {
+    childWindow.resizeTo(layout.width, layout.height);
+
+    // Move the window to the correct position, taking screenLeft and screenTop into account.
+    // Unfortunately, this doesn't work in Firefox, which always opens the child windows on the leftmost screen.
+    childWindow.moveTo(childWindow.screenLeft + layout.left, childWindow.screenTop + layout.top);
+
+    childWindow.addEventListener("load", () => {
+      childWindow.sessionStorage.setItem("isLoaded", "true");
+    });
+  }
+
+  return childWindow;
+}

--- a/nusight2/src/client/windows/child_window.ts
+++ b/nusight2/src/client/windows/child_window.ts
@@ -1,6 +1,5 @@
-import { zip } from "@shared/array/zip";
-
 import { bestFitColumns } from "@client/base/best_fit_columns";
+import { zip } from "@shared/array/zip";
 
 /** A size value, either in pixels or as a percentage */
 type Size = `${number}px` | `${number}%`;

--- a/nusight2/src/client/windows/cross_window_messenger.ts
+++ b/nusight2/src/client/windows/cross_window_messenger.ts
@@ -1,0 +1,111 @@
+/** Describes a class of type T which is a message that can be sent across windows */
+export interface CrossWindowMessageType<T> {
+  type: string;
+  new (...args: any[]): T;
+}
+
+type CrossWindowMessageCallback<T> = (message: T, source: MessageEventSource | null) => void;
+
+/**
+ * Implements an interface for communicating across parent and child windows and windows that share
+ * the same [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel).
+ */
+export class CrossWindowMessenger {
+  /** The BroadcastChannel used to communicate between windows that don't share a parent-child relationship */
+  broadcastChannel: BroadcastChannel;
+
+  /** Maps message types to registered callbacks for those messages */
+  callbacksByType: Record<string, Set<CrossWindowMessageCallback<any>>> = {};
+
+  /** Maps message types to their corresponding message classes, for encoding and decoding */
+  typeToMessageClass: Record<string, CrossWindowMessageType<any>> = {};
+
+  constructor(broadcastChannel: BroadcastChannel) {
+    this.broadcastChannel = broadcastChannel;
+
+    window.addEventListener("message", this.messageReceived);
+    this.broadcastChannel.addEventListener("message", this.messageReceived);
+  }
+
+  /** Handle a message received from another window */
+  private messageReceived = (event: MessageEvent) => {
+    if (!event.data.type) {
+      return;
+    }
+
+    const callbacks = this.callbacksByType[event.data.type] ?? new Set();
+
+    if (callbacks.size > 0) {
+      const MessageClass = this.typeToMessageClass[event.data.type];
+
+      if (!MessageClass) {
+        throw new Error(`No message class registered for message type "${event.data.type}"`);
+      }
+
+      const payload = decode(event.data, MessageClass);
+
+      for (const callback of callbacks) {
+        callback(payload, event.source);
+      }
+    }
+  };
+
+  /** Stop listening for messages */
+  destroy() {
+    window.removeEventListener("message", this.messageReceived);
+    this.broadcastChannel.removeEventListener("message", this.messageReceived);
+  }
+
+  /** Listen for messages from other windows */
+  on<T>(MessageClass: CrossWindowMessageType<T>, callback: CrossWindowMessageCallback<T>) {
+    const type = MessageClass.type;
+
+    const ExistingMessageClass = this.typeToMessageClass[type];
+    if (ExistingMessageClass && ExistingMessageClass !== MessageClass) {
+      throw new Error(
+        `Message type "${type}" is already registered to class "${ExistingMessageClass.name}", and cannot be registered to class "${MessageClass.name}"`,
+      );
+    }
+
+    this.typeToMessageClass[type] = MessageClass;
+
+    const callbacks = this.callbacksByType[type] ?? new Set();
+    callbacks.add(callback);
+
+    this.callbacksByType[type] = callbacks;
+
+    return () => {
+      callbacks.delete(callback);
+    };
+  }
+
+  /** Send the given message to all windows that share the same broadcast channel */
+  send<T>(message: T) {
+    this.broadcastChannel.postMessage(encode(message));
+  }
+
+  /** Send the given message to the window that opened this window, if any */
+  sendToParent<T>(message: T) {
+    window.opener?.postMessage(encode(message), "*");
+  }
+}
+
+/** Encode the given message for sending across windows */
+function encode<T>(message: T, MessageClass?: CrossWindowMessageType<T>): { type: string; payload: T } {
+  const Class = MessageClass ?? ((message as any).constructor as CrossWindowMessageType<T>);
+
+  if (typeof Class.type !== "string") {
+    throw new Error(`Message class ${Class.name} does not have a type property`);
+  }
+
+  return { type: Class.type, payload: message };
+}
+
+/** Decode the given message received from another window */
+function decode<T>(message: { type: string; payload: T }, MessageClass: CrossWindowMessageType<T>): T {
+  if (message.type !== MessageClass.type) {
+    throw new Error(`Expected message type "${MessageClass.type}" but got "${message.type}"`);
+  }
+
+  return new MessageClass(message.payload);
+}

--- a/nusight2/src/shared/array/zip.ts
+++ b/nusight2/src/shared/array/zip.ts
@@ -1,0 +1,4 @@
+/** Zip two arrays together into an array of tuples. */
+export function zip<A, B>(a: A[], b: B[]): [A, B][] {
+  return a.map((_, i) => [a[i], b[i]]);
+}


### PR DESCRIPTION
## Summary
- Adds cross-window messaging and child window management for NUsight popouts
- Ports Horus popout infrastructure: `Popout`, `ChildWindow`, `CrossWindowMessenger`, and layout helpers (`object_fit`, `best_fit_columns`)
- Adds a small `zip` array utility used by the windows code

Part of the Horus sync stack (`a2`), rebased onto `houliston/advanced-scrubber` after the protobuf-es migration squash merge.

## Test plan
- [ ] `./b format` passes
- [ ] NUsight builds and runs (`yarn dev` / virtual robots)
- [ ] Popout windows open and communicate with the parent window as expected


Made with [Cursor](https://cursor.com)