### PR TITLE
Add timeline component and render2d rectangle geometry for NUsight

### DIFF
--- a/nusight2/src/client/components/timeline/animation_group.ts
+++ b/nusight2/src/client/components/timeline/animation_group.ts
@@ -1,0 +1,60 @@
+function lerp(start: bigint, end: bigint, percent: number) {
+  return start + BigInt(Math.floor(percent * Number(end - start)));
+}
+
+/**
+ * Options for animating a group of values in sync.
+ * Generic enforces a fixed length for the number of values to animate simultaneously.
+ */
+export interface AnimationGroupOpts<T extends [...bigint[]]> {
+  duration: number;
+  startValues: [...T];
+  endValues: [...T];
+  onUpdate: (values: T) => void;
+  onEnd: () => void;
+}
+
+export interface AnimationGroup<T extends [...bigint[]]> {
+  startValues: [...T];
+  endValues: [...T];
+  /** Cancel the animation at the current duration */
+  cancel: () => void;
+}
+
+/**
+ * Animates a set of values to another set of values linearly from one set of values to another
+ * over a given duration.
+ *
+ * Calls the `onUpdate` callback with the current animation values for each frame until the animation
+ * is complete.
+ */
+export function animateValues<T extends [...bigint[]]>(opts: AnimationGroupOpts<T>): AnimationGroup<T> {
+  const { duration, startValues, endValues, onUpdate, onEnd } = opts;
+
+  const startTime = Date.now();
+  let animationHandle: number | undefined;
+
+  const update = () => {
+    const elapsedPercent = (Date.now() - startTime) / duration;
+
+    // Exit condition
+    if (elapsedPercent >= 1) {
+      onUpdate(opts.endValues);
+      onEnd();
+      return;
+    }
+
+    onUpdate(startValues.map((val, i) => lerp(val, endValues[i], elapsedPercent)) as T);
+    animationHandle = requestAnimationFrame(update);
+  };
+
+  const cancel = () => {
+    onEnd();
+    if (animationHandle !== undefined) {
+      cancelAnimationFrame(animationHandle);
+    }
+  };
+
+  update();
+  return { startValues, endValues, cancel };
+}

--- a/nusight2/src/client/components/timeline/controller.ts
+++ b/nusight2/src/client/components/timeline/controller.ts
@@ -1,0 +1,75 @@
+import { action } from "mobx";
+
+import { animateValues, AnimationGroup } from "./animation_group";
+import { TimelineModel } from "./model";
+
+export type TimelineEventHandler = (timestamp: bigint) => void;
+
+export interface TimelineEventHandlers {
+  onViewRangeChange?: TimelineEventHandler;
+  onViewCentreChange?: TimelineEventHandler;
+}
+
+export class TimelineController {
+  private viewAnimation?: AnimationGroup<[bigint, bigint]>;
+
+  constructor(
+    private model: TimelineModel,
+    public handlers: TimelineEventHandlers,
+  ) {}
+
+  /**
+   * Zoom the camera view in or out by a single step.
+   * The position of the focal timestamp in the view will be maintained before/after the
+   * zoom change.
+   */
+  @action.bound
+  public zoom(direction: "in" | "out", focalTimestamp: bigint) {
+    // If currently in an animation, move from the end values to not reset the view position
+    const currentCentre = this.viewAnimation ? this.viewAnimation.endValues[0] : this.model.view.centre;
+    const currentRange = this.viewAnimation ? this.viewAnimation.endValues[1] : this.model.view.range;
+    this.viewAnimation?.cancel();
+
+    // The percentage along the view to focus the zoom on
+    const focalPercent = Number(focalTimestamp - (currentCentre - currentRange / 2n)) / Number(currentRange);
+
+    // Zoom in or out depending on the direction
+    const startRange = this.model.view.range;
+    const divisor = 5n;
+
+    // Since we are using bigints, we cannot use a multiplier to zoom in and out (due to integer math).
+    // So we use addition instead by adding/subtracting a percentage of the current range.
+    this.model.view.range =
+      currentRange + (direction === "in" ? -currentRange / (divisor + 1n) : currentRange / divisor);
+
+    // Emit the range, allowing it to be clamped if necessary
+    this.handlers.onViewRangeChange?.(this.model.view.range);
+
+    // Set the view center so that the focal timestamp is in the same position as before the zoom
+    const startCentre = this.model.view.centre;
+    const relativeFocalTimestamp = BigInt(Math.floor(focalPercent * Number(this.model.view.range)));
+    const viewLeft = focalTimestamp - relativeFocalTimestamp;
+    this.model.view.centre = viewLeft + this.model.view.range / 2n;
+
+    // Emit the centre, allowing it to be clamped if necessary
+    this.handlers.onViewCentreChange?.(this.model.view.centre);
+
+    // Animate from the current view to the new view
+    this.viewAnimation = animateValues({
+      duration: 100,
+      startValues: [startCentre, startRange],
+      endValues: [this.model.view.centre, this.model.view.range],
+      onUpdate: action(([centre, range]) => {
+        this.model.view.centre = centre;
+        this.model.view.range = range;
+      }),
+      onEnd: () => (this.viewAnimation = undefined),
+    });
+  }
+
+  @action.bound
+  public setViewCentre(centre: bigint) {
+    this.model.view.centre = centre;
+    this.handlers.onViewCentreChange?.(this.model.view.centre);
+  }
+}

--- a/nusight2/src/client/components/timeline/geometry.ts
+++ b/nusight2/src/client/components/timeline/geometry.ts
@@ -1,0 +1,234 @@
+import { CSSProperties } from "react";
+import { BasicAppearance } from "@client/render2d/appearance/basic_appearance";
+import { LineAppearance } from "@client/render2d/appearance/line_appearance";
+import { Render2DEventHandlers } from "@client/render2d/event/event_handlers";
+import { CircleGeometry } from "@client/render2d/geometry/circle_geometry";
+import { LineGeometry } from "@client/render2d/geometry/line_geometry";
+import { PolygonGeometry } from "@client/render2d/geometry/polygon_geometry";
+import { RectangleGeometry } from "@client/render2d/geometry/rectangle_geometry";
+import { TextGeometry } from "@client/render2d/geometry/text_geometry";
+import { Geometry } from "@client/render2d/object/geometry";
+import { Group } from "@client/render2d/object/group";
+import { Shape, ShapeOpts } from "@client/render2d/object/shape";
+import { Transform } from "@shared/math/transform";
+import { Vector2 } from "@shared/math/vector2";
+import { Property } from "csstype";
+
+interface CircleOpts {
+  x: number;
+  y: number;
+  radius: number;
+  color?: string;
+  cursor?: CSSProperties["cursor"];
+  eventHandlers?: Render2DEventHandlers;
+}
+
+export function circle(opts: CircleOpts) {
+  const { x, y, radius, color = "#000000", cursor, eventHandlers } = opts;
+  return Shape.of({
+    geometry: CircleGeometry.of({ x, y, radius }),
+    appearance: BasicAppearance.of({ fill: { color }, cursor }),
+    eventHandlers,
+  });
+}
+
+interface TextOpts {
+  text: string;
+  x: number;
+  y: number;
+  color: string;
+  /** Alpha value from 0 to 1 */
+  alpha?: number;
+  /** Size of the text with a unit (e.g "10px") */
+  size?: string;
+  align?: TextGeometry["textAlign"];
+  baseline?: TextGeometry["textBaseline"];
+  /** @deprecated pointerEvents is not supported in NUbots render2d; prop is accepted but ignored */
+  pointerEvents?: ShapeOpts<Geometry> extends { pointerEvents?: infer P } ? P : string;
+}
+
+/** Shorthand for creating a text geometry */
+export function text(opts: TextOpts) {
+  const { text, x, y, color, alpha, size = "15px", align = "middle", baseline = "bottom" } = opts;
+  return Shape.of({
+    geometry: TextGeometry.of({
+      text,
+      x,
+      y,
+      textAlign: align,
+      textBaseline: baseline,
+      worldScale: true,
+      fontSize: size,
+    }),
+    appearance: BasicAppearance.of({ fill: { color, alpha } }),
+  });
+}
+
+interface LineOpts {
+  x: number;
+  x2?: number;
+  y: number;
+  y2?: number;
+  color?: string;
+  width?: number;
+  alpha?: number;
+  cursor?: Property.Cursor;
+  cap?: "butt" | "round" | "square";
+  ignorePointerEvents?: boolean;
+  eventHandlers?: Render2DEventHandlers;
+}
+
+/** Shorthand for creating a line geometry */
+export function line(opts: LineOpts) {
+  const {
+    x,
+    x2 = x,
+    y,
+    y2 = y,
+    color = "#000000",
+    width = 1,
+    alpha = 1,
+    cap = "butt",
+    ignorePointerEvents,
+    eventHandlers,
+  } = opts;
+  return Shape.of({
+    geometry: LineGeometry.of({
+      origin: Vector2.of(x, y),
+      target: Vector2.of(x2, y2),
+    }),
+    appearance: LineAppearance.of({ stroke: { cap, color, alpha, width, nonScaling: true } }),
+    eventHandlers: ignorePointerEvents ? undefined : eventHandlers,
+  });
+}
+
+interface RectangleOpts {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+  color: string;
+  border?: string;
+  borderWidth?: number;
+  /** @deprecated dashArray not supported in NUbots BasicAppearance; prop accepted but ignored */
+  borderDashArray?: string;
+  /**
+   * If set to `full`, will use the larger of width or height to calculate the border radius, for a "full"
+   * pill shaped rounding.
+   */
+  borderRadius?: number | "full";
+  cursor?: CSSProperties["cursor"];
+  eventHandlers?: Render2DEventHandlers;
+  /** @deprecated pointerEvents is not supported in NUbots render2d; prop is accepted but ignored */
+  pointerEvents?: CSSProperties["pointerEvents"];
+  alpha?: number;
+}
+
+/** Shorthand for drawing a rectangle */
+export function rectangle(opts: RectangleOpts) {
+  const {
+    x = 0,
+    y = 0,
+    width,
+    height,
+    color,
+    border = color,
+    borderWidth,
+    borderRadius,
+    cursor,
+    eventHandlers,
+    alpha,
+  } = opts;
+  return Shape.of({
+    geometry: RectangleGeometry.of(x, y, width, height, borderRadius),
+    appearance: BasicAppearance.of({
+      fill: { color, alpha },
+      stroke:
+        border !== "transparent"
+          ? {
+              color: border,
+              width: borderWidth,
+              nonScaling: true,
+            }
+          : undefined,
+      cursor,
+    }),
+    eventHandlers,
+  });
+}
+
+interface MarkerOpts {
+  color: string;
+  ignorePointerEvents?: boolean;
+  eventHandlers?: Render2DEventHandlers;
+}
+
+/** Shorthand for the geometry of the time markers */
+export function markerShape({ color, ignorePointerEvents, eventHandlers }: MarkerOpts) {
+  return Shape.of({
+    geometry: PolygonGeometry.of([
+      Vector2.of(-7, -18),
+      Vector2.of(7, -18),
+      Vector2.of(7, -6),
+      Vector2.of(0, 0),
+      Vector2.of(-7, -6),
+    ]),
+    appearance: BasicAppearance.of({ fill: { color }, cursor: "pointer" }),
+    eventHandlers: ignorePointerEvents ? undefined : eventHandlers,
+  });
+}
+
+interface FlagOpts {
+  x: number;
+  y: number;
+  color: string;
+  outline?: string;
+  direction: "left" | "right";
+  eventHandlers?: Render2DEventHandlers;
+}
+
+export function flag({ x, y, color, outline, direction, eventHandlers }: FlagOpts) {
+  return Group.of({
+    children: [
+      Shape.of({
+        geometry: PolygonGeometry.of([
+          Vector2.of(16, -15),
+          Vector2.of(0, -15),
+          Vector2.of(0, 0),
+          Vector2.of(8, -5),
+          Vector2.of(16, -5),
+        ]),
+        appearance: BasicAppearance.of({
+          fill: { color },
+          stroke: outline ? { color: outline } : undefined,
+          cursor: "pointer",
+        }),
+        eventHandlers,
+      }),
+    ],
+    transform: Transform.of({ translate: { x, y }, scale: { x: direction === "left" ? -1 : 1, y: 1 } }),
+  });
+}
+
+interface LabelOpts {
+  text: string;
+  color: string;
+  textColor: string;
+}
+
+/** Shorthand for geometry containing text over a rectangular background */
+export function label(opts: LabelOpts): [Shape<RectangleGeometry>, Shape<TextGeometry>] {
+  const y = -49;
+  const width = 100;
+  const height = 28;
+  return [
+    rectangle({ x: -width / 2, y, width, height, color: opts.color }),
+    text({
+      x: 0,
+      y: y + height / 2,
+      text: opts.text,
+      color: opts.textColor,
+      baseline: "middle",
+    }),
+  ];
+}

--- a/nusight2/src/client/components/timeline/header/timeline_header.tsx
+++ b/nusight2/src/client/components/timeline/header/timeline_header.tsx
@@ -1,0 +1,67 @@
+import { useCallback, useContext } from "react";
+import React from "react";
+import { Renderer } from "@client/render2d/renderer";
+import { useUpdatable } from "@hooks/use_updatable";
+import classNames from "classnames";
+import { observer } from "mobx-react";
+
+import { timelineContext } from "../view";
+
+import { TimelineHeaderViewModel } from "./view_model";
+
+export type HeaderInput = (time: bigint) => void;
+
+export interface TimelineHeaderProps {
+  className?: string;
+  onPointerDown?: HeaderInput;
+  onPointerMove?: HeaderInput;
+  onPointerUp?: HeaderInput;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+}
+
+export const TimelineHeader = observer(function TimelineHeader(props: TimelineHeaderProps) {
+  const { onPointerDown, onPointerMove, onPointerUp, onMouseEnter, onMouseLeave, className } = props;
+  const context = useContext(timelineContext);
+
+  if (!context) {
+    throw new Error("Cannot have a <TimelineHeader> component outside of a <TimelineView>");
+  }
+
+  const { model, controller } = context;
+  const viewModelOpts: ConstructorParameters<typeof TimelineHeaderViewModel> = [
+    model,
+    controller,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+  ];
+
+  // Create single view model instance that updates when props change
+  const viewModel = useUpdatable(
+    () => new TimelineHeaderViewModel(...viewModelOpts),
+    (instance, newOpts) => instance.update(newOpts),
+    [model, controller, onPointerDown, onPointerMove, onPointerUp],
+  );
+
+  // Track size in px of renderer canvas and update it on the view model
+  const onResize = useCallback((width: number, height: number) => {
+    viewModel.setCanvasSize({ width: Math.floor(width), height: Math.floor(height) });
+  }, []);
+
+  return (
+    <div
+      className={classNames("relative min-h-[2rem]", className)}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <Renderer
+        engine="svg"
+        camera={viewModel.camera}
+        scene={viewModel.scene}
+        eventHandlers={viewModel.eventHandlers}
+        onResize={onResize}
+      />
+    </div>
+  );
+});

--- a/nusight2/src/client/components/timeline/header/view_model.ts
+++ b/nusight2/src/client/components/timeline/header/view_model.ts
@@ -1,0 +1,291 @@
+import { Render2DEventHandlers } from "@client/render2d/event/event_handlers";
+import { Render2DMouseEvent } from "@client/render2d/event/mouse_event";
+import { Geometry } from "@client/render2d/object/geometry";
+import { Group } from "@client/render2d/object/group";
+import { Shape } from "@client/render2d/object/shape";
+import { flag, line, markerShape, text } from "@components/timeline/geometry";
+import { clamp } from "@shared/math/clamp";
+import { Transform } from "@shared/math/transform";
+import { Vector2 } from "@shared/math/vector2";
+import { Timestamp } from "@shared/time/timestamp";
+import { action, computed } from "mobx";
+
+import { TimelineController } from "../controller";
+import { HighlightRangeModel, TimelineModel } from "../model";
+import { TimelineViewModel } from "../view_model";
+
+import { HeaderInput } from "./timeline_header";
+
+const colors = {
+  timePoints: "var(--color-auto-contrast-5)",
+} as const;
+
+/** Header section of a TimelineView */
+export class TimelineHeaderViewModel extends TimelineViewModel {
+  private onPointerDown?: HeaderInput;
+  private onPointerMove?: HeaderInput;
+  private onPointerUp?: HeaderInput;
+
+  constructor(
+    model: TimelineModel,
+    controller: TimelineController,
+    onPointerDown?: HeaderInput,
+    onPointerMove?: HeaderInput,
+    onPointerUp?: HeaderInput,
+  ) {
+    super(model, controller);
+    this.onPointerDown = onPointerDown;
+    this.onPointerMove = onPointerMove;
+    this.onPointerUp = onPointerUp;
+  }
+
+  @action
+  update(args: ConstructorParameters<typeof TimelineHeaderViewModel>) {
+    const [model, controller, onPointerDown, onPointerMove, onPointerUp] = args;
+    this.model = model;
+    this.controller = controller;
+    this.onPointerDown = onPointerDown;
+    this.onPointerMove = onPointerMove;
+    this.onPointerUp = onPointerUp;
+  }
+
+  readonly eventHandlers: Render2DEventHandlers = {
+    ...this.defaultEventHandlers,
+    onMouseMove: action((e) => {
+      this.defaultEventHandlers.onMouseMove?.(e);
+      this.onPointerMove?.(this.hoveredTime);
+    }),
+    onMouseUp: action((e) => {
+      this.defaultEventHandlers.onMouseUp?.(e);
+      this.onPointerUp?.(this.hoveredTime);
+    }),
+    onMouseDown: action((e) => {
+      if (this.onPointerDown) {
+        this.onPointerDown(this.hoveredTime);
+      } else {
+        this.defaultEventHandlers.onMouseDown?.(e);
+      }
+    }),
+  };
+
+  /** Camera transform to convert coordinates to pixel values */
+  @computed
+  get camera(): Transform {
+    return Transform.of({
+      scale: Vector2.of(this.canvas.width, -this.canvas.height),
+      // Half pixel offset centers coordinates on pixels instead of the
+      // border between pixels. This means lines with width 1 will display properly.
+      translate: Vector2.of(this.canvas.width / 2 + 0.5, this.canvas.height / 2 - 0.5),
+    });
+  }
+
+  /** The elements of the timeline header section */
+  @computed
+  get scene(): Group {
+    return Group.of({
+      children: [this.timeTicks, this.highlightAreaFlags, this.visibleMarkers, this.outOfBoundsMarkers],
+    });
+  }
+
+  /**
+   * Vertical lines to show time points at set interval.
+   * The major lines also show text above them for their time.
+   */
+  @computed
+  get timeTicks(): Group {
+    const geometry: Shape<Geometry>[] = [];
+    const { width, height } = this.canvas;
+    const { major, minor } = this.timeGridPositions;
+    const color = colors.timePoints;
+
+    /**
+     * Linear smoothing of a value when it is between the given range.
+     * Returns 0 when past the min side and 1 when past the max side.
+     */
+    function smoothBetween(value: number, min: number, max: number) {
+      return clamp((value - min) / (max - min), 0, 1);
+    }
+
+    /**
+     * Get an alpha value from a given x position, allowing the text to fade out
+     * as it reaches the edge of the view
+     */
+    function getFadeOutAlpha(position: number) {
+      const transparentPos = 0;
+      const opaquePos = 50;
+      return (
+        smoothBetween(position, transparentPos, opaquePos) *
+        smoothBetween(position, width + transparentPos, width - opaquePos)
+      );
+    }
+
+    const commonOpts = { align: "end", baseline: "hanging", size: "13px" } as const;
+
+    // The minor lines - 10% the height of the header
+    minor.forEach(({ position }) =>
+      geometry.push(line({ x: position, y: height * 0.9, y2: height, color, alpha: getFadeOutAlpha(position) })),
+    );
+
+    // The major lines - 65% the height of the header with a text label for each
+    major.forEach(({ time, position }) => {
+      const alpha = getFadeOutAlpha(position);
+      if (alpha > 0) {
+        const textX = position - 5; // Shift the text a little bit to the side of the major line
+        const textY = height * 0.3; // Shift the text a little down from the major line
+        geometry.push(
+          line({ x: position, y: height * 0.35, y2: height, color, alpha }),
+          text({ text: Timestamp.toFormattedDate(time), x: textX, y: textY, color, alpha, ...commonOpts }),
+        );
+      }
+    });
+
+    return Group.of({ children: geometry });
+  }
+
+  @computed
+  private get highlightAreaFlags(): Group {
+    // Filter out ranges with the flags hidden
+    const visibleRanges = this.model.highlightRanges.filter((range) => !range.hideFlags);
+    if (visibleRanges.length === 0) {
+      return Group.of();
+    }
+
+    // Create the geometry for one side of a highlight range
+    const createGeometry = (side: "start" | "end", range: HighlightRangeModel) => {
+      return flag({
+        x: this.timeToPixel(range[side]),
+        y: this.canvas.height,
+        direction: side === "start" ? "left" : "right",
+        color: range.color,
+        outline: range.borderColor,
+        eventHandlers: {
+          onMouseDown: (e: Render2DMouseEvent) => {
+            range.onMouseDown?.(side, range);
+            e.stopPropagation();
+          },
+          onMouseUp: () => range.onMouseUp?.(side, range),
+          onMouseMove: () => range.onMouseMove?.(side, this.hoveredTime, range),
+          onMouseEnter: () => range.onMouseEnter?.(side, range),
+          onMouseLeave: () => range.onMouseLeave?.(side, range),
+        },
+      });
+    };
+
+    // Create a geometry for each side of each visible range
+    return Group.of({
+      children: visibleRanges.flatMap((range) => [createGeometry("start", range), createGeometry("end", range)]),
+    });
+  }
+
+  @computed
+  private get markerViewModels() {
+    const graceRegion = 4; // Number of pixels for marker to be out of view by before being considered out of bounds
+
+    return this.model.markers.map((marker) => {
+      const x = this.timeToPixel(marker.timestamp);
+      const isInView = x >= -graceRegion && x <= this.canvas.width + graceRegion;
+      return { x, isInView, marker };
+    });
+  }
+
+  @computed
+  get visibleMarkers(): Group {
+    const y = this.canvas.height;
+    const visibleMarkers = this.markerViewModels.filter((m) => m.isInView);
+
+    return Group.of({
+      children: visibleMarkers.map(({ x, marker }) => {
+        // Create event handlers for the marker
+        const eventHandlers: Render2DEventHandlers = {
+          onMouseDown: (e: Render2DMouseEvent) => {
+            marker.onMouseDown?.(marker);
+            e.stopPropagation();
+          },
+          onMouseUp: () => marker.onMouseUp?.(marker),
+          onMouseMove: () => marker.onMouseMove?.(this.hoveredTime, marker),
+          onMouseEnter: () => marker.onMouseEnter?.(marker),
+          onMouseLeave: () => marker.onMouseLeave?.(marker),
+        };
+
+        // If the marker doesn't have any event handlers, ignore pointer events
+        const ignorePointerEvents =
+          (marker.onMouseDown ||
+            marker.onMouseMove ||
+            marker.onMouseUp ||
+            marker.onMouseEnter ||
+            marker.onMouseLeave) === undefined;
+
+        const children: Shape<Geometry>[] = [markerShape({ color: marker.color, eventHandlers, ignorePointerEvents })];
+        if (marker.text) {
+          children.push(
+            text({
+              text: marker.text,
+              x: -15,
+              y: -10,
+              color: marker.color,
+              align: "end",
+              baseline: "middle",
+              size: "13px",
+            }),
+          );
+        }
+
+        return Group.of({
+          children,
+          transform: Transform.of({ translate: { x, y }, scale: { x: marker.scale, y: marker.scale } }),
+        });
+      }),
+    });
+  }
+
+  @computed
+  get outOfBoundsMarkers(): Group {
+    const y = this.canvas.height - 12;
+    const outOfBoundsMarkers = this.markerViewModels.filter((m) => m.marker.clampToView && !m.isInView);
+    const centrePixel = this.canvas.width / 2;
+
+    // Sort by furthest to the centre of the view so that closest appears on top (rendered last)
+    const sortedMarkers = outOfBoundsMarkers.sort((a, b) => Math.abs(b.x - centrePixel) - Math.abs(a.x - centrePixel));
+
+    // Function for scaling markers based on their distance from the view
+    function getScale(distance: number) {
+      // Scale with negative exponential function to make markers scale fast initially and then more gradually
+      // as they get further away.
+      // 'power' a lower value increases the range that the markers scale over
+      // 'minScale' is the minimum scale that the markers will be scaled to
+      // 'base' is the base of the exponential function, changing the steepness of the curve
+      const power = 1 / 8000;
+      const minScale = 0.7;
+      const base = Math.E;
+      const exp = Math.pow(base, -(distance * power));
+
+      // Clamp the scale within valid range
+      return clamp(exp, minScale, 1);
+    }
+
+    return Group.of({
+      children: sortedMarkers.map(({ x, marker }) => {
+        // Scale down markers as they move further from the view
+        const distanceToEdge = x < 0 ? -x : x - this.canvas.width;
+        const scale = marker.scale * getScale(distanceToEdge);
+
+        // Rotate and shift the marker up so the base is at the edge of the view
+        const transform = Transform.of({
+          translate: { x: clamp(x, 0, this.canvas.width), y },
+          rotate: x < 0 ? Math.PI / 2 : -Math.PI / 2,
+          scale: { x: scale, y: scale },
+        });
+
+        // Center the view on the marker if it is clicked
+        const eventHandlers: Render2DEventHandlers = {
+          onMouseDown: (e: Render2DMouseEvent) => {
+            this.controller.setViewCentre(marker.timestamp);
+            e.stopPropagation();
+          },
+        };
+
+        return Group.of({ children: [markerShape({ color: marker.color, eventHandlers })], transform });
+      }),
+    });
+  }
+}

--- a/nusight2/src/client/components/timeline/highlight_range/timeline_highlight_range.tsx
+++ b/nusight2/src/client/components/timeline/highlight_range/timeline_highlight_range.tsx
@@ -1,0 +1,55 @@
+import { useContext, useEffect } from "react";
+import { usePropertyChange } from "@hooks/use_property_change";
+import { action, observable } from "mobx";
+import { observer } from "mobx-react";
+
+import { HighlightRangeModel } from "../model";
+import { timelineContext } from "../view";
+
+export type TimelineHighlightRangeProps = HighlightRangeModel;
+
+export const TimelineHighlightRange = observer(function TimelineHighlightRange(props: TimelineHighlightRangeProps) {
+  const context = useContext(timelineContext);
+  if (!context) {
+    throw new Error("Cannot have a <HighlightRange> component outside of a <TimelineView>");
+  }
+
+  const { model } = context;
+
+  const highlightRangeModel = usePropertyChange<TimelineHighlightRangeProps, HighlightRangeModel>(
+    () =>
+      observable({
+        start: props.start,
+        end: props.end,
+        color: props.color,
+        borderColor: props.borderColor,
+        hideFlags: props.hideFlags,
+        hideBody: props.hideBody,
+        onMouseDown: props.onMouseDown,
+        onMouseUp: props.onMouseUp,
+        onMouseMove: props.onMouseMove,
+        onMouseEnter: props.onMouseEnter,
+        onMouseLeave: props.onMouseLeave,
+      }),
+    action((instance, newValue) => {
+      instance.start = newValue.start;
+      instance.end = newValue.end;
+      instance.color = newValue.color;
+      instance.borderColor = newValue.borderColor;
+      instance.hideFlags = newValue.hideFlags;
+      instance.hideBody = newValue.hideBody;
+      instance.onMouseDown = newValue.onMouseDown;
+      instance.onMouseUp = newValue.onMouseUp;
+      instance.onMouseMove = newValue.onMouseMove;
+      instance.onMouseEnter = newValue.onMouseEnter;
+      instance.onMouseLeave = newValue.onMouseLeave;
+    }),
+    props,
+  );
+
+  useEffect(() => {
+    return model.addHighlightRange(highlightRangeModel);
+  }, [model, highlightRangeModel]);
+
+  return null;
+});

--- a/nusight2/src/client/components/timeline/marker/timeline_marker.tsx
+++ b/nusight2/src/client/components/timeline/marker/timeline_marker.tsx
@@ -1,0 +1,60 @@
+import { useContext, useEffect } from "react";
+import { usePropertyChange } from "@hooks/use_property_change";
+import { action, observable } from "mobx";
+import { observer } from "mobx-react";
+
+import { TimelineMarkerModel } from "../model";
+import { timelineContext } from "../view";
+
+/** Type where the specified keys are optional */
+type SetOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+export type TimelineMarkerProps = SetOptional<TimelineMarkerModel, "color" | "scale">;
+
+export const TimelineMarker = observer(function TimelineMarker(props: TimelineMarkerProps) {
+  const context = useContext(timelineContext);
+  if (!context) {
+    throw new Error("Cannot have a <TimelineMarker> component outside of a <TimelineView>");
+  }
+
+  const { model } = context;
+
+  // Create observable marker model from props that updates when any prop changes
+  const markerModel = usePropertyChange<TimelineMarkerProps, TimelineMarkerModel>(
+    () =>
+      observable({
+        timestamp: props.timestamp,
+        text: props.text,
+        color: props.color ?? "#ffffff",
+        scale: props.scale ?? 1,
+        hideTail: props.hideTail,
+        clampToView: props.clampToView,
+        onMouseDown: props.onMouseDown,
+        onMouseMove: props.onMouseMove,
+        onMouseUp: props.onMouseUp,
+        onMouseEnter: props.onMouseEnter,
+        onMouseLeave: props.onMouseLeave,
+      }),
+    action((instance, newValue) => {
+      instance.timestamp = newValue.timestamp;
+      instance.text = newValue.text;
+      instance.color = newValue.color ?? "#ffffff";
+      instance.scale = newValue.scale ?? 1;
+      instance.hideTail = newValue.hideTail;
+      instance.clampToView = newValue.clampToView;
+      instance.onMouseDown = newValue.onMouseDown;
+      instance.onMouseUp = newValue.onMouseUp;
+      instance.onMouseMove = newValue.onMouseMove;
+      instance.onMouseEnter = newValue.onMouseEnter;
+      instance.onMouseLeave = newValue.onMouseLeave;
+    }),
+    props,
+  );
+
+  // Add marker to timeline model while this component is mounted
+  useEffect(() => {
+    return model.addMarker(markerModel);
+  }, [model, markerModel]);
+
+  return null;
+});

--- a/nusight2/src/client/components/timeline/model.ts
+++ b/nusight2/src/client/components/timeline/model.ts
@@ -1,0 +1,92 @@
+import { action, computed, observable } from "mobx";
+
+export interface TimelineDataPoint {
+  timestamp: bigint;
+  color?: string;
+}
+
+export interface TimelineCameraView {
+  centre: bigint;
+  range: bigint;
+}
+
+export interface TimelineMarkerModel {
+  /** The timestamp of the marker */
+  timestamp: bigint;
+  /** Text to display beside the marker head */
+  text?: string;
+  /** Color of the marker */
+  color: string;
+  /** Scale of the marker */
+  scale: number;
+  /** Whether to hide the tail section of the marker */
+  hideTail?: boolean;
+  /** Whether to clamp the marker to the view bounds */
+  clampToView?: boolean;
+  onMouseDown?: (marker: TimelineMarkerModel) => void;
+  onMouseUp?: (marker: TimelineMarkerModel) => void;
+  onMouseMove?: (time: bigint, marker: TimelineMarkerModel) => void;
+  onMouseEnter?: (marker: TimelineMarkerModel) => void;
+  onMouseLeave?: (marker: TimelineMarkerModel) => void;
+}
+
+export interface HighlightRangeModel {
+  start: bigint;
+  end: bigint;
+  color: string;
+  borderColor?: string;
+  hideFlags?: boolean;
+  hideBody?: boolean;
+  onMouseDown?: (side: "start" | "end", range: HighlightRangeModel) => void;
+  onMouseUp?: (side: "start" | "end", range: HighlightRangeModel) => void;
+  onMouseMove?: (side: "start" | "end", time: bigint, range: HighlightRangeModel) => void;
+  onMouseEnter?: (side: "start" | "end", range: HighlightRangeModel) => void;
+  onMouseLeave?: (side: "start" | "end", range: HighlightRangeModel) => void;
+}
+
+export class TimelineModel {
+  view: TimelineCameraView;
+  @observable markers: TimelineMarkerModel[] = [];
+  @observable highlightRanges: HighlightRangeModel[] = [];
+
+  constructor(view: TimelineCameraView) {
+    this.view = view;
+  }
+
+  /**
+   * Adds a marker to this timeline model.
+   * This returns a callback to remove the marker from this model.
+   */
+  @action
+  addMarker(marker: TimelineMarkerModel) {
+    this.markers.push(marker);
+    return action(() => {
+      const idx = this.markers.indexOf(marker);
+      if (idx !== -1) {
+        this.markers.splice(idx, 1);
+      }
+    });
+  }
+
+  /**
+   * Adds a highlight range to this timeline model.
+   * This returns a callback to remove the highlight range from this model.
+   */
+  @action
+  addHighlightRange(range: HighlightRangeModel) {
+    this.highlightRanges.push(range);
+    return action(() => {
+      const idx = this.highlightRanges.indexOf(range);
+      if (idx !== -1) {
+        this.highlightRanges.splice(idx, 1);
+      }
+    });
+  }
+
+  /** The min and max timestamps of the current view */
+  @computed
+  get viewBounds() {
+    const halfViewRange = this.view.range / 2n;
+    return { min: this.view.centre - halfViewRange, max: this.view.centre + halfViewRange };
+  }
+}

--- a/nusight2/src/client/components/timeline/prevent_mouse_scroll.tsx
+++ b/nusight2/src/client/components/timeline/prevent_mouse_scroll.tsx
@@ -1,0 +1,21 @@
+import React, { useRef } from "react";
+import { useEffect } from "react";
+
+/** Scrolling using the mouse wheel from inside this element is prevented */
+export function PreventMouseScroll(props: { className?: string; children?: React.ReactNode }) {
+  const element = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const preventScroll = (e: WheelEvent) => e.preventDefault();
+    element.current?.addEventListener("wheel", preventScroll, { passive: false });
+    return () => {
+      element.current?.removeEventListener("wheel", preventScroll);
+    };
+  }, []);
+
+  return (
+    <div ref={element} className={props.className}>
+      {props.children}
+    </div>
+  );
+}

--- a/nusight2/src/client/components/timeline/row/timeline_row.tsx
+++ b/nusight2/src/client/components/timeline/row/timeline_row.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback, useContext } from "react";
+import { Render2DMouseEvent } from "@client/render2d/event/mouse_event";
+import { Renderer } from "@client/render2d/renderer";
+import { useUpdatable } from "@hooks/use_updatable";
+import { observer } from "mobx-react";
+
+import { TimelineDataPoint } from "../model";
+import { timelineContext } from "../view";
+
+import { TimelineRowViewModel } from "./view_model";
+
+export interface TimelineRowProps {
+  dataPoints?: TimelineDataPoint[];
+  connectorPoints?: TimelineDataPoint[];
+  highlightedDataPoints?: TimelineDataPoint[];
+  className?: string;
+  dataPointWidth?: number;
+  dataPointHeight?: number;
+  connectorHeight?: number;
+  onDataPointClick?: (dataPoint: TimelineDataPoint, e: Render2DMouseEvent) => void;
+}
+
+/**
+ * Render a timeline row, using the view from the current timeline context.
+ *
+ * The default color of the data points and connectors in the row uses the current CSS 'color' value.
+ */
+export const TimelineRow = observer((props: TimelineRowProps) => {
+  const { dataPoints, connectorPoints, highlightedDataPoints, className, onDataPointClick } = props;
+  const { dataPointWidth, dataPointHeight, connectorHeight } = props;
+
+  const context = useContext(timelineContext);
+
+  if (!context) {
+    throw new Error("Cannot have a <TimelineRow> component outside of <TimelineView>");
+  }
+
+  const { model, controller } = context;
+  const viewModelOpts: ConstructorParameters<typeof TimelineRowViewModel> = [
+    model,
+    controller,
+    dataPoints,
+    connectorPoints,
+    highlightedDataPoints,
+    dataPointWidth,
+    dataPointHeight,
+    connectorHeight,
+    onDataPointClick,
+  ];
+
+  // Create single view model instance that updates when props change
+  const viewModel = useUpdatable(
+    () => new TimelineRowViewModel(...viewModelOpts),
+    (instance, newOpts) => instance.update(newOpts),
+    viewModelOpts,
+  );
+
+  // Track size in px of renderer canvas and update it on the view model
+  const onResize = useCallback((width: number, height: number) => {
+    viewModel.setCanvasSize({ width: Math.floor(width), height: Math.floor(height) });
+  }, []);
+
+  return (
+    <div className={className}>
+      <div className="relative w-full h-full">
+        <Renderer
+          engine="svg"
+          camera={viewModel.camera}
+          scene={viewModel.scene}
+          eventHandlers={viewModel.defaultEventHandlers}
+          onResize={onResize}
+        />
+      </div>
+    </div>
+  );
+});

--- a/nusight2/src/client/components/timeline/row/view_model.ts
+++ b/nusight2/src/client/components/timeline/row/view_model.ts
@@ -1,0 +1,505 @@
+import { ClusteringTree, TreeData, TreeDataCluster } from "@client/data_structures/cluster_tree";
+import { Render2DEventHandlers } from "@client/render2d/event/event_handlers";
+import { Render2DMouseEvent } from "@client/render2d/event/mouse_event";
+import { Geometry } from "@client/render2d/object/geometry";
+import { Group } from "@client/render2d/object/group";
+import { Shape } from "@client/render2d/object/shape";
+import { clamp } from "@shared/math/clamp";
+import { Transform } from "@shared/math/transform";
+import { Vector2 } from "@shared/math/vector2";
+import { action, computed, observable } from "mobx";
+import { createTransformer } from "mobx-utils";
+
+import { TimelineController } from "../controller";
+import { line, rectangle, text } from "../geometry";
+import { HighlightRangeModel, TimelineDataPoint } from "../model";
+import { TimelineModel } from "../model";
+import { TimelineViewModel } from "../view_model";
+
+const colors = {
+  content: "currentColor",
+  outlineInner: "var(--color-auto-ring-inner)",
+  outlineOuter: "var(--color-auto-ring-outer)",
+  dataPointBorder: "rgba(0,0,0,0.2)",
+  dataClusterText: "rgba(0,0,0,0.4)",
+} as const;
+
+const DefaultAppearance = {
+  dataPoint: { width: 15, height: 18 },
+  connector: { height: 4 },
+} as const;
+
+export class TimelineRowViewModel extends TimelineViewModel {
+  private readonly innerOutlineWidth = 1.5;
+  private readonly outerOutlineWidth = 3.5;
+
+  @observable.ref private data: TimelineDataPoint[];
+  @observable.shallow private connectors: TimelineDataPoint[];
+  @observable.shallow private highlightedDataPoints: TimelineDataPoint[];
+
+  @observable dataPointWidth: number;
+  @observable dataPointHeight: number;
+  @observable connectorHeight: number;
+
+  private onDataPointClick?: (dataPoint: TimelineDataPoint, e: Render2DMouseEvent) => void;
+
+  constructor(
+    model: TimelineModel,
+    controller: TimelineController,
+    data?: TimelineDataPoint[],
+    connectorPoints?: TimelineDataPoint[],
+    highlightedPoints?: TimelineDataPoint[],
+    dataPointWidth?: number,
+    dataPointHeight?: number,
+    connectorHeight?: number,
+    onDataPointClick?: (dataPoint: TimelineDataPoint, e: Render2DMouseEvent) => void,
+  ) {
+    super(model, controller);
+    this.data = data ?? [];
+    this.connectors = connectorPoints ?? [];
+    this.highlightedDataPoints = highlightedPoints ?? [];
+    this.dataPointWidth = dataPointWidth ?? DefaultAppearance.dataPoint.width;
+    this.dataPointHeight = dataPointHeight ?? DefaultAppearance.dataPoint.height;
+    this.connectorHeight = connectorHeight ?? DefaultAppearance.connector.height;
+    this.onDataPointClick = onDataPointClick;
+  }
+
+  @action
+  update(args: ConstructorParameters<typeof TimelineRowViewModel>) {
+    const [
+      model,
+      controller,
+      data,
+      connectorPoints,
+      highlightedPoints,
+      dataPointWidth,
+      dataPointHeight,
+      connectorHeight,
+      onDataPointClick,
+    ] = args;
+    this.model = model;
+    this.controller = controller;
+    this.data = data ?? [];
+    this.connectors = connectorPoints ?? [];
+    this.highlightedDataPoints = highlightedPoints ?? [];
+    this.dataPointWidth = dataPointWidth ?? DefaultAppearance.dataPoint.width;
+    this.dataPointHeight = dataPointHeight ?? DefaultAppearance.dataPoint.height;
+    this.connectorHeight = connectorHeight ?? DefaultAppearance.connector.height;
+    this.onDataPointClick = onDataPointClick;
+  }
+
+  /** Camera transform to convert coordinates to pixel values */
+  @computed
+  get camera(): Transform {
+    return Transform.of({
+      scale: Vector2.of(this.canvas.width, -this.canvas.height),
+      // Half pixel offset centers coordinates on pixels instead of the
+      // border between pixels. This means lines with width 1 will display properly.
+      translate: Vector2.of(this.canvas.width / 2 + 0.5, 0),
+    });
+  }
+
+  @computed
+  get scene(): Group {
+    return Group.of({
+      children: [
+        this.verticalGridLines,
+        this.connectorsGeometry,
+        this.nodesGeometry,
+        this.highlightedDataPointsGeometry,
+        this.markerTails,
+        this.highlightRanges,
+      ],
+    });
+  }
+
+  /** Minimum time gap between data points before they are clustered together */
+  @computed
+  get minDataPointGap() {
+    const nanosPerPixel = this.model.view.range / BigInt(this.canvas.width);
+    return BigInt(this.dataPointWidth + 1) * nanosPerPixel;
+  }
+
+  /** This row's data as a cluster tree */
+  @computed
+  get dataClusterTree() {
+    return new ClusteringTree((dataPoint) => dataPoint.timestamp, this.data);
+  }
+
+  /** Highlighted data points to only include the ones in this row's data */
+  @computed
+  get highlightedDataPointsInRow() {
+    return this.highlightedDataPoints.filter((dataPoint) => this.data.includes(dataPoint));
+  }
+
+  /**
+   * The visible nodes of each row depending on the zoom level and offset of the view.
+   * This merges data points together into a cluster if they are overlapping.
+   */
+  @computed
+  get visibleNodes() {
+    const { min, max } = this.model.viewBounds;
+    const nodes: TreeData<TimelineDataPoint>[] = [];
+
+    // Get the first node before and after our range
+    const [prev, next] = this.dataClusterTree.getBoundingData(min, max, this.minDataPointGap);
+
+    // Add all the nodes in the range
+    prev && nodes.push(prev);
+    nodes.push(...this.dataClusterTree.getData(this.minDataPointGap, min, max));
+    next && nodes.push(next);
+
+    return nodes;
+  }
+
+  /** Checks if a data point's corresponding node is currently visible */
+  private readonly isNodeVisible = createTransformer((dataPoint: TimelineDataPoint) => {
+    return this.visibleNodes.find((node) => node.type === "single" && node.value === dataPoint);
+  });
+
+  private getClosestDataPoint(timestamp: bigint): TimelineDataPoint | undefined {
+    const [left, right] = this.dataClusterTree.getBoundingData(timestamp, timestamp);
+
+    // Check if there is 0 or 1 closest data points, returning undefined or that
+    // data point respectively.
+    if (!left || !right) {
+      return left ? left.value : right?.value;
+    }
+
+    // If there is a data point on both sides return the one with the closest timestamp
+    const leftDist = Math.abs(Number(this.hoveredTime - left.value.timestamp));
+    const rightDist = Math.abs(Number(this.hoveredTime - right.value.timestamp));
+    return leftDist < rightDist ? left.value : right.value;
+  }
+
+  /** The connector points filtered to only include changes in color */
+  @computed
+  get filteredConnectorPoints() {
+    const defaultColor = colors.content;
+    return this.connectors.filter((dataPoint, i, connectors) => {
+      // Always include first and last data points
+      if (i === 0 || i === connectors.length - 1) {
+        return true;
+      }
+
+      const thisColor = dataPoint.color ?? defaultColor;
+      const prevColor = connectors[i - 1].color ?? defaultColor;
+      return thisColor !== prevColor;
+    });
+  }
+
+  /** Vertical lines at the time points of the markers from the model */
+  @computed
+  private get markerTails(): Group {
+    const { height } = this.canvas;
+    const markersWithTail = this.model.markers.filter((marker) => !marker.hideTail);
+    return Group.of({
+      children: markersWithTail.map((marker) =>
+        line({
+          x: this.timeToPixel(marker.timestamp),
+          y: -height / 2,
+          y2: height / 2,
+          color: marker.color,
+          width: 2,
+          ignorePointerEvents: true,
+        }),
+      ),
+    });
+  }
+
+  @computed
+  private get highlightRanges(): Group {
+    // Filter out ranges with the body hidden
+    const visibleRanges = this.model.highlightRanges.filter((range) => !range.hideBody);
+    if (visibleRanges.length === 0) {
+      return Group.of();
+    }
+
+    const { height } = this.canvas;
+    const hitBoxWidth = 8;
+
+    // Create the geometry for one side of a highlight range
+    const createGeometry = (side: "start" | "end", range: HighlightRangeModel) => {
+      return [
+        line({
+          // Shift the line a little to place it on the outside of the actual range.
+          // This means that when the range is 0, both lines will be visible.
+          x: this.timeToPixel(range[side]) + (side === "start" ? -0.5 : 0.5),
+          y: -height / 2,
+          y2: height / 2,
+          color: range.borderColor ?? range.color,
+          width: 1.5,
+          ignorePointerEvents: true,
+        }),
+        // Rectangle to serve as the hitbox for the range bounds
+        rectangle({
+          // Set the side of the hitbox on its line so that when the range
+          // is 0, the hitboxes don't overlap and both sides are clickable.
+          x: this.timeToPixel(range[side]) + (side === "start" ? -hitBoxWidth : 0),
+          width: hitBoxWidth,
+          y: -height / 2,
+          height: height,
+          color: "transparent",
+          border: "transparent",
+          cursor: "ew-resize",
+          eventHandlers: {
+            onMouseDown: (e: Render2DMouseEvent) => {
+              range.onMouseDown?.(side, range);
+              e.stopPropagation();
+            },
+            onMouseUp: () => range.onMouseUp?.(side, range),
+            onMouseMove: () => range.onMouseMove?.(side, this.hoveredTime, range),
+            onMouseEnter: () => range.onMouseEnter?.(side, range),
+            onMouseLeave: () => range.onMouseLeave?.(side, range),
+          },
+        }),
+      ];
+    };
+
+    return Group.of({
+      children: visibleRanges.flatMap((highlightRange) => [
+        rectangle({
+          x: this.timeToPixel(highlightRange.start),
+          width: this.timeToPixel(highlightRange.end) - this.timeToPixel(highlightRange.start),
+          y: -height / 2,
+          height: height,
+          color: highlightRange.color,
+          alpha: 0.2,
+          border: "transparent",
+        }),
+        ...createGeometry("start", highlightRange),
+        ...createGeometry("end", highlightRange),
+      ]),
+    });
+  }
+
+  /** Vertical lines to show time points at set intervals */
+  @computed
+  private get verticalGridLines(): Group {
+    const children: Shape<Geometry>[] = [];
+    const { major, minor } = this.timeGridPositions;
+    const { height } = this.canvas;
+    const color = "var(--color-auto-contrast-6)";
+
+    minor.forEach((time) =>
+      children.push(line({ x: time.position, y: -height / 2, y2: height / 2, color, alpha: 0.2 })),
+    );
+    major.forEach((time) =>
+      children.push(line({ x: time.position, y: -height / 2, y2: height / 2, color, alpha: 0.5 })),
+    );
+
+    return Group.of({ children });
+  }
+
+  /** Geometry for all the connection lines between data points */
+  @computed
+  private get connectorsGeometry() {
+    const children = this.filteredConnectorPoints.map(this.createConnectorGeometry);
+    return Group.of({ children });
+  }
+
+  /** Geometry for the nodes (data points and clusters) of this row */
+  @computed
+  private get nodesGeometry() {
+    const children = this.visibleNodes.map(this.createNodeGeometry);
+    return Group.of({ children });
+  }
+
+  /** Geometry for the nodes that are currently highlighted */
+  @computed
+  private get highlightedDataPointsGeometry() {
+    const children = this.highlightedDataPointsInRow.map(this.createHighlightedDataPointGeometry);
+    return Group.of({ children });
+  }
+
+  /** Create geometry for the connector from a connector point to the next connector point */
+  private readonly createConnectorGeometry = createTransformer((dataPoint: TimelineDataPoint) => {
+    const defaultColor = colors.content;
+    const height = this.connectorHeight;
+    const { width } = this.canvas;
+
+    const nextDataPoint = this.filteredConnectorPoints[this.filteredConnectorPoints.indexOf(dataPoint) + 1];
+    if (!nextDataPoint) {
+      return Group.of();
+    }
+
+    const x1 = clamp(this.timeToPixel(dataPoint.timestamp), 0, width);
+    const x2 = clamp(this.timeToPixel(nextDataPoint.timestamp), 0, width);
+
+    const commonOpts = {
+      x: x1,
+      y: -height / 2,
+      width: x2 - x1,
+      height,
+      color: dataPoint.color ?? defaultColor,
+      cursor: "pointer",
+    } as const;
+
+    return Group.of({
+      children: [
+        // Using multiple layers, draw the connector with a dark border
+        rectangle(commonOpts),
+        rectangle({ ...commonOpts, color: colors.dataPointBorder }),
+        rectangle({ ...commonOpts, y: -height / 2 + 1, height: height - 2 }),
+      ],
+    });
+  });
+
+  /** Create geometry for a node containing either a cluster or single data point */
+  private readonly createNodeGeometry = (node: TreeData<TimelineDataPoint>) => {
+    return node.type === "cluster" ? this.createClusterGeometry(node) : this.createDataPointGeometry(node.value);
+  };
+
+  /** Create geometry for a single cluster of data points */
+  private readonly createClusterGeometry = createTransformer((node: TreeDataCluster<TimelineDataPoint>): Group => {
+    const defaultColor = colors.content;
+    const { min, max } = this.model.viewBounds;
+    const height = this.dataPointHeight;
+
+    // If outside the view range return empty group
+    if (node.max.timestamp < min || node.min.timestamp > max) {
+      return Group.of();
+    }
+
+    // Timestamp of the left and right of the geometry
+    const timestampLeft = node.min.timestamp < min ? min : node.min.timestamp > max ? max : node.min.timestamp;
+    const timestampRight = node.max.timestamp < min ? min : node.max.timestamp > max ? max : node.max.timestamp;
+
+    // Positions of the left and right of the geometry
+    const x1 = this.timeToPixel(timestampLeft);
+    const x2 = this.timeToPixel(timestampRight);
+
+    const children: Shape<Geometry>[] = [];
+
+    const eventHandlers: Render2DEventHandlers | undefined = this.onDataPointClick
+      ? {
+          onMouseDown: (e) => {
+            const closestDataPoint = this.getClosestDataPoint(this.hoveredTime);
+            if (closestDataPoint) {
+              this.onDataPointClick?.(closestDataPoint, e);
+            }
+          },
+        }
+      : undefined;
+
+    const x = x1 - this.dataPointWidth / 2;
+    const y = -height / 2;
+    const width = x2 - x1 + this.dataPointWidth;
+    const color = node.min.color ?? defaultColor;
+    const commonOpts = { x, y, width, height, color, cursor: "pointer", borderRadius: "full", eventHandlers } as const;
+
+    // Using multiple layers, draw the cluster with a dark border
+    children.push(
+      rectangle(commonOpts),
+      rectangle({ ...commonOpts, color: colors.dataPointBorder }),
+      rectangle({
+        ...commonOpts,
+        x: x1 - this.dataPointWidth / 2 + 1,
+        y: -height / 2 + 1,
+        width: x2 - x1 + this.dataPointWidth - 2,
+        height: height - 2,
+      }),
+    );
+
+    if (node.childCount > 5) {
+      // Centre position of the centre of the geometry
+      const visibleCentre = (x1 + x2) / 2;
+
+      // Timestamp centre and range of visible section of cluster
+      const localCentre = (timestampLeft + timestampRight) / 2n;
+
+      // Timestamp centre and range of entire cluster
+      const globalCentre = (node.max.timestamp + node.min.timestamp) / 2n;
+      const globalRange = node.max.timestamp - node.min.timestamp;
+
+      // Position text to shift it toward global centre without going off screen
+      // (x0.8 to stop the text partially going out of view)
+      const textPos = visibleCentre - (Number(localCentre - globalCentre) / Number(globalRange)) * (x2 - x1) * 0.8;
+
+      // Calculate frequency of nodes in the cluster
+      const frequency = (node.childCount / Number(node.max.timestamp - node.min.timestamp)) * 1e9;
+      children.push(
+        text({
+          text: `${frequency.toFixed(2)}Hz`,
+          x: textPos,
+          y: 1,
+          size: "13px",
+          color: colors.dataClusterText,
+          baseline: "middle",
+        }),
+      );
+    }
+
+    return Group.of({ children });
+  });
+
+  /** Create geometry for a single data point with an outline */
+  private readonly createHighlightedDataPointGeometry = createTransformer((dataPoint: TimelineDataPoint) => {
+    const width = this.dataPointWidth;
+    const height = this.dataPointHeight;
+
+    const x = this.timeToPixel(dataPoint.timestamp);
+    const commonOpts = { x, y: -height / 2 + width / 2, y2: height / 2 - width / 2, cap: "round" } as const;
+
+    // If the dataPoint's node is visible create a solid outline, otherwise if the dataPoint is part of a
+    // cluster create a dashed outline
+    const outline = this.isNodeVisible(dataPoint)
+      ? [
+          line({ ...commonOpts, width: width + 2 * this.outerOutlineWidth, color: colors.outlineOuter }),
+          line({ ...commonOpts, width: width + 2 * this.innerOutlineWidth, color: colors.outlineInner }),
+        ]
+      : [
+          rectangle({
+            borderRadius: "full",
+            color: colors.outlineInner,
+            x: x - width / 2 - this.outerOutlineWidth,
+            y: -height / 2 - this.outerOutlineWidth,
+            width: width + 2 * this.outerOutlineWidth,
+            height: height + 2 * this.outerOutlineWidth,
+          }),
+          rectangle({
+            borderRadius: "full",
+            color: "transparent",
+            alpha: 0,
+            border: colors.outlineOuter,
+            borderWidth: 2,
+            // Note: borderDashArray is not supported in NUbots BasicAppearance; dashed border renders solid
+            borderDashArray: "4",
+            x: x - width / 2 - this.outerOutlineWidth + 0.5,
+            y: -height / 2 - this.outerOutlineWidth + 0.5,
+            width: width + 2 * this.outerOutlineWidth - 1,
+            height: height + 2 * this.outerOutlineWidth - 1,
+          }),
+        ];
+
+    return Group.of({ children: [...outline, this.createDataPointGeometry(dataPoint)] });
+  });
+
+  /** Create geometry for a single data point */
+  private readonly createDataPointGeometry = createTransformer((dataPoint: TimelineDataPoint) => {
+    const defaultColor = colors.content;
+    const width = this.dataPointWidth;
+    const height = this.dataPointHeight;
+
+    const eventHandlers: Render2DEventHandlers = { onMouseDown: (e) => this.onDataPointClick?.(dataPoint, e) };
+
+    const x = this.timeToPixel(dataPoint.timestamp);
+    const commonOpts = {
+      x,
+      y: -height / 2 + width / 2,
+      y2: height / 2 - width / 2,
+      cursor: "pointer",
+      cap: "round",
+      eventHandlers,
+    } as const;
+
+    return Group.of({
+      children: [
+        // Using multiple layers, draw the data point with a dark border
+        line({ ...commonOpts, width, color: dataPoint.color ?? defaultColor }),
+        line({ ...commonOpts, width, color: colors.dataPointBorder }),
+        line({ ...commonOpts, width: width - 2, color: dataPoint.color ?? defaultColor }),
+      ],
+    });
+  });
+}

--- a/nusight2/src/client/components/timeline/stories/highlight_range.stories.tsx
+++ b/nusight2/src/client/components/timeline/stories/highlight_range.stories.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { lightOrDarkDecorator } from "@components/storybook/color_mode";
+import { Meta, StoryObj } from "@storybook/react";
+import { action, observable } from "mobx";
+
+import { TimelineHeader } from "../header/timeline_header";
+import { TimelineHighlightRange } from "../highlight_range/timeline_highlight_range";
+import { TimelineRow } from "../row/timeline_row";
+import { TimelineView } from "../view";
+
+const meta: Meta<typeof TimelineHighlightRange> = {
+  title: "components/Timeline/HighlightRange",
+  decorators: [lightOrDarkDecorator],
+};
+
+export default meta;
+
+export const Marker: StoryObj<typeof TimelineHighlightRange> = {
+  argTypes: {
+    color: { control: "color" },
+    hideFlags: { control: "boolean" },
+    hideBody: { control: "boolean" },
+  },
+  args: {
+    color: "#FF0000",
+    hideFlags: false,
+    hideBody: false,
+  },
+
+  render: ({ color, hideBody, hideFlags }) => {
+    const view = useMemo(() => observable({ centre: BigInt(0), range: BigInt(10e9) }), []);
+
+    const [highlightStart, setHighlightStart] = useState(BigInt(-2e9));
+    const [highlightEnd, setHighlightEnd] = useState(BigInt(2e9));
+    const [isRangeSelected, setIsRangeSelected] = useState(false);
+
+    const onMouseDown = useCallback(() => setIsRangeSelected(true), []);
+    const onMouseUp = useCallback(() => setIsRangeSelected(false), []);
+    const onMouseMove = useCallback(
+      action((side: "start" | "end", timestamp: bigint) => {
+        if (isRangeSelected) {
+          if (side === "start") {
+            setHighlightStart(timestamp > highlightEnd ? highlightEnd : timestamp);
+          } else {
+            setHighlightEnd(timestamp < highlightStart ? highlightStart : timestamp);
+          }
+        }
+      }),
+      [isRangeSelected],
+    );
+
+    return (
+      <div className="w-full rounded overflow-hidden bg-auto-surface-0">
+        <TimelineView view={view}>
+          <TimelineHeader className="h-12 border-b border-auto" />
+          <TimelineRow className="h-40" />
+          <TimelineHighlightRange
+            start={highlightStart}
+            end={highlightEnd}
+            color={color}
+            hideFlags={hideFlags}
+            hideBody={hideBody}
+            onMouseDown={onMouseDown}
+            onMouseUp={onMouseUp}
+            onMouseMove={onMouseMove}
+          />
+        </TimelineView>
+      </div>
+    );
+  },
+};

--- a/nusight2/src/client/components/timeline/stories/marker.stories.tsx
+++ b/nusight2/src/client/components/timeline/stories/marker.stories.tsx
@@ -1,0 +1,51 @@
+import React, { useMemo } from "react";
+import { lightOrDarkDecorator } from "@components/storybook/color_mode";
+import { Meta, StoryObj } from "@storybook/react";
+import { observable } from "mobx";
+
+import { TimelineHeader } from "../header/timeline_header";
+import { TimelineMarker } from "../marker/timeline_marker";
+import { TimelineRow } from "../row/timeline_row";
+import { TimelineView } from "../view";
+
+const meta: Meta<typeof TimelineMarker> = {
+  title: "components/Timeline/Marker",
+  decorators: [lightOrDarkDecorator],
+  argTypes: {
+    text: { control: { type: "text" } },
+    color: { control: { type: "color" } },
+    scale: { control: { type: "range", min: 0.1, max: 2, step: 0.05 } },
+    clampToView: { control: { type: "boolean" } },
+    hideTail: { control: { type: "boolean" } },
+  },
+  args: {
+    color: "#FF0000",
+    scale: 1,
+    clampToView: false,
+    hideTail: false,
+  },
+};
+
+export default meta;
+
+export const Marker: StoryObj<typeof TimelineMarker> = {
+  render: ({ text, color, scale, clampToView, hideTail }) => {
+    const view = useMemo(() => observable({ centre: BigInt(0), range: BigInt(10e9) }), []);
+    return (
+      <div className="w-full rounded overflow-hidden bg-auto-surface-0">
+        <TimelineView view={view}>
+          <TimelineHeader className="h-12 border-b border-auto" />
+          <TimelineRow className="h-40" />
+          <TimelineMarker
+            timestamp={0n}
+            text={text}
+            color={color}
+            scale={scale}
+            clampToView={clampToView}
+            hideTail={hideTail}
+          />
+        </TimelineView>
+      </div>
+    );
+  },
+};

--- a/nusight2/src/client/components/timeline/stories/timeline.stories.tsx
+++ b/nusight2/src/client/components/timeline/stories/timeline.stories.tsx
@@ -1,0 +1,172 @@
+import React, { useMemo, useState } from "react";
+import { IconButton } from "@components/icon_button/view";
+import { lightOrDarkDecorator } from "@components/storybook/color_mode";
+import { clamp } from "@shared/math/clamp";
+import { Meta, StoryObj } from "@storybook/react";
+import classNames from "classnames";
+import { action, observable } from "mobx";
+
+import { TimelineHeader } from "../header/timeline_header";
+import { TimelineMarker } from "../marker/timeline_marker";
+import { TimelineDataPoint } from "../model";
+import { TimelineRow } from "../row/timeline_row";
+import { TimelineView } from "../view";
+
+type StoryComponent = React.FunctionComponent<{
+  headerHeight: number;
+  rowHeight: number;
+  dataPointWidth: number;
+  dataPointHeight: number;
+  connectorHeight: number;
+}>;
+
+const meta: Meta<StoryComponent> = {
+  title: "components/Timeline",
+  decorators: [lightOrDarkDecorator],
+  argTypes: {
+    headerHeight: { control: { type: "range", min: 1, max: 200, step: 1 } },
+    rowHeight: { control: { type: "range", min: 1, max: 200, step: 1 } },
+    dataPointWidth: { control: { type: "range", min: 1, max: 200, step: 1 } },
+    dataPointHeight: { control: { type: "range", min: 1, max: 200, step: 1 } },
+    connectorHeight: { control: { type: "range", min: 1, max: 200, step: 1 } },
+  },
+  args: {
+    headerHeight: 60,
+  },
+};
+
+const currentTimeNanos = BigInt(Math.floor(Date.now() * 1e6));
+
+export default meta;
+
+function createTimestampRange(start: bigint, length: number, step: bigint) {
+  function variance() {
+    return BigInt(Math.floor(Math.random() * Number(step / 2n) - Number(step / 4n)));
+  }
+
+  return Array(length)
+    .fill(0n)
+    .map((_, i) => start + step * BigInt(i) + variance());
+}
+
+function createPackets(opts: { frequency: number; time: number }) {
+  const stepSize = Math.floor(1e9 / opts.frequency);
+  const length = Math.floor(opts.time / stepSize);
+  const step = BigInt(stepSize);
+
+  return createTimestampRange(currentTimeNanos, length, step).map((timestamp) => ({ timestamp }));
+}
+
+function fakeTimelineContent(): { dataPoints: TimelineDataPoint[]; className?: string }[] {
+  const footageLength = 100000000000;
+  return [
+    {
+      dataPoints: [
+        { timestamp: currentTimeNanos + BigInt(1e9), color: "#bb1cd4" },
+        { timestamp: currentTimeNanos + BigInt(2e9), color: "#bb1cd4" },
+        { timestamp: currentTimeNanos + BigInt(5e9), color: "#eb8334" },
+        { timestamp: currentTimeNanos + BigInt(6e9), color: "#bb1cd4" },
+        { timestamp: currentTimeNanos + BigInt(6.5e9), color: "#eb4034" },
+        { timestamp: currentTimeNanos + BigInt(9e9), color: "#1c99d4" },
+      ],
+    },
+    { dataPoints: createPackets({ frequency: 237.1, time: footageLength / 2 }), className: "text-red-500" },
+    { dataPoints: createPackets({ frequency: 10, time: footageLength }), className: "text-green-500" },
+    { dataPoints: createPackets({ frequency: 2, time: footageLength * 0.75 }), className: "text-blue-500" },
+  ];
+}
+
+export const Default: StoryObj<StoryComponent> = {
+  render: () => {
+    const view = useMemo(() => observable({ centre: currentTimeNanos, range: BigInt(10e9) }), []);
+    const content = useMemo(() => fakeTimelineContent(), []);
+
+    const [highlightedDataPoint, setHighlightedDataPoint] = useState<TimelineDataPoint | null>(null);
+
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="flex justify-end gap-1">
+          <IconButton onClick={action(() => (view.range += view.range / 5n))}>zoom_out</IconButton>
+          <IconButton onClick={action(() => (view.range -= view.range / 6n))}>zoom_in</IconButton>
+        </div>
+        <TimelineView view={view} className="flex flex-col w-full rounded overflow-hidden bg-auto-surface-0">
+          <TimelineHeader className="h-12 border-b border-auto" />
+          {content.map(({ dataPoints, className }, i) => (
+            <TimelineRow
+              key={i}
+              className={classNames("h-8 border-b border-auto", className)}
+              dataPoints={dataPoints}
+              highlightedDataPoints={highlightedDataPoint ? [highlightedDataPoint] : undefined}
+              onDataPointClick={setHighlightedDataPoint}
+            />
+          ))}
+        </TimelineView>
+      </div>
+    );
+  },
+};
+
+export const RangeLimit: StoryObj<StoryComponent> = {
+  render: () => {
+    const viewMin = 0n;
+    const viewMax = BigInt(10e9);
+    const minRange = BigInt(0.1e9);
+    const view = useMemo(() => observable({ centre: BigInt(5e9), range: BigInt(10e9) }), []);
+
+    return (
+      <div className="w-full rounded overflow-hidden bg-auto-surface-0">
+        <TimelineView
+          view={view}
+          onViewCentreChange={(viewCentre) => {
+            const min = viewMin + view.range / 2n;
+            const max = viewMax - view.range / 2n;
+            view.centre = clamp(viewCentre, min, max);
+          }}
+          onViewRangeChange={(viewRange) => {
+            view.range = clamp(viewRange, minRange, viewMax - viewMin);
+          }}
+        >
+          <TimelineHeader className="h-12 border-b border-auto" />
+          <TimelineRow className="h-40" />
+        </TimelineView>
+      </div>
+    );
+  },
+};
+
+export const TimeInput: StoryObj<StoryComponent> = {
+  render: () => {
+    const view = useMemo(() => observable({ centre: BigInt(5e9), range: BigInt(10e9) }), []);
+
+    return (
+      <div className="w-full rounded overflow-hidden bg-auto-surface-0">
+        <TimelineView view={view}>
+          <TimelineHeader className="h-12 border-b border-auto" />
+          <TimelineRow className="h-40" />
+          <DraggableMarker startTimestamp={BigInt(3e9)} color="#0ea5e9" />
+          <DraggableMarker startTimestamp={BigInt(7e9)} color="#e11d48" />
+        </TimelineView>
+      </div>
+    );
+  },
+};
+
+function DraggableMarker(props: { startTimestamp: bigint; color: string }) {
+  const { startTimestamp, color } = props;
+  const [timestamp, setTimestamp] = useState(startTimestamp);
+  const [isDragging, setIsDragging] = useState(false);
+  return (
+    <TimelineMarker
+      timestamp={timestamp}
+      color={color}
+      onMouseDown={() => setIsDragging(true)}
+      onMouseUp={() => setIsDragging(false)}
+      onMouseMove={(time) => {
+        if (isDragging) {
+          setTimestamp(time);
+        }
+      }}
+      clampToView
+    />
+  );
+}

--- a/nusight2/src/client/components/timeline/view.tsx
+++ b/nusight2/src/client/components/timeline/view.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useMemo } from "react";
+import { useUpdatable } from "@hooks/use_updatable";
+
+import { TimelineController, TimelineEventHandler } from "./controller";
+import { TimelineCameraView, TimelineModel } from "./model";
+
+interface TimelineContext {
+  model: TimelineModel;
+  controller: TimelineController;
+}
+
+export const timelineContext = createContext<TimelineContext | undefined>(undefined);
+
+export interface TimelineViewProps {
+  view: TimelineCameraView;
+  className?: string;
+  onViewRangeChange?: TimelineEventHandler;
+  onViewCentreChange?: TimelineEventHandler;
+  children?: React.ReactNode;
+}
+
+export function TimelineView({ view, className, onViewRangeChange, onViewCentreChange, children }: TimelineViewProps) {
+  // Create a single model instance that updates when props change
+  const model = useUpdatable(
+    () => new TimelineModel(view),
+    (instance, [view]) => (instance.view = view),
+    [view],
+  );
+
+  const controller = useMemo(
+    () => new TimelineController(model, { onViewRangeChange, onViewCentreChange }),
+    [model, onViewRangeChange, onViewRangeChange],
+  );
+
+  // Provide model to descendent timeline components
+  const context = useMemo<TimelineContext>(() => ({ model, controller }), [model, controller]);
+
+  return (
+    <timelineContext.Provider value={context}>
+      <div className={className}>{children}</div>
+    </timelineContext.Provider>
+  );
+}

--- a/nusight2/src/client/components/timeline/view_model.ts
+++ b/nusight2/src/client/components/timeline/view_model.ts
@@ -1,0 +1,151 @@
+import { Render2DEventHandlers } from "@client/render2d/event/event_handlers";
+import { Vector2 } from "@shared/math/vector2";
+import { action, computed, observable } from "mobx";
+
+import { TimelineController } from "./controller";
+import { TimelineModel } from "./model";
+
+export interface Dimensions {
+  width: number;
+  height: number;
+}
+
+export abstract class TimelineViewModel {
+  @observable.ref protected model: TimelineModel;
+  @observable.ref protected controller: TimelineController;
+
+  /** Current dimensions of the canvas */
+  @observable public canvas: Dimensions = { width: 100, height: 100 };
+
+  /** Current position of the mouse in the canvas */
+  @observable public mousePos = Vector2.of();
+
+  /** State of pan action */
+  @observable private panningState: { startPos: number; startViewCentre: bigint } | null = null;
+
+  constructor(model: TimelineModel, controller: TimelineController) {
+    this.model = model;
+    this.controller = controller;
+  }
+
+  @action
+  setCanvasSize(size: Dimensions) {
+    this.canvas = size;
+  }
+
+  /** Transform from a pixel x position on the canvas to a timestamp */
+  pixelToTime(pixel: number) {
+    const { range, centre } = this.model.view;
+    const start = centre - range / 2n;
+    const percentAcrossCanvas = pixel / this.canvas.width;
+    return start + BigInt(Math.floor(Number(range) * percentAcrossCanvas));
+  }
+
+  /** Transform from a timestamp to a pixel x position on the canvas */
+  timeToPixel(time: bigint): number {
+    const { range, centre } = this.model.view;
+    const start = centre - range / 2n;
+    const percentAcrossCanvas = Number(time - start) / Number(range);
+    return percentAcrossCanvas * this.canvas.width;
+  }
+
+  /** Transform from a timestamp to a pixel x position on the canvas */
+  timeToCanvasPercent(time: bigint): number {
+    const { range, centre } = this.model.view;
+    const start = centre - range / 2n;
+    const percentAcrossCanvas = Number(time - start) / Number(range);
+    return percentAcrossCanvas;
+  }
+
+  /** The timestamp at the mouse position */
+  @computed
+  get hoveredTime(): bigint {
+    return this.pixelToTime(this.mousePos.x);
+  }
+
+  /** Events that are triggered by mouse inputs on any part of the canvas */
+  readonly defaultEventHandlers: Render2DEventHandlers = {
+    /** Handle scrubbing and panning when the mouse is moved */
+    onMouseMove: action((e) => {
+      const mousePos = Vector2.of(e.x, e.y);
+      if (this.panningState) {
+        const mouseOffset = mousePos.x - this.panningState.startPos;
+        const timeOffset = BigInt(Math.floor((mouseOffset / this.canvas.width) * Number(this.model.view.range)));
+        this.controller.setViewCentre(this.panningState.startViewCentre - timeOffset);
+      }
+      this.mousePos = mousePos;
+    }),
+
+    /** Disable scrubbing and panning when the mouse is released */
+    onMouseUp: action((e) => {
+      if (e.button === 0) {
+        this.panningState = null;
+      }
+    }),
+
+    /** Start panning when the left mouse button is pressed */
+    onMouseDown: action((e) => {
+      if (e.button === 0) {
+        this.panningState = { startPos: this.mousePos.x, startViewCentre: this.model.view.centre };
+      }
+    }),
+
+    /** Zoom in or out when the scroll wheel is scrolled */
+    onWheel: action((e) => {
+      this.controller.zoom(Math.sign(e.deltaY) < 1 ? "in" : "out", this.pixelToTime(e.worldX));
+    }),
+  };
+
+  /**
+   * Evenly spaced timestamps in the current view range.
+   *
+   * Major grid lines are spaced timestamps where the distance between them is
+   * the smallest power of 10 that is greater than a minimum spacing value, or half
+   * that if it can fit.
+   *
+   * E.g. Major spaces go from 10s -> 5s -> 1s -> 0.5s -> 0.1s etc
+   *
+   * Minor grid lines are spaced by 1/10th of the major grid if it is a power of 10,
+   * otherwise 1/5th of the major grid.
+   */
+  @computed
+  get timeGridPositions() {
+    const { min, max } = this.model.viewBounds;
+
+    const minimumPixelSpacing = 200;
+    const minimumSpacing = BigInt(
+      Math.floor((minimumPixelSpacing / this.canvas.width) * Number(this.model.view.range)),
+    );
+
+    // Basically log10
+    const power = BigInt(minimumSpacing.toString().length);
+
+    let major = 10n ** power;
+    const minor = major / 10n;
+
+    if (major / 2n > minimumSpacing) {
+      major /= 2n;
+    }
+
+    // Generate an array of steps from the given start to the given end, spaced by
+    // the given step size
+    function getSteps(start: bigint, end: bigint, step: bigint) {
+      const length = (end - start) / step;
+      return Array.from(Array(Number(length)).keys(), (i) => start + BigInt(i) * step);
+    }
+
+    // First major timestamp before start of view
+    const start = min - (min % major);
+
+    const minorSteps = getSteps(start, max + minor, minor)
+      .filter((time) => time % major !== 0n)
+      .map((time) => ({ time, position: this.timeToCanvasPercent(time) * this.canvas.width }));
+
+    const majorSteps = getSteps(start, max + major, major).map((time) => ({
+      time,
+      position: this.timeToCanvasPercent(time) * this.canvas.width,
+    }));
+
+    return { major: majorSteps, minor: minorSteps };
+  }
+}

--- a/nusight2/src/client/data_structures/cluster_tree.ts
+++ b/nusight2/src/client/data_structures/cluster_tree.ts
@@ -1,0 +1,362 @@
+//
+// Binary Tree with the constraint that the gap between its immediate
+// children must be larger than the gaps between their children.
+//
+// This allows the content of the tree to be quickly retrieved at
+// any 'detail level' where clusters of leaves with a gap smaller
+// than the desired value are merged together into a cluster.
+//
+//                        o
+//                   /         \
+//                o               \
+//             /     \               \
+//           o         \               \
+//         /   \         \               \
+//        o     \           o              \
+//       / \     \         / \              \
+//      o   o     o       o   o              o
+//
+// Gap:  -3- --5-- ---7--- -3- ------14------
+//
+
+/**
+ * Return value from a tree search representing a single data point.
+ *
+ * This contains a reference to a data point inserted in the tree.
+ */
+export interface TreeDataSingle<T> {
+  type: "single";
+  value: T;
+}
+
+/** Return value from a tree search representing a cluster of data points */
+export interface TreeDataCluster<T> {
+  type: "cluster";
+
+  /** The highest data point of this cluster */
+  max: T;
+
+  /** The lowest data point of this cluster */
+  min: T;
+
+  /** The total number of data points in this cluster */
+  childCount: number;
+}
+
+/**
+ * A single return value for a tree search. This can be either a single data point or
+ * a cluster of data points.
+ */
+export type TreeData<T> = TreeDataSingle<T> | TreeDataCluster<T>;
+
+interface LeafNode<T, V extends number | bigint> {
+  type: "leaf";
+
+  /** The parent of this node. If undefined then this is the root. */
+  parent?: InnerNode<T, V>;
+
+  /** This node type points to an individual data point */
+  data: TreeDataSingle<T>;
+}
+
+/** A node in the tree that is not a leaf */
+interface InnerNode<T, V extends number | bigint> {
+  type: "inner";
+
+  /** The child of this node with lower data points.  */
+  low: MaybeLazyNode<T, V>;
+
+  /** The child of this node with higher data points.  */
+  high: MaybeLazyNode<T, V>;
+
+  /**
+   * The high side of the gap between this node's children.
+   * This is the lowest data point of the high side.
+   */
+  gapMax: V;
+
+  /**
+   * The low side of the gap between this node's children.
+   * This is the highest data point of the low side
+   */
+  gapMin: V;
+
+  /** The size of the gap between this node's children. This is `gapMax - gapMin`. */
+  gapSize: V;
+
+  /** This node type points to a cluster of data points. */
+  data: TreeDataCluster<T>;
+}
+
+/** A node that hasn't been computed yet. Stores the range that it represents. */
+interface LazyNode<T, V extends number | bigint> {
+  type: "lazy";
+  firstIndex: number;
+  lastIndex: number;
+  /** Will be called once this lazy node is resolved */
+  onResolved: (resolvedNode: Node<T, V>) => void;
+}
+
+type Node<T, V extends number | bigint> = InnerNode<T, V> | LeafNode<T, V>;
+
+type MaybeLazyNode<T, V extends number | bigint> = Node<T, V> | LazyNode<T, V>;
+
+/**
+ * Data structure for clustering values of a data series together.
+ *
+ * When the objects stored in this data structure are retrieved, a minimum `gap` can be
+ * specified, where any elements that are closer together than this gap size are
+ * grouped together into clusters.
+ *
+ * This allows for efficient viewing of large data series when the series only needs to
+ * be viewed at a lower resolution.
+ */
+export class ClusteringTree<T, V extends number | bigint> {
+  private root?: Node<T, V>;
+
+  private data: T[] = [];
+
+  /**
+   * Each element in this array stores the gap between the corresponding element in the data array
+   * and the one before it. For the first element, the gap is -1.
+   */
+  private gapSizes: number[] = [];
+
+  /**
+   * Constructor takes a list of starting data of the tree's type and a callback that takes
+   * an item in the tree and returns its numeric value, which is used for sorting and clustering.
+   *
+   * The data must already be sorted by its value.
+   */
+  constructor(
+    private readonly getValue: (value: T) => V,
+    data?: T[],
+  ) {
+    if (!data) {
+      return;
+    }
+
+    // Empty array, no root
+    if (data.length === 0) {
+      return;
+    }
+
+    this.setData(data);
+  }
+
+  /** Set the data stored in this tree */
+  setData(data: T[]) {
+    this.data = data;
+    this.gapSizes = data.map((d, i) => (i === 0 ? -1 : this.getValue(d) - this.getValue(data[i - 1])));
+    this.resolveLazyNode({
+      type: "lazy",
+      firstIndex: 0,
+      lastIndex: data.length - 1,
+      onResolved: (node) => (this.root = node),
+    });
+  }
+
+  /**
+   * Find the index of the largest gap between nodes in the specified range. This is used to build the
+   * tree, where the largest gap between a node's children determines where to split the
+   * child branches of the node.
+   */
+  private largestGapIndex(minIndex: number, maxIndex: number) {
+    let largestGap = -Infinity;
+    let largestGapIndex = -1;
+
+    for (let i = minIndex; i <= maxIndex; i++) {
+      const gapSize = this.gapSizes[i];
+      if (
+        gapSize > largestGap ||
+        // If the gap equals the current largest, give it a chance at being selected as the
+        // largest gap. This results in a more balanced tree if many of the data points have
+        // the same gap size, which makes the tree have more consistent access times.
+        (gapSize === largestGap && Math.random() < 1 / (maxIndex - minIndex))
+      ) {
+        largestGap = this.gapSizes[i];
+        largestGapIndex = i;
+      }
+    }
+
+    return largestGapIndex;
+  }
+
+  /** Convert a potentially lazy node in the tree to a resolved node */
+  private resolveLazyNode(node: MaybeLazyNode<T, V>): Node<T, V> {
+    if (node.type !== "lazy") {
+      return node;
+    }
+
+    // Only a single node, make a leaf
+    if (node.firstIndex === node.lastIndex) {
+      const resolvedNode: LeafNode<T, V> = {
+        type: "leaf",
+        data: {
+          type: "single",
+          value: this.data[node.firstIndex],
+        },
+      };
+      node.onResolved(resolvedNode);
+      return resolvedNode;
+    }
+
+    // Find the largest gap between this node's children
+    const largestGapIdx = this.largestGapIndex(node.firstIndex, node.lastIndex);
+    this.gapSizes[largestGapIdx] = -1;
+
+    // Get the values of the nodes either side of the gap
+    const gapMin = this.getValue(this.data[largestGapIdx - 1]);
+    const gapMax = this.getValue(this.data[largestGapIdx]);
+
+    // Create the inner node
+    const newNode: InnerNode<T, V> = {
+      type: "inner",
+      gapMin,
+      gapMax,
+      gapSize: (gapMax - gapMin) as V,
+      data: {
+        type: "cluster",
+        min: this.data[node.firstIndex],
+        max: this.data[node.lastIndex],
+        childCount: node.lastIndex - node.firstIndex + 1,
+      },
+      // Make the children lazy nodes, where their indices are set to
+      // either side of the largest gap between all this node's children
+      low: {
+        type: "lazy",
+        firstIndex: node.firstIndex,
+        lastIndex: largestGapIdx - 1,
+        onResolved: (node) => (newNode.low = node),
+      },
+      high: {
+        type: "lazy",
+        firstIndex: largestGapIdx,
+        lastIndex: node.lastIndex,
+        onResolved: (node) => (newNode.high = node),
+      },
+    };
+    node.onResolved(newNode);
+    return newNode;
+  }
+
+  /**
+   * Search the tree using a search callback. The search callback returns either a boolean indicating
+   * if the node being searched for is found, or the next node to continue the search at (typically a
+   * child of the current node). Returns the node if found, otherwise `undefined`
+   */
+  private searchTree(searchFn: (node: Node<T, V>) => MaybeLazyNode<T, V> | boolean): Node<T, V> | undefined {
+    if (!this.root) {
+      return undefined;
+    }
+
+    let current = this.root;
+    let result = searchFn(this.root);
+
+    while (typeof result === "object") {
+      current = this.resolveLazyNode(result);
+      result = searchFn(current);
+    }
+
+    return result === true ? current : undefined;
+  }
+
+  /**
+   * Return set of elements from the tree in the given range with a gap size greater than the given size.
+   *
+   * Allows the data to be retrieved at specific 'resolution', where any group nodes with a gap smaller than
+   * the specified gap are merged into a cluster.
+   */
+  getData(gapSize: V, min: V, max: V): TreeData<T>[] {
+    if (!this.root) {
+      return [];
+    }
+
+    const nodes: TreeData<T>[] = [];
+    const nodesToVisit: MaybeLazyNode<T, V>[] = [this.root];
+
+    // Depth first search through the tree culling nodes outside of the requested
+    // range and only searching down to the requested gap size
+    while (nodesToVisit.length > 0) {
+      // Visit the next node
+      const node = this.resolveLazyNode(nodesToVisit.pop()!);
+
+      // If the node is an inner node...
+      if (node.type === "inner") {
+        // Ignore it if it is outside the requested range
+        if (this.getValue(node.data.max) < min || this.getValue(node.data.min) > max) {
+          continue;
+        }
+
+        // Add it to the results if its gap size is smaller than the target, otherwise continue
+        // searching its children
+        if (node.gapSize < gapSize) {
+          nodes.push(node.data);
+        } else {
+          nodesToVisit.push(node.high, node.low);
+        }
+      }
+      // If the node is a leaf and it is in view, add it to the results
+      else if (this.getValue(node.data.value) > min && this.getValue(node.data.value) < max) {
+        nodes.push(node.data);
+      }
+    }
+
+    return nodes;
+  }
+
+  /**
+   * Returns a pair of values containing the first value or cluster below a specified value
+   * and the first value or cluster above a specified value.
+   *
+   * If no value is given for the gap size, the returned values will always be single data points.
+   */
+  getBoundingData(min: V, max: V): [TreeDataSingle<T> | undefined, TreeDataSingle<T> | undefined];
+  getBoundingData(min: V, max: V, gapSize: V): [TreeData<T> | undefined, TreeData<T> | undefined];
+  getBoundingData(min: V, max: V, gapSize?: V): [TreeData<T> | undefined, TreeData<T> | undefined] {
+    const firstNodeBelow = this.searchTree((node) => {
+      const dataPoint = node.type === "leaf" ? node.data.value : node.data.max;
+
+      // If reached a leaf or the gap size is smaller than the target, return the current node if it
+      // is below the min value
+      if (node.type === "leaf" || (gapSize && node.gapSize < gapSize)) {
+        return this.getValue(dataPoint) < min;
+      }
+
+      // Go to the larger child node that is less than the min
+      return node.gapMax < min ? node.high : node.low;
+    });
+
+    const firstNodeAbove = this.searchTree((node) => {
+      const dataPoint = node.type === "leaf" ? node.data.value : node.data.min;
+
+      // If reached a leaf or the gap size is smaller than the target, return the current node if it
+      // is above the max value
+      if (node.type === "leaf" || (gapSize && node.gapSize < gapSize)) {
+        return this.getValue(dataPoint) > max;
+      }
+
+      // Go to the smaller child node that is greater than the max
+      return node.gapMin > max ? node.low : node.high;
+    });
+
+    return [firstNodeBelow?.data, firstNodeAbove?.data];
+  }
+
+  /** Get the index of a value in the tree. If the value is not found, returns -1 */
+  indexOf(value: T): number {
+    let idx = 0;
+    const found = this.searchTree((node) => {
+      if (node.type === "leaf") {
+        return node.data.value === value;
+      }
+
+      const isHighSide = this.getValue(value) > node.gapMin;
+      const lowSideChildren = node.low.type === "inner" ? node.low.data.childCount : 1;
+      idx += isHighSide ? lowSideChildren : 0;
+      return isHighSide ? node.high : node.low;
+    });
+
+    return found ? idx : -1;
+  }
+}

--- a/nusight2/src/client/hooks/use_property_change.ts
+++ b/nusight2/src/client/hooks/use_property_change.ts
@@ -1,0 +1,35 @@
+import { useRef, useState } from "react";
+
+/**
+ * Map properties from a dependency object to an instance object. Works as follows:
+ *  - calls `create()` on first render and stores the returned value as the instance object
+ *  - when properties of `dependency` change, calls `update()` with the instance object and dependency object
+ *  - returns the instance
+ */
+export function usePropertyChange<D extends object, T extends object>(
+  create: (initialValue: D) => T,
+  update: (instance: T, newValue: D) => void,
+  dependency: D,
+) {
+  // Last values of the dependency object
+  const prevDependencies = useRef(Object.values(dependency));
+
+  // Create the initial instance object
+  const [instance] = useState(() => create(dependency));
+
+  // Check if the properties of the dependency object have changed
+  const newDependencies = Object.values(dependency);
+  const needsUpdate =
+    prevDependencies.current.length !== newDependencies.length ||
+    prevDependencies.current.some((dep, i) => !Object.is(dep, newDependencies[i]));
+
+  // Store the new values of the dependency object
+  prevDependencies.current = newDependencies;
+
+  // Update the instance object with the new values
+  if (needsUpdate) {
+    update(instance, dependency);
+  }
+
+  return instance;
+}

--- a/nusight2/src/client/render2d/geometry/rectangle_geometry.ts
+++ b/nusight2/src/client/render2d/geometry/rectangle_geometry.ts
@@ -1,0 +1,21 @@
+import { observable } from "mobx";
+
+export class RectangleGeometry {
+  @observable x: number;
+  @observable y: number;
+  @observable width: number;
+  @observable height: number;
+  @observable borderRadius: number | "full";
+
+  constructor(opts: { x: number; y: number; width: number; height: number; borderRadius: number | "full" }) {
+    this.x = opts.x;
+    this.y = opts.y;
+    this.width = opts.width;
+    this.height = opts.height;
+    this.borderRadius = opts.borderRadius;
+  }
+
+  static of(x: number, y: number, width: number, height: number, borderRadius?: number | "full"): RectangleGeometry {
+    return new RectangleGeometry({ x, y, width, height, borderRadius: borderRadius ?? 0 });
+  }
+}

--- a/nusight2/src/client/render2d/object/geometry.ts
+++ b/nusight2/src/client/render2d/object/geometry.ts
@@ -4,6 +4,7 @@ import { CircleGeometry } from "../geometry/circle_geometry";
 import { LineGeometry } from "../geometry/line_geometry";
 import { PathGeometry } from "../geometry/path_geometry";
 import { PolygonGeometry } from "../geometry/polygon_geometry";
+import { RectangleGeometry } from "../geometry/rectangle_geometry";
 import { TextGeometry } from "../geometry/text_geometry";
 
 export type Geometry =
@@ -13,4 +14,5 @@ export type Geometry =
   | LineGeometry
   | PathGeometry
   | PolygonGeometry
+  | RectangleGeometry
   | TextGeometry;

--- a/nusight2/src/client/render2d/svg/rectangle.tsx
+++ b/nusight2/src/client/render2d/svg/rectangle.tsx
@@ -1,0 +1,28 @@
+import React, { useContext } from "react";
+import { observer } from "mobx-react";
+
+import { RectangleGeometry } from "../geometry/rectangle_geometry";
+import { Shape } from "../object/shape";
+import { rendererTransformsContext } from "../svg_renderer";
+
+import { toSvgAppearance, toSvgEventHandlers } from "./rendering";
+
+type Props = { model: Shape<RectangleGeometry> };
+export const Rectangle = observer(({ model: { geometry, appearance, eventHandlers } }: Props) => {
+  const transforms = useContext(rendererTransformsContext);
+  const radius =
+    geometry.borderRadius === "full"
+      ? Math.min(Math.abs(geometry.width), Math.abs(geometry.height)) / 2
+      : geometry.borderRadius;
+  return (
+    <rect
+      x={geometry.x}
+      y={geometry.y}
+      width={geometry.width}
+      height={geometry.height}
+      rx={radius?.toString()}
+      {...toSvgAppearance(appearance)}
+      {...toSvgEventHandlers(eventHandlers, transforms)}
+    />
+  );
+});

--- a/nusight2/src/client/render2d/svg/rendering.tsx
+++ b/nusight2/src/client/render2d/svg/rendering.tsx
@@ -14,6 +14,7 @@ import { LineGeometry } from "../geometry/line_geometry";
 import { MarkerGeometry } from "../geometry/marker_geometry";
 import { PathGeometry } from "../geometry/path_geometry";
 import { PolygonGeometry } from "../geometry/polygon_geometry";
+import { RectangleGeometry } from "../geometry/rectangle_geometry";
 import { TextGeometry } from "../geometry/text_geometry";
 import { Geometry } from "../object/geometry";
 import { Shape } from "../object/shape";
@@ -26,6 +27,7 @@ import { Line } from "./line";
 import { Marker } from "./marker";
 import { Path } from "./path";
 import { Polygon } from "./polygon";
+import { Rectangle } from "./rectangle";
 import { Text } from "./text";
 
 export function toSvgEventHandlers(eventHandlers: Render2DEventHandlers, transforms: SVGRendererTransforms) {
@@ -104,6 +106,8 @@ export const ShapeView = observer(({ obj }: Props): JSX.Element => {
     return <Path model={obj as Shape<PathGeometry>} />;
   } else if (obj.geometry instanceof PolygonGeometry) {
     return <Polygon model={obj as Shape<PolygonGeometry>} />;
+  } else if (obj.geometry instanceof RectangleGeometry) {
+    return <Rectangle model={obj as Shape<RectangleGeometry>} />;
   } else if (obj.geometry instanceof TextGeometry) {
     return <Text model={obj as Shape<TextGeometry>} />;
   } else {


### PR DESCRIPTION
Part of the advanced scrubber work, stacked on top of the popouts/windows infrastructure (#1800). Targets the `houliston/advanced-scrubber` integration branch.

## What this adds

- **Timeline component** (`nusight2/src/client/components/timeline/`) — a reusable, zoomable/pannable timeline with:
  - header with time-axis labels and fade-out gridlines
  - rows, markers, and highlight ranges
  - MobX view models for header/row/timeline
  - Storybook stories for the timeline, markers, and highlight ranges
- **`data_structures/cluster_tree.ts`** — clustering structure backing timeline row layout.
- **`render2d/geometry/rectangle_geometry.ts`** + SVG `rectangle` renderer — rectangle primitive for render2d.
- **`hooks/use_property_change.ts`** — hook to observe MobX property changes.

## Notes

- Consumes the popouts/windows infrastructure from #1800.
- The timeline component's in-app consumer (the advanced scrubber packet inspector) lands in a later PR in this stack.

## Verification

- `yarn tscheck` — 0 errors
- `yarn vitest run` — 37 files / 273 tests passing