### PR TITLE
Add Advanced Scrubber packet inspector for NUsight

### DIFF
--- a/nusight2/src/client/components/advanced_scrubber/advanced_scrubber.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/advanced_scrubber.tsx
@@ -1,0 +1,100 @@
+import React, { useCallback, useMemo } from "react";
+import { NbsScrubberController } from "@components/nbs_scrubbers/nbs_scrubber/controller";
+import { NbsScrubberLeftControls, NbsScrubberRightControls } from "@components/nbs_scrubbers/nbs_scrubber/view";
+import { TimelineCameraView } from "@components/timeline/model";
+import { useRpcController } from "@hooks/use_rpc_controller";
+import { observable } from "mobx";
+import { observer } from "mobx-react";
+
+import { AdvancedScrubberScrubberModel } from "./model";
+import { PacketTimeline } from "./packet_timeline/packet_timeline";
+
+/**
+ * Inline scrubber position slider.
+ *
+ * A plain range input that seeks by percentage. A minimap/overview zoom feature
+ * could be layered on top in the future.
+ */
+const ScrubberSlider = observer(function ScrubberSlider(props: {
+  model: AdvancedScrubberScrubberModel;
+  controller?: NbsScrubberController;
+}) {
+  const { model, controller } = props;
+  const { scrubber } = model;
+
+  const onInput = useCallback(
+    (event: React.FormEvent<HTMLInputElement>) => {
+      controller?.seekToPercent(Number(event.currentTarget.value));
+    },
+    [controller],
+  );
+
+  return (
+    <div className="flex-1 flex flex-col gap-1 min-w-0">
+      <div className="flex justify-between text-xs text-auto-secondary px-0.5">
+        <span>{scrubber.currentFormatted}</span>
+      </div>
+      <input
+        className="w-full"
+        type="range"
+        onInput={onInput}
+        value={scrubber.percentPlayed}
+        min={0}
+        step={0.001}
+        max={1}
+        disabled={!controller}
+      />
+    </div>
+  );
+});
+
+export const AdvancedScrubber = observer(function AdvancedScrubber(props: { model: AdvancedScrubberScrubberModel }) {
+  const { scrubber, indices = [] } = props.model;
+  const divider = <div className="h-2/3 border-l border-auto" />;
+
+  const timelineCameraView = useMemo<TimelineCameraView>(
+    () =>
+      observable({
+        centre: (scrubber.start + scrubber.end) / 2n,
+        // Widen the initial view slightly to ensure packets at the start and end are visible
+        range: scrubber.end - scrubber.start + (scrubber.end - scrubber.start) / 20n,
+      }),
+    [scrubber],
+  );
+
+  const controller = useRpcController((network) => new NbsScrubberController(scrubber, network), [scrubber]);
+
+  return (
+    <div className="w-full h-full bg-auto-surface-0 text-auto-primary flex flex-col justify-start items-center">
+      <div className="w-full flex justify-between items-center px-4 py-2 bg-auto-surface-2">
+        <span className="font-medium text-base">{scrubber.name}</span>
+        <div className="flex h-full items-center gap-2 text-sm">
+          <span className="text-secondary">Start</span>
+          <span>{scrubber.startFormatted}</span>
+          {divider}
+          <span className="text-secondary">End</span>
+          <span>{scrubber.endFormatted}</span>
+          {divider}
+          <span className="text-secondary">Duration</span>
+          <span>{scrubber.durationFormatted}</span>
+        </div>
+      </div>
+      <div className="w-full flex items-center gap-4 px-4 py-1 border-y border-auto">
+        <div className="flex items-center gap-1">
+          <NbsScrubberLeftControls model={scrubber} controller={controller} />
+        </div>
+        {divider}
+        {/* Plain scrubber slider; a minimap/overview zoom feature is not implemented in this view. */}
+        <ScrubberSlider model={props.model} controller={controller} />
+        {divider}
+        <NbsScrubberRightControls model={scrubber} controller={controller} />
+      </div>
+      <PacketTimeline
+        scrubber={scrubber}
+        indices={indices}
+        controller={controller}
+        timelineCameraView={timelineCameraView}
+      />
+    </div>
+  );
+});

--- a/nusight2/src/client/components/advanced_scrubber/create.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/create.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useMemo } from "react";
+import { Network } from "@client/network/network";
+import { NUsightNetwork } from "@client/network/nusight_network";
+import { AppModel } from "@components/app/model";
+import { NoSelectedDataSource } from "@components/blank_state";
+import { useAutoSelectDataSourceFromUrl } from "@hooks/use_auto_select_data_source";
+import { observer } from "mobx-react";
+
+import { AdvancedScrubber } from "./advanced_scrubber";
+import { AdvancedScrubberModel, AdvancedScrubberScrubberModel } from "./model";
+import { AdvancedScrubberNetwork } from "./network";
+
+export function createStandaloneAdvancedScrubberView({
+  appModel,
+  nusightNetwork,
+}: {
+  appModel: AppModel;
+  nusightNetwork: NUsightNetwork;
+}) {
+  const model = AdvancedScrubberModel.of(appModel);
+
+  return observer(() => {
+    // Auto select the robot specified in the URL if any.
+    useAutoSelectDataSourceFromUrl(model, model.setSelectedRobot, { fallbackToFirst: false });
+
+    return model.selectedScrubber ? (
+      <AdvancedScrubberWindow model={model.selectedScrubber} nusightNetwork={nusightNetwork} />
+    ) : (
+      <NoSelectedDataSource
+        hasDataSources={model.robots.length > 0}
+        pendingAction="view advanced scrubber"
+        urlSelectionRequired
+      />
+    );
+  });
+}
+
+interface AdvancedScrubberWindowProps {
+  nusightNetwork: NUsightNetwork;
+  model: AdvancedScrubberScrubberModel;
+}
+
+const AdvancedScrubberWindow = observer(function AdvancedScrubberWindow(props: AdvancedScrubberWindowProps) {
+  const { nusightNetwork, model } = props;
+
+  const network = useMemo(() => {
+    return new AdvancedScrubberNetwork(model, Network.of(nusightNetwork));
+  }, [nusightNetwork]);
+
+  useEffect(() => {
+    return () => network.destroy();
+  }, [network]);
+
+  useEffect(() => {
+    const title = document.title;
+    document.title = `${model.scrubber.name} Scrubber — NUsight`;
+    return () => {
+      document.title = title;
+    };
+  }, [model.scrubber.name]);
+
+  return <AdvancedScrubber model={model} />;
+});

--- a/nusight2/src/client/components/advanced_scrubber/install.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/install.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { NavigationConfiguration } from "@client/navigation";
+import { NUsightNetwork } from "@client/network/nusight_network";
+import { AppModel } from "@components/app/model";
+
+function IconScrubber(props: { className?: string }) {
+  return (
+    <svg
+      className={props.className}
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z" />
+    </svg>
+  );
+}
+
+export function installStandaloneAdvancedScrubber({
+  nav,
+  appModel,
+  nusightNetwork,
+}: {
+  nav: NavigationConfiguration;
+  appModel: AppModel;
+  nusightNetwork: NUsightNetwork;
+}) {
+  nav.addRoute({
+    path: "/scrubber",
+    Icon: IconScrubber,
+    label: "Scrubber",
+    Content: React.lazy(async () => {
+      const { createStandaloneAdvancedScrubberView } = await import("./create");
+      return {
+        default: createStandaloneAdvancedScrubberView({ appModel, nusightNetwork }),
+      };
+    }),
+  });
+}

--- a/nusight2/src/client/components/advanced_scrubber/model.ts
+++ b/nusight2/src/client/components/advanced_scrubber/model.ts
@@ -1,0 +1,56 @@
+import { memoize } from "@client/base/memoize";
+import { AppModel } from "@components/app/model";
+import { NbsScrubberModel } from "@components/nbs_scrubbers/model";
+import { RobotModel } from "@components/robot/model";
+import { action, computed, observable } from "mobx";
+
+export class AdvancedScrubberModel {
+  @observable.ref selectedRobot?: RobotModel;
+
+  constructor(private appModel: AppModel) {}
+
+  static of = memoize((appModel: AppModel) => {
+    return new AdvancedScrubberModel(appModel);
+  });
+
+  @computed
+  get robots(): RobotModel[] {
+    return this.appModel.robots.filter((r) => r.type === "nbs-scrubber");
+  }
+
+  @action.bound
+  setSelectedRobot(robot?: RobotModel) {
+    this.selectedRobot = robot;
+  }
+
+  @computed
+  get selectedScrubber(): AdvancedScrubberScrubberModel | undefined {
+    if (this.selectedRobot) {
+      const scrubber = this.appModel.scrubbersModel.scrubberOf(this.selectedRobot);
+      return scrubber ? AdvancedScrubberScrubberModel.of(scrubber) : undefined;
+    }
+  }
+}
+
+export interface MessageTypeId {
+  typeName: string;
+  typeHash: string;
+  subtype: number;
+}
+
+/** Scrubber timestamps of a message type subtype pair */
+export interface TypeIndex {
+  type: MessageTypeId;
+  timestamps: bigint[];
+}
+
+export class AdvancedScrubberScrubberModel {
+  /** Timestamps of each message type subtype of this model's scrubber */
+  @observable.ref indices?: TypeIndex[];
+
+  constructor(public scrubber: NbsScrubberModel) {}
+
+  static of = memoize((scrubber: NbsScrubberModel) => {
+    return new AdvancedScrubberScrubberModel(scrubber);
+  });
+}

--- a/nusight2/src/client/components/advanced_scrubber/network.ts
+++ b/nusight2/src/client/components/advanced_scrubber/network.ts
@@ -1,0 +1,32 @@
+import { Network } from "@client/network/network";
+import { RobotModel } from "@components/robot/model";
+import { ScrubberIndex } from "@proto/message/eye/Scrubber";
+import { Timestamp } from "@shared/time/timestamp";
+import { action } from "mobx";
+
+import { AdvancedScrubberScrubberModel } from "./model";
+
+export class AdvancedScrubberNetwork {
+  constructor(
+    private model: AdvancedScrubberScrubberModel,
+    private network: Network,
+  ) {
+    this.network.on({ type: ScrubberIndex, subtype: model.scrubber.id }, this.onScrubberIndex);
+  }
+
+  destroy() {
+    this.network.off();
+  }
+
+  @action
+  private onScrubberIndex = (_: RobotModel, message: ScrubberIndex) => {
+    this.model.indices = message.indices.map((index) => ({
+      type: {
+        typeName: index.typeName!,
+        typeHash: index.typeHash!,
+        subtype: index.subtype!,
+      },
+      timestamps: index.timestamps?.map((t) => Timestamp.toNanos(t)) ?? [],
+    }));
+  };
+}

--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/controller.ts
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/controller.ts
@@ -1,0 +1,68 @@
+import { NbsScrubberController } from "@components/nbs_scrubbers/nbs_scrubber/controller";
+import { TimelineDataPoint } from "@components/timeline/model";
+import { RpcNetwork } from "@hooks/use_rpc_controller";
+import { ScrubberPacketRequest } from "@proto/message/eye/Scrubber";
+import { clamp } from "@shared/math/clamp";
+import { messageNameToType } from "@shared/messages/generated/type_converters";
+import { Timestamp } from "@shared/time/timestamp";
+import { action } from "mobx";
+
+import { MessageTypeId } from "../model";
+
+import { PacketTimelineModel } from "./model";
+
+export class PacketTimelineController {
+  constructor(
+    private network: RpcNetwork,
+    private model: PacketTimelineModel,
+    private scrubberController: NbsScrubberController,
+  ) {}
+
+  seek(timestamp: bigint) {
+    const clampedTimestamp = clamp(timestamp, this.model.scrubber.start, this.model.scrubber.end);
+    this.scrubberController.seekToTimestamp(clampedTimestamp);
+  }
+
+  @action.bound
+  async selectPacket(type: MessageTypeId, offset: number, dataPoint: TimelineDataPoint) {
+    const { typeHash, subtype } = type;
+    const result = await this.network.call(
+      new ScrubberPacketRequest({ id: this.model.scrubber.id, typeHash, subtype, offset }),
+    );
+
+    if (result.ok) {
+      this.setSelectedMessage(type, result.data.response.data, dataPoint);
+    } else {
+      // TODO: add toast messages to NUsight to show errors like this without using alert()
+      alert(result.error.message);
+    }
+  }
+
+  @action.bound
+  deselectPacket() {
+    this.model.highlightedDataPoints = [];
+    this.model.selectedMessage = undefined;
+  }
+
+  @action
+  private setSelectedMessage(type: MessageTypeId, payload: Uint8Array, dataPoint: TimelineDataPoint) {
+    this.model.highlightedDataPoints = [dataPoint];
+    this.scrubberController.seekToTimestamp(dataPoint.timestamp);
+    try {
+      this.model.selectedMessage = {
+        type,
+        timestamp: new Timestamp(dataPoint.timestamp),
+        message: messageNameToType(type.typeName).fromBinary(payload),
+        size: payload.length,
+      };
+    } catch {
+      // Fallback to showing the raw bytes if decoding failed
+      this.model.selectedMessage = {
+        type,
+        timestamp: new Timestamp(dataPoint.timestamp),
+        message: payload,
+        size: payload.length,
+      };
+    }
+  }
+}

--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/bytes.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/bytes.tsx
@@ -1,0 +1,107 @@
+import React, { useMemo, useState } from "react";
+import { siUnit } from "@client/base/si_unit";
+import classNames from "classnames";
+
+// The number of bytes to display on each row
+const SECTION_LENGTH = 8;
+
+/** Splits a Uint8Array into views of a specified size */
+function splitArray(array: Uint8Array, size: number) {
+  const sections = Math.ceil(array.length / size);
+  return new Array(sections).fill(null).map((_, i) => array.subarray(i * size, i * size + size));
+}
+
+/** Render a row of formatted bytes */
+function FormattedBytes(props: {
+  bytes: Uint8Array;
+  highlighted: number;
+  onHover: (index: number) => void;
+  formatByte: (byte: number) => string;
+}) {
+  const { bytes, highlighted, onHover, formatByte } = props;
+  return (
+    <div>
+      {Array.from(bytes).map((byte, i) => (
+        <span
+          key={i}
+          onMouseEnter={() => onHover(i)}
+          onMouseLeave={() => onHover(-1)}
+          className={classNames(
+            "px-1 rounded-sm hover:bg-nusight-500/30",
+            highlighted === i ? "bg-nusight-500/15" : "",
+          )}
+        >
+          {formatByte(byte)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A row in the custom display for bytes.
+ * Displays the offset of this set of bytes and the bytes themselves in hex and ASCII.
+ */
+function BytesViewRow(props: { offset: number; bytes: Uint8Array }) {
+  const { offset, bytes } = props;
+
+  const [highlighted, setHighlighted] = useState(-1);
+  const divider = <div className="border-r border-auto" />;
+
+  return (
+    <div className="flex gap-2 cursor-default">
+      {/* Offset of this set of bytes in hex */}
+      <div className="text-auto-hint">{offset.toString(16).padStart(8, "0")}</div>
+      {divider}
+      {/* Bytes as their hex values */}
+      <FormattedBytes
+        bytes={bytes}
+        highlighted={highlighted}
+        onHover={setHighlighted}
+        formatByte={(byte) => byte.toString(16).padStart(2, "0")}
+      />
+      {divider}
+      {/* Bytes as ASCII characters, only converting the useful range */}
+      <FormattedBytes
+        bytes={bytes}
+        highlighted={highlighted}
+        onHover={setHighlighted}
+        formatByte={(byte) => (byte > 32 && byte < 127 ? String.fromCharCode(byte) : ".")}
+      />
+    </div>
+  );
+}
+
+export function BytesView(props: { value: Uint8Array }) {
+  const [shownRows, setShownRows] = useState(10);
+
+  const shownBytes = useMemo(
+    () => props.value.subarray(0, Math.min(SECTION_LENGTH * shownRows, props.value.length)),
+    [shownRows, props.value],
+  );
+
+  const sections = useMemo(() => splitArray(shownBytes, SECTION_LENGTH), [shownBytes]);
+  const remainingBytes = props.value.length - shownBytes.length;
+  const [formattedRemaining, units] = siUnit(remainingBytes, "b");
+
+  if (props.value.length === 0) {
+    return <div className="text-auto-secondary">(empty)</div>;
+  }
+
+  return (
+    <div className="text-auto-secondary">
+      {sections.map((bytes, i) => (
+        <BytesViewRow key={i} offset={i * SECTION_LENGTH} bytes={bytes} />
+      ))}
+      {remainingBytes > 0 ? (
+        <div
+          onClick={() => setShownRows((value) => value + 10)}
+          className="hover:text-blue-700 dark:hover:text-blue-500 cursor-pointer mt-2"
+        >
+          +{formattedRemaining.toFixed(2)}
+          {units} more (click to show)
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/custom_formats.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/custom_formats.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { CompressedImage } from "@proto/message/output/CompressedImage";
+import { MessageInstance, MessageType } from "@shared/messages/types";
+import { Duration } from "@shared/proto/google/protobuf/duration";
+import { Timestamp as ProtobufTimestamp } from "@shared/proto/google/protobuf/timestamp";
+import { Timestamp } from "@shared/time/timestamp";
+
+import { BytesView } from "./bytes";
+import { CompressedImageView } from "./image";
+import { isMatrixLike, isVectorLike, MatrixView, VectorView } from "./math";
+
+function isMessageInstance(value: unknown): value is MessageInstance<string> {
+  return typeof value === "object" && value !== null && "$typeName" in value;
+}
+
+function isMessageType<T extends MessageInstance<string>>(
+  value: MessageInstance<string>,
+  type: MessageType<T>,
+): value is T {
+  return value.$typeName === type.typeName;
+}
+
+/** Get a custom display for the given value if one exists */
+export function formatValue(value: unknown): { content: React.ReactNode; keepOriginal?: boolean } | null {
+  // Skip checking how to format if value is a primitive.
+  // Primitives can just be rendered as strings.
+  if (!isMessageInstance(value)) {
+    return null;
+  }
+
+  if (value instanceof Uint8Array) {
+    return { content: <BytesView value={value} /> };
+  } else if (isMessageType(value, ProtobufTimestamp)) {
+    return { content: <TimestampView timestamp={value} /> };
+  } else if (isMessageType(value, Duration)) {
+    return { content: <DurationView duration={value} /> };
+  } else if (isVectorLike(value)) {
+    return { content: <VectorView vec={value} /> };
+  } else if (isMatrixLike(value)) {
+    return { content: <MatrixView matrix={value} /> };
+  } else if (isMessageType(value, CompressedImage)) {
+    return {
+      content: <CompressedImageView msg={value} />,
+      keepOriginal: true,
+    };
+  }
+
+  return null;
+}
+
+function TimestampView(props: { timestamp: ProtobufTimestamp }) {
+  const { timestamp } = props;
+  const nanos = Timestamp.toNanos({ seconds: timestamp.seconds, nanos: timestamp.nanos });
+  return <div className="text-auto-secondary w-full">Timestamp: {Timestamp.toFormattedDate(nanos)}</div>;
+}
+
+function DurationView(props: { duration: Duration }) {
+  const { duration } = props;
+  const nanos = Timestamp.toNanos({ seconds: duration.seconds, nanos: duration.nanos });
+  return <div className="text-auto-secondary w-full">Duration: {Timestamp.toFormattedDuration(nanos)}</div>;
+}

--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/image.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/image.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef } from "react";
+import { CompressedImage } from "@proto/message/output/CompressedImage";
+
+export interface CompressedImageViewProps {
+  msg: CompressedImage;
+  children?: React.ReactNode;
+}
+
+/**
+ * Renders a CompressedImage message as an image preview.
+ *
+ * Uses a canvas element with createImageBitmap for JPEG decoding.
+ */
+export function CompressedImageView(props: CompressedImageViewProps) {
+  const { msg, children } = props;
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !msg.data?.length) {
+      return;
+    }
+
+    const blob = new Blob([msg.data], { type: "image/jpeg" });
+    createImageBitmap(blob, { colorSpaceConversion: "none", premultiplyAlpha: "none" })
+      .then((bitmap) => {
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+        canvas.width = bitmap.width;
+        canvas.height = bitmap.height;
+        ctx.drawImage(bitmap, 0, 0);
+        bitmap.close();
+      })
+      .catch(() => {
+        // Non-JPEG formats are not decoded here; show nothing
+      });
+  }, [msg]);
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="my-0.5 max-h-60 w-full object-contain bg-black"
+        style={{ imageRendering: "pixelated" }}
+      />
+      {children}
+    </>
+  );
+}

--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/math.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/math.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { MessageInstance } from "@shared/messages/types";
+
+interface VectorLike {
+  x?: number;
+  y?: number;
+  z?: number;
+  t?: number;
+}
+
+interface MatrixLike {
+  x?: VectorLike;
+  y?: VectorLike;
+  z?: VectorLike;
+  t?: VectorLike;
+}
+
+/** Filter the given object to include only the keys `x`, `y`, `z` and `t` */
+function filterVectorEntries(message: object) {
+  return Object.entries(message).filter(([key]) => ["x", "y", "z", "t"].includes(key));
+}
+
+/** Check whether a VectorLike is an integer type */
+function isIntVec(vec: MessageInstance & VectorLike) {
+  // The most reliable way to do this is by checking the name of the message.
+  // The integer vector types begin with 'uvec' or 'ivec'.
+  const type = vec.$typeName;
+  return type.startsWith("uvec") || type.startsWith("ivec");
+}
+
+function Bracket({ type }: { type: "open" | "close" }) {
+  return <div className={`w-1 shrink-0 border-y border-gray-400 ${type === "open" ? "border-l" : "border-r"}`} />;
+}
+
+function VectorElements({ vec }: { vec: MessageInstance & VectorLike }) {
+  const isInt = isIntVec(vec);
+  const formatValue = (value?: number | null) => {
+    return (value ?? 0).toFixed(isInt ? 0 : 3);
+  };
+
+  return (
+    <>
+      {filterVectorEntries(vec).map(([key, val]) => (
+        <span key={key}>{formatValue(val)}</span>
+      ))}
+    </>
+  );
+}
+
+/**
+ * Check whether an object is a VectorLike.
+ * An object is VectorLike if its keys are a subset of 'x', 'y', 'z', 't' and all values are numbers.
+ */
+export function isVectorLike(value: object): value is VectorLike {
+  const entries = filterVectorEntries(value);
+  return (
+    entries.length > 0 &&
+    entries.length <= 4 &&
+    entries.every(([key, val]) => ["x", "y", "z", "t"].includes(key) && typeof val === "number")
+  );
+}
+
+/**
+ * Check whether an object is a MatrixLike.
+ * An object is MatrixLike if its keys are a subset of 'x', 'y', 'z', 't' and all values are VectorLike.
+ */
+export function isMatrixLike(value: object): value is MatrixLike {
+  const entries = filterVectorEntries(value);
+  return (
+    entries.length > 0 &&
+    entries.length <= 4 &&
+    entries.every(([key, val]) => ["x", "y", "z", "t"].includes(key) && isVectorLike(val))
+  );
+}
+
+export function VectorView({ vec }: { vec: MessageInstance & VectorLike }) {
+  return (
+    <div className="relative flex h-fit gap-3 text-auto-secondary">
+      <Bracket type="open" />
+      <VectorElements vec={vec} />
+      <Bracket type="close" />
+    </div>
+  );
+}
+
+export function MatrixView({ matrix }: { matrix: MessageInstance & MatrixLike }) {
+  return (
+    <div className="relative flex h-fit gap-3 text-auto-secondary">
+      <Bracket type="open" />
+      {filterVectorEntries(matrix).map(([key, vec]) => (
+        <div key={key} className="flex flex-col items-end">
+          <VectorElements vec={vec} />
+        </div>
+      ))}
+      <Bracket type="close" />
+    </div>
+  );
+}

--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/model.ts
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/model.ts
@@ -1,0 +1,217 @@
+import { DescField, isMessage, ScalarType } from "@bufbuild/protobuf";
+import { isReflectMessage, reflect, ReflectList, ReflectMap, ReflectMessage } from "@bufbuild/protobuf/reflect";
+import { MessageTypeId } from "@components/advanced_scrubber/model";
+import { InternalNode, LeafNode, Node } from "@components/collapsible_tree/types";
+import { messageNameToType } from "@shared/messages/generated/type_converters";
+import { MessageInstance } from "@shared/messages/types";
+import { action, IObservableValue, observable } from "mobx";
+
+export interface MessageNodeAttributes {
+  value: unknown;
+  fieldType: DescField["fieldKind"] | ScalarType;
+  typeName: string;
+  showRawData?: IObservableValue<boolean>;
+}
+
+export type MessageNode = Node<MessageNodeAttributes>;
+export type MessageLeafNode = LeafNode<MessageNodeAttributes>;
+export type MessageInternalNode = InternalNode<MessageNodeAttributes>;
+
+function createLeafNode(value: unknown, fieldName: string, fieldType: ScalarType | "enum"): MessageLeafNode {
+  return {
+    type: "leaf",
+    name: fieldName,
+    value,
+    fieldType: fieldType,
+    typeName: "scalar",
+  };
+}
+
+function createMapNode(map: ReflectMap, existingNode?: MessageNode): MessageInternalNode {
+  const children: MessageNode[] = [];
+  const mapDesc = map.field();
+
+  const keyTypeName = ScalarType[mapDesc.mapKey].toLowerCase();
+
+  let valueTypeName;
+  if (mapDesc.mapKind === "message") {
+    valueTypeName = mapDesc.message.typeName;
+  } else if (mapDesc.mapKind === "enum") {
+    valueTypeName = mapDesc.enum.typeName;
+  } else {
+    valueTypeName = ScalarType[mapDesc.scalar].toLowerCase();
+  }
+
+  const typeName = "map" + "<" + keyTypeName + ", " + valueTypeName + ">[" + map.size + "]";
+
+  for (const [key, item] of map.entries()) {
+    const childFieldName = String(key);
+
+    // Determine existing child node if available
+    const existingChild =
+      existingNode?.type === "internal"
+        ? existingNode.children.find((child) => child.name === childFieldName)
+        : undefined;
+
+    if (mapDesc.mapKind === "enum") {
+      const enumString = mapDesc.enum.values[item as number]?.name ?? item;
+      children.push(createLeafNode(enumString, childFieldName, "enum"));
+    } else if (mapDesc.mapKind === "scalar") {
+      children.push(createLeafNode(item, childFieldName, mapDesc.scalar));
+    } else if (isReflectMessage(item)) {
+      children.push(createMessageNode(item, childFieldName, existingChild));
+    }
+  }
+
+  return {
+    type: "internal",
+    name: map.field().localName,
+    fieldType: "map",
+    typeName,
+    value: map,
+    isExpanded: existingNode?.type === "internal" && existingNode.name === typeName && existingNode.isExpanded,
+    showRawData: observable.box(
+      existingNode?.type === "internal" && existingNode.name === typeName && existingNode.showRawData?.get(),
+    ),
+    children,
+  };
+}
+
+function createListNode(list: ReflectList, existingNode?: MessageNode): MessageInternalNode {
+  const children: MessageNode[] = [];
+  const listDesc = list.field();
+
+  let typeName;
+  if (listDesc.listKind === "message") {
+    typeName = listDesc.message.typeName;
+  } else if (listDesc.listKind === "enum") {
+    typeName = listDesc.enum.typeName;
+  } else {
+    typeName = ScalarType[listDesc.scalar].toLowerCase();
+  }
+  typeName += "[" + list.size + "]";
+
+  for (const [index, item] of list.entries()) {
+    // Determine existing child node if available
+    const existingChild = existingNode?.type === "internal" ? existingNode?.children[index] : undefined;
+
+    const fieldName = "[" + index.toString() + "]";
+
+    if (listDesc.listKind === "enum") {
+      const enumString = listDesc.enum.values[item as number]?.name ?? item;
+      children.push(createLeafNode(enumString, fieldName, "enum"));
+    } else if (listDesc.listKind === "scalar") {
+      children.push(createLeafNode(item, fieldName, listDesc.scalar));
+    } else if (isReflectMessage(item)) {
+      children.push(createMessageNode(item, fieldName, existingChild));
+    }
+  }
+
+  return {
+    type: "internal",
+    fieldType: "list",
+    typeName,
+    name: list.field().localName,
+    value: list,
+    isExpanded: existingNode?.type === "internal" && existingNode.name === typeName && existingNode.isExpanded,
+    showRawData: observable.box(
+      existingNode?.type === "internal" && existingNode.name === typeName && existingNode.showRawData?.get(),
+    ),
+    children,
+  };
+}
+
+function createMessageNode(
+  message: ReflectMessage,
+  fieldName: string,
+  existingNode?: MessageNode,
+): MessageInternalNode {
+  const children: MessageNode[] = [];
+
+  for (const field of message.fields) {
+    const existingChild =
+      existingNode?.type === "internal"
+        ? existingNode.children.find((child) => child.name === field.localName)
+        : undefined;
+
+    if (message.isSet(field) === false && message.oneofs.some((oo) => oo.fields.includes(field))) {
+      children.push(createLeafNode(null, field.localName, ScalarType.STRING));
+    } else if (field.fieldKind === "message") {
+      const childMessage = message.get(field);
+      children.push(createMessageNode(childMessage, field.localName, existingChild));
+    } else if (field.fieldKind === "list") {
+      const childList = message.get(field);
+      children.push(createListNode(childList, existingChild));
+    } else if (field.fieldKind === "map") {
+      const childMap = message.get(field);
+      children.push(createMapNode(childMap, existingChild));
+    } else if (field.fieldKind === "enum") {
+      const enumValue = message.get(field);
+      const enumString = field.enum.values[enumValue]?.name ?? enumValue;
+      children.push(createLeafNode(enumString, field.localName, "enum"));
+    } else {
+      const leafValue = message.get(field);
+      children.push(createLeafNode(leafValue, field.localName, field.scalar));
+    }
+  }
+
+  const name = fieldName;
+
+  return {
+    type: "internal",
+    value: message.message,
+    fieldType: "message",
+    typeName: message.desc.typeName,
+    name,
+    isExpanded: existingNode?.type === "internal" && existingNode.name === name && existingNode.isExpanded,
+    showRawData: observable.box(
+      existingNode?.type === "internal" && existingNode.name === name && existingNode.showRawData?.get(),
+    ),
+    children,
+  };
+}
+
+export class MessageNodeModel {
+  root: MessageInternalNode;
+
+  /**
+   * Creates the root node from a message or raw bytes
+   */
+  private createRootNode(
+    message: MessageInstance | Uint8Array,
+    type: MessageTypeId,
+    existingNode?: MessageInternalNode,
+  ): MessageInternalNode {
+    if (isMessage(message)) {
+      const schema = messageNameToType(message.$typeName).schema;
+      const reflectMessage = reflect(schema, message);
+      return createMessageNode(reflectMessage, "message", existingNode);
+    } else {
+      return {
+        type: "internal",
+        name: "message",
+        value: message,
+        fieldType: "message",
+        typeName: "unknown (" + type.typeHash + ")",
+        isExpanded: true,
+        showRawData: observable.box(false),
+        children: [createLeafNode(message, "bytes", ScalarType.BYTES)],
+      };
+    }
+  }
+
+  constructor(message: MessageInstance | Uint8Array, type: MessageTypeId) {
+    this.root = this.createRootNode(message, type);
+    // Expand the root node by default
+    this.root.isExpanded = true;
+  }
+
+  /**
+   * Update the tree with a new message while keeping the expansion state
+   * of matching fields in the new message.
+   */
+  @action
+  update(message: MessageInstance | Uint8Array, type: MessageTypeId) {
+    this.root = this.createRootNode(message, type, this.root);
+  }
+}

--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/view.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/view.tsx
@@ -1,0 +1,228 @@
+import React, { useCallback } from "react";
+import { ScalarType } from "@bufbuild/protobuf";
+import { siUnit } from "@client/base/si_unit";
+import { CollapsibleTree } from "@components/collapsible_tree/collapsible_tree";
+import { InternalNode, NodeContentProps, NodeLabelProps } from "@components/collapsible_tree/types";
+import { Icon } from "@components/icon/view";
+import { useTimedState } from "@hooks/use_timed_state";
+import { useUpdatable } from "@hooks/use_updatable";
+import { Timestamp } from "@shared/time/timestamp";
+import classNames from "classnames";
+import { action } from "mobx";
+import { observer } from "mobx-react";
+
+import { MessageViewModel } from "../model";
+
+import { BytesView } from "./custom_formats/bytes";
+import { formatValue } from "./custom_formats/custom_formats";
+import { MessageNode, MessageNodeAttributes, MessageNodeModel } from "./model";
+
+const ColorPalette = {
+  key: "text-[#0F0E7D] dark:text-[#9CDCFE]", // The color of keys of the message fields
+  type: "text-[#795E26] dark:text-[#DCDCAA]", // The color of the type name of a message field if it is not a primitive
+  string: "text-[#a31515] dark:text-[#ce9178]", // The color of a string value
+  number: "text-[#098658] dark:text-[#b5cea8]", // The color of a number value
+  boolean: "text-[#0000FF] dark:text-[#569CD6]", // The color of a boolean value
+  enum: "text-[#267F99] dark:text-[#4EC9B0]", // The color of an enum value
+  error: "text-[#CD3131] dark:text-[#C586C0]", // The color of an unknown value
+  undefined: "text-[#6c6c6c] dark:text-[#939393]", // The color of an undefined value
+} as const;
+
+/** Stringify a value, converting BigInt to a string ending in "n" */
+function stringifyWithBigInt(object: unknown): string {
+  return JSON.stringify(object, (_, val) => (typeof val === "bigint" ? val.toString() + "n" : val), 4);
+}
+
+/** Display for a primitive value of a message */
+function MessageFieldPrimitive(props: Readonly<{ value: unknown; type: MessageNodeAttributes["fieldType"] }>) {
+  const { value } = props;
+
+  if (value === null || value === undefined) {
+    return <span className={ColorPalette.undefined}>undefined</span>;
+  }
+
+  switch (props.type) {
+    case ScalarType.STRING:
+      return <span className={ColorPalette.string}>{`"${value}"`}</span>;
+    case ScalarType.BOOL:
+      return <span className={ColorPalette.boolean}>{String(value)}</span>;
+    case "enum":
+      return <span className={ColorPalette.enum}>{String(value)}</span>;
+    case ScalarType.DOUBLE:
+    case ScalarType.FLOAT:
+    case ScalarType.INT64:
+    case ScalarType.UINT64:
+    case ScalarType.INT32:
+    case ScalarType.UINT32:
+    case ScalarType.FIXED64:
+    case ScalarType.FIXED32:
+    case ScalarType.SFIXED32:
+    case ScalarType.SFIXED64:
+    case ScalarType.SINT32:
+    case ScalarType.SINT64:
+      return (
+        <>
+          <span className={ColorPalette.type}>{ScalarType[props.type].toLowerCase()} = </span>
+          <span className={ColorPalette.number}>{Number(value)}</span>
+        </>
+      );
+    case ScalarType.BYTES:
+      if (value instanceof Uint8Array) {
+        return (
+          <div style={{ paddingLeft: "15px" }}>
+            <BytesView value={value} />
+          </div>
+        );
+      } else {
+        return <span className={ColorPalette.error}>{String(value)}</span>;
+      }
+    default:
+      return <span className={ColorPalette.error}>{String(value)}</span>;
+  }
+}
+
+const MessageFieldType = observer(function MessageFieldType(props: {
+  node: InternalNode<MessageNodeAttributes>;
+  isExpanded: boolean;
+}) {
+  const { typeName, value, showRawData } = props.node;
+  const showingRawData = showRawData?.get();
+
+  // Whether the value was copied, used to show feedback when copying
+  const [copied, setIsCopied] = useTimedState(false, 2000);
+  const copyValue = useCallback(() => {
+    navigator.clipboard.writeText(stringifyWithBigInt(value)).then(() => {
+      setIsCopied(true);
+    });
+  }, [value, setIsCopied]);
+
+  const hasCustomDisplay = formatValue(value) !== null;
+  return (
+    <>
+      <span className={classNames(ColorPalette.type, "whitespace-nowrap pr-2")}>{typeName}</span>
+      {props.isExpanded ? (
+        <button
+          title="Copy JSON"
+          className={classNames(
+            "w-4 h-4 mt-0.5 rounded flex justify-center cursor-pointer select-none active:ring-1 ring-inset ring-auto",
+            copied ? "text-green-800 dark:text-green-300" : "text-auto-icon-button",
+          )}
+          onClick={copyValue}
+        >
+          <Icon className="text-sm -mt-0.5">{copied ? "check" : "content_copy"}</Icon>
+        </button>
+      ) : null}
+      {props.isExpanded && hasCustomDisplay ? (
+        <button
+          title={showingRawData ? "Show formatted data" : "Show raw data"}
+          className={classNames(
+            "w-4 h-4 mt-0.5 rounded flex justify-center text-auto-icon-button cursor-pointer select-none ml-0.5 ring-inset ring-auto",
+            showingRawData ? "bg-transparent active:ring-1" : "bg-auto-contrast-3 ring-1",
+          )}
+          onClick={action(() => showRawData?.set(!showingRawData))}
+        >
+          <Icon className="text-sm -mt-0.5">data_object</Icon>
+        </button>
+      ) : null}
+    </>
+  );
+});
+
+/**
+ * Displays the field key and value for primitives, and the field key and type for non-primitives. For non-primitives,
+ * the value will be displayed separately using MessageFieldChildren.
+ */
+function MessageField(props: NodeLabelProps<MessageNode>) {
+  const { level, node, toggleButton } = props;
+  return (
+    <div
+      style={{ paddingLeft: `${15 * level}px` }}
+      className="hover:bg-auto-contrast-2 cursor-default w-full whitespace-pre-wrap flex leading-5"
+    >
+      {toggleButton}
+      {/* For object nodes which display a (key, type) pair, use flex so they don't wrap */}
+      <div className={node.type === "leaf" ? "block break-all" : "flex"}>
+        <span className="pr-2">
+          <span className={ColorPalette.key}>{node.name}</span>:
+        </span>
+        {node.type === "leaf" ? (
+          <MessageFieldPrimitive value={node.value} type={node.fieldType} />
+        ) : (
+          <MessageFieldType node={node} isExpanded={node.isExpanded} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Displays the nested child content of a non-primitive message field */
+const MessageFieldChildren = observer(function MessageFieldChildren(props: NodeContentProps<MessageNode>) {
+  const { node, level, children } = props;
+  if (node.type === "leaf") {
+    return null;
+  }
+
+  // Pad the content depending on the level in the tree
+  const padding = 15 * level + 40;
+
+  // Display a message if the node is an empty object
+  if (node.children.length === 0) {
+    return (
+      <div style={{ paddingLeft: padding + "px" }} className="hover:bg-auto-contrast-2 text-auto-hint">
+        (empty)
+      </div>
+    );
+  }
+
+  // Get a custom display for the node's value if it has one
+  const formatted = node.showRawData?.get() ? null : formatValue(node.value);
+
+  return formatted ? (
+    <>
+      <div style={{ paddingLeft: padding + "px" }} className="hover:bg-auto-contrast-2 py-1">
+        {formatted.content}
+      </div>
+      {formatted.keepOriginal ? children() : null}
+    </>
+  ) : (
+    <>{children()}</>
+  );
+});
+
+function MessageStat(props: { name: string; children: React.ReactNode }) {
+  return (
+    <div className="flex justify-between gap-4 w-full text-sm py-0.5">
+      <span className="text-auto-secondary">{props.name}</span>
+      {props.children}
+    </div>
+  );
+}
+
+export function MessageView({ viewModel }: { viewModel: MessageViewModel }) {
+  const [bytes, units] = siUnit(viewModel.size, "b");
+  const content = useUpdatable(
+    () => new MessageNodeModel(viewModel.message, viewModel.type),
+    (instance, [message]) => instance.update(message, viewModel.type),
+    [viewModel.message],
+  );
+
+  const timestampNanos = Timestamp.toNanos(viewModel.timestamp);
+
+  return (
+    <div className="p-4 flex flex-col h-full gap-2 bg-auto-surface-2">
+      <div className="relative h-full border border-auto rounded overflow-hidden">
+        <div className="absolute w-full h-full top-0 right-0 py-1 overflow-y-auto text-xs font-mono">
+          <CollapsibleTree root={content.root} NodeLabel={MessageField} NodeContent={MessageFieldChildren} />
+        </div>
+      </div>
+      <div className="divide-y">
+        <MessageStat name="Timestamp">
+          <span className="truncate">{Timestamp.toFormattedDate(timestampNanos)}</span>
+        </MessageStat>
+        <MessageStat name="Size">
+          <span>{bytes.toFixed(2) + units}</span>
+        </MessageStat>
+      </div>
+    </div>
+  );
+}

--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/model.ts
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/model.ts
@@ -1,0 +1,75 @@
+import { NbsScrubberModel } from "@components/nbs_scrubbers/model";
+import { TimelineCameraView, TimelineDataPoint } from "@components/timeline/model";
+import { CompressedImage } from "@proto/message/output/CompressedImage";
+import { MessageInstance } from "@shared/messages/types";
+import { NbsTimestamp } from "@shared/time/timestamp";
+import { action, observable } from "mobx";
+
+import { MessageTypeId } from "../model";
+
+const messageColors = [
+  "#ef4444",
+  "#f97316",
+  "#f59e0b",
+  "#eab308",
+  "#84cc16",
+  "#22c55e",
+  "#10b981",
+  "#14b8a6",
+  "#06b6d4",
+  "#0ea5e9",
+  "#3b82f6",
+  "#6366f1",
+  "#8b5cf6",
+  "#a855f7",
+  "#d946ef",
+  "#ec4899",
+  "#f43f5e",
+];
+
+/** Get a color for a message type */
+export function getMessageColor(messageName: string) {
+  // Simple hash of message name to use as index of color so that a message
+  // name always has the same color
+  const charCodes = [...messageName].map((val) => val.charCodeAt(0));
+  const index = charCodes.reduce((a, b) => a + b, 0) % messageColors.length;
+  return messageColors[index];
+}
+
+/** Get an icon to represent a message type */
+export const messageNameToIcon: Record<string, string> = {
+  // Icon for unknown message types
+  Unknown: "question_mark",
+  [CompressedImage.typeName]: "image",
+  // Default icon for all other message types
+  default: "data_object",
+} as const;
+
+export interface MessageViewModel {
+  /** Message type info */
+  type: MessageTypeId;
+  /** Timestamp of the message */
+  timestamp: NbsTimestamp;
+  /** Size of the message in bytes*/
+  size: number;
+  /** The message itself */
+  message: MessageInstance | Uint8Array;
+}
+
+export class PacketTimelineModel {
+  @observable view: TimelineCameraView;
+  @observable scrubber: NbsScrubberModel;
+  @observable.ref selectedMessage: MessageViewModel | undefined;
+  @observable.shallow highlightedDataPoints: TimelineDataPoint[] = [];
+
+  constructor(scrubber: NbsScrubberModel, view: TimelineCameraView) {
+    this.scrubber = scrubber;
+    this.view = view;
+  }
+
+  @action
+  update(scrubber: NbsScrubberModel, view: TimelineCameraView) {
+    this.scrubber = scrubber;
+    this.view = view;
+  }
+}

--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/packet_timeline.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/packet_timeline.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useMemo, useState } from "react";
+import React from "react";
+import { Icon } from "@components/icon/view";
+import { NbsScrubberModel } from "@components/nbs_scrubbers/model";
+import { NbsScrubberController } from "@components/nbs_scrubbers/nbs_scrubber/controller";
+import { ResizeContainer } from "@components/resize_container/resize_container";
+import { ResizePanel } from "@components/resize_container/resize_panel";
+import { TimelineHeader } from "@components/timeline/header/timeline_header";
+import { TimelineMarker } from "@components/timeline/marker/timeline_marker";
+import { TimelineCameraView, TimelineDataPoint } from "@components/timeline/model";
+import { PreventMouseScroll } from "@components/timeline/prevent_mouse_scroll";
+import { TimelineRow } from "@components/timeline/row/timeline_row";
+import { TimelineView } from "@components/timeline/view";
+import { useRpcController } from "@hooks/use_rpc_controller";
+import { useUpdatable } from "@hooks/use_updatable";
+import classNames from "classnames";
+import { observer } from "mobx-react";
+
+import { MessageTypeId, TypeIndex } from "../model";
+
+import { PacketTimelineController } from "./controller";
+import { MessageView } from "./message/view";
+import { getMessageColor, messageNameToIcon, PacketTimelineModel } from "./model";
+
+export interface PacketTimelineProps {
+  scrubber: NbsScrubberModel;
+  indices: TypeIndex[];
+  controller: NbsScrubberController;
+  timelineCameraView: TimelineCameraView;
+}
+
+export const PacketTimeline = observer((props: PacketTimelineProps) => {
+  const { scrubber, indices, controller, timelineCameraView } = props;
+
+  const model = useUpdatable(
+    () => new PacketTimelineModel(scrubber, timelineCameraView),
+    (instance, [scrubber, view]) => instance.update(scrubber, view),
+    [scrubber, timelineCameraView],
+  );
+
+  const timelineController = useRpcController(
+    (network) => new PacketTimelineController(network, model, controller),
+    [scrubber, model],
+  );
+
+  return (
+    <div className="flex w-full h-full">
+      <ResizeContainer horizontal>
+        <ResizePanel minSize={300} initialRatio={0.75}>
+          <TimelineView view={timelineCameraView} className="flex flex-col w-full h-full">
+            <div className="h-0 grow z-0 pointer-events-none">
+              <div className="w-full h-full flex flex-col overflow-y-auto">
+                <PacketTimelineHeader model={model} controller={timelineController} />
+                <PacketTimelineBody indices={indices} model={model} controller={timelineController} />
+              </div>
+            </div>
+          </TimelineView>
+        </ResizePanel>
+        <ResizePanel minSize={300} initialRatio={0.25} className="bg-auto-surface-1 whitespace-pre-wrap text-left">
+          {model.selectedMessage ? (
+            <MessageView viewModel={model.selectedMessage} />
+          ) : (
+            <div className="flex flex-col gap-2 items-center justify-center h-full">
+              <Icon className="text-auto-icon">info</Icon>
+              <span className="text-auto-hint text-sm">No packet selected</span>
+            </div>
+          )}
+        </ResizePanel>
+      </ResizeContainer>
+    </div>
+  );
+});
+
+const PacketTimelineHeader = observer(function PacketTimelineHeader(props: {
+  model: PacketTimelineModel;
+  controller: PacketTimelineController;
+}) {
+  const { model, controller } = props;
+  const [isScrubbing, setIsScrubbing] = useState(false);
+  const [hoveredTime, setHoveredTime] = useState<bigint | undefined>(undefined);
+
+  const startScrubbing = useCallback(
+    (timestamp: bigint) => {
+      controller.seek(timestamp);
+      setIsScrubbing(true);
+    },
+    [controller, setIsScrubbing],
+  );
+
+  const onScrub = useCallback(
+    (timestamp: bigint) => {
+      if (isScrubbing) {
+        controller.seek(timestamp);
+      }
+      setHoveredTime(timestamp);
+    },
+    [isScrubbing, setHoveredTime],
+  );
+
+  const stopScrubbing = useCallback(() => setIsScrubbing(false), [setIsScrubbing]);
+
+  return (
+    <>
+      <div className="flex w-full h-12 border-b border-auto shrink-0 sticky top-0 bg-auto-surface-2 pointer-events-auto">
+        <div className="w-80 bg-auto-surface-2 border-r border-auto"></div>
+        <PreventMouseScroll className="flex-1">
+          <TimelineHeader
+            className="w-full h-full"
+            onPointerDown={startScrubbing}
+            onPointerMove={onScrub}
+            onPointerUp={stopScrubbing}
+            onMouseLeave={() => setHoveredTime(undefined)}
+          />
+        </PreventMouseScroll>
+      </div>
+      <TimelineMarker timestamp={model.scrubber.current} color="var(--color-nusight-500)" clampToView />
+      {!isScrubbing && hoveredTime !== undefined ? (
+        <TimelineMarker timestamp={hoveredTime} color="var(--color-auto-contrast-2)" />
+      ) : null}
+    </>
+  );
+});
+
+const PacketTimelineBody = observer(function PacketTimelineBody(props: {
+  indices: TypeIndex[];
+  model: PacketTimelineModel;
+  controller: PacketTimelineController;
+}) {
+  const { indices, model, controller } = props;
+
+  return (
+    <>
+      {indices.map((typeIndex) => (
+        <PacketTimelineBodyRow
+          key={typeIndex.type.typeHash + typeIndex.type.subtype}
+          typeIndex={typeIndex}
+          model={model}
+          controller={controller}
+        />
+      ))}
+      {/* Render a final blank row to fill the remaining height */}
+      <div className="flex w-full h-full -z-[1] pointer-events-auto">
+        <div className="w-80 bg-auto-surface-2 border-r border-auto"></div>
+        <div className="flex-1">
+          <TimelineRow className="w-full h-full" />
+        </div>
+      </div>
+    </>
+  );
+});
+
+const PacketTimelineBodyRow = observer(function PacketTimelineBodyRow(props: {
+  typeIndex: TypeIndex;
+  model: PacketTimelineModel;
+  controller: PacketTimelineController;
+}) {
+  const { typeIndex, model, controller } = props;
+  const type = typeIndex.type;
+  const selected = model.selectedMessage;
+  const isSelected = type.typeHash === selected?.type.typeHash && type.subtype === selected?.type.subtype;
+
+  const color = useMemo(() => {
+    const nameOrHash = type.typeName === "" ? type.typeHash : type.typeName;
+    return getMessageColor(nameOrHash);
+  }, [type.typeName]);
+
+  const dataPoints = useMemo<TimelineDataPoint[]>(
+    () => typeIndex.timestamps.map((timestamp) => ({ timestamp, color })),
+    [typeIndex.timestamps],
+  );
+
+  const onDataPointClick = useCallback(
+    (dataPoint: TimelineDataPoint) => {
+      if (model.highlightedDataPoints.includes(dataPoint)) {
+        controller.deselectPacket();
+      } else {
+        const index = typeIndex.timestamps.indexOf(dataPoint.timestamp);
+        controller.selectPacket(type, index, dataPoint);
+      }
+    },
+    [typeIndex, controller],
+  );
+
+  return (
+    <div className="relative flex w-full h-8 shrink-0 border-b border-auto -z-[1] pointer-events-auto">
+      <div className="w-80 bg-auto-surface-2 border-r border-auto">
+        <PacketTypeView type={type} isSelected={isSelected} />
+      </div>
+      <div className="flex-1">
+        <PreventMouseScroll className="w-full h-full">
+          <TimelineRow
+            onDataPointClick={onDataPointClick}
+            dataPoints={dataPoints}
+            highlightedDataPoints={model.highlightedDataPoints}
+            dataPointHeight={16}
+            dataPointWidth={12}
+            className={classNames("w-full h-full", isSelected ? "bg-nusight-500/20" : "")}
+          />
+        </PreventMouseScroll>
+      </div>
+    </div>
+  );
+});
+
+function PacketTypeView(props: { type: MessageTypeId; isSelected: boolean }) {
+  const { type, isSelected } = props;
+  const { typeName, typeHash, subtype } = type;
+
+  // Empty name indicates that the name is not known
+  const fullName = typeName === "" ? "Unknown" : typeName;
+  const baseName = fullName.split(".").at(-1);
+
+  // 0 subtype indicates that the message has no subtype
+  const hasSubtype = subtype !== 0;
+  const fullNameWithSubtype = fullName + (hasSubtype ? "#" + subtype : "");
+
+  const iconName = messageNameToIcon[fullName] ?? messageNameToIcon["default"];
+
+  return (
+    <div className={classNames("h-full", isSelected ? "dark" : "")} title={fullNameWithSubtype}>
+      <div
+        className={classNames("flex h-full px-2 gap-2 items-center", isSelected ? "bg-nusight-500" : "bg-transparent")}
+      >
+        <Icon size="20" className="text-auto-icon">
+          {iconName}
+        </Icon>
+        <div className="flex gap-1 truncate text-sm text-auto-primary">
+          {baseName}
+          {typeName === "" ? <span className="text-auto-secondary">({typeHash})</span> : null}
+          {hasSubtype ? <span className="text-auto-secondary">#{subtype}</span> : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/nusight2/src/client/components/blank_state.tsx
+++ b/nusight2/src/client/components/blank_state.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { useUrlSelectedDataSource } from "@hooks/use_auto_select_data_source";
+
+import { Icon } from "./icon/view";
+
+interface BlankStateProps {
+  title: string;
+  icon?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export function BlankState({ icon, title, children }: BlankStateProps) {
+  return (
+    <div className="flex flex-col justify-center items-center h-full p-8">
+      {icon ? (
+        <div className="opacity-60 mb-2">
+          {typeof icon === "string" ? <Icon className="text-6xl/none">{icon}</Icon> : icon}
+        </div>
+      ) : null}
+      <div className="text-3xl font-light">{title}</div>
+      {children ? <p className="text-base opacity-80 mt-4">{children}</p> : null}
+    </div>
+  );
+}
+
+interface NoSelectedDataSourceProps {
+  /** Whether any robots are connected */
+  hasDataSources: boolean;
+  /** Whether a robot is required to be specified in the URL */
+  urlSelectionRequired?: boolean;
+  /** The action that the user would be performing if a robot was selected, shown in the message */
+  pendingAction: string;
+}
+
+/**
+ * Shows a blank state when no robot is connected or selected, with an appropriate message based on:
+ * - whether a particular robot is specified for selection in the URL, and whether URL selection is required
+ * - whether any robots are connected
+ */
+export function NoSelectedDataSource(props: NoSelectedDataSourceProps) {
+  const { hasDataSources, pendingAction, urlSelectionRequired } = props;
+
+  const urlDataSource = useUrlSelectedDataSource();
+
+  // If a specific robot is expected for selection (i.e. there's a robot ID or name specified in the URL),
+  // show a message indicating that
+  if (urlDataSource) {
+    return (
+      <BlankState title="Waiting for robot to connect" icon="electrical_services">
+        The specified robot <span className="font-bold">{urlDataSource.id ?? urlDataSource.name}</span> is not connected
+      </BlankState>
+    );
+  }
+
+  // Some views require a robot to be specified in the URL.
+  // If this is the case and no robot is specified, show a message indicating that.
+  if (urlSelectionRequired && !urlDataSource) {
+    return (
+      <BlankState title="No robot specified" icon="error">
+        Specify a robot in the URL to {pendingAction}
+      </BlankState>
+    );
+  }
+
+  // If there are robots connected, show a message prompting the user to select one
+  if (hasDataSources) {
+    return (
+      <BlankState title="No robot selected" icon="electrical_services">
+        Select a robot to {pendingAction}
+      </BlankState>
+    );
+  }
+
+  // Otherwise, show a message prompting the user to connect a robot
+  return (
+    <BlankState title="No connected robots" icon="electrical_services">
+      Connect a device or load an NBS file to {pendingAction}
+    </BlankState>
+  );
+}

--- a/nusight2/src/client/components/collapsible_tree/collapsible_tree.tsx
+++ b/nusight2/src/client/components/collapsible_tree/collapsible_tree.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback, useState } from "react";
+import { Icon } from "@components/icon/view";
+
+import { NodeContentComponentType } from "./types";
+import { NodeContentProps } from "./types";
+import { NodeLabelComponentType } from "./types";
+import { NodeLabelProps } from "./types";
+import { InternalNode } from "./types";
+
+function DefaultNodeLabel(props: NodeLabelProps) {
+  const { node, level, toggleButton } = props;
+  return (
+    <div className="flex items-center" style={{ paddingLeft: 16 * level + "px" }}>
+      {toggleButton}
+      <span>{node.name}</span>
+    </div>
+  );
+}
+
+function DefaultNodeContent(props: NodeContentProps) {
+  return <>{props.children()}</>;
+}
+
+export interface CollapsibleTreeProps<T = {}> {
+  root: InternalNode<T>;
+  NodeLabel?: NodeLabelComponentType<T>;
+  NodeContent?: NodeContentComponentType<T>;
+}
+
+/** A collapsible tree, supporting custom node types */
+export function CollapsibleTree<T>(props: CollapsibleTreeProps<T>) {
+  const { root } = props;
+
+  // Use the default components if they aren't given
+  const NodeLabel = props.NodeLabel ?? DefaultNodeLabel;
+  const NodeContent = props.NodeContent ?? DefaultNodeContent;
+
+  return <InternalNodeView node={root} level={0} path={root.name} NodeLabel={NodeLabel} NodeContent={NodeContent} />;
+}
+
+interface InternalNodeViewProps {
+  node: InternalNode;
+  path: string;
+  level: number;
+  NodeLabel: NodeLabelComponentType;
+  NodeContent: NodeContentComponentType;
+}
+
+/** An internal node in the collapsible tree */
+function InternalNodeView(props: InternalNodeViewProps) {
+  const { node, path, level, NodeLabel, NodeContent } = props;
+  const [isExpanded, setIsExpanded] = useState(node.isExpanded);
+
+  const toggleExpanded = useCallback(() => {
+    setIsExpanded((value) => {
+      node.isExpanded = !value;
+      return !value;
+    });
+  }, [setIsExpanded, node]);
+
+  return (
+    <div className="flex flex-col">
+      <NodeLabel
+        path={path}
+        level={level}
+        node={node}
+        toggleButton={
+          <button className="flex items-center w-5 h-5 shrink-0" onClick={toggleExpanded}>
+            <Icon size="20" rotate={isExpanded ? "90" : "0"} className="transition-transform text-auto-hint">
+              chevron_right
+            </Icon>
+          </button>
+        }
+      />
+      {isExpanded ? (
+        <NodeContent level={level} node={node} path={path}>
+          {() => (
+            <NodeContentView node={node} path={path} level={level} NodeLabel={NodeLabel} NodeContent={NodeContent} />
+          )}
+        </NodeContent>
+      ) : null}
+    </div>
+  );
+}
+
+interface NodeChildrenViewProps {
+  node: InternalNode;
+  path: string;
+  level: number;
+  NodeLabel: NodeLabelComponentType;
+  NodeContent: NodeContentComponentType;
+}
+
+/** An unordered list of a node's children */
+function NodeContentView(props: NodeChildrenViewProps) {
+  const { node, path, level, NodeLabel, NodeContent } = props;
+  return (
+    <ul>
+      {node.children.map((node) => {
+        return (
+          <li key={node.name}>
+            {node.type === "internal" ? (
+              <InternalNodeView
+                path={path + "." + node.name}
+                level={level + 1}
+                node={node}
+                NodeLabel={NodeLabel}
+                NodeContent={NodeContent}
+              />
+            ) : (
+              <NodeLabel
+                path={path + "." + node.name}
+                level={level + 1}
+                node={node}
+                toggleButton={<div className="w-5 h-5 shrink-0" />}
+              />
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/nusight2/src/client/components/collapsible_tree/types.ts
+++ b/nusight2/src/client/components/collapsible_tree/types.ts
@@ -1,0 +1,49 @@
+export interface RootNode<T = {}> {
+  children: Node<T>[];
+}
+
+/**
+ * A node in a collapsible tree.
+ * The generic allows extra attributes to be added to the node.
+ */
+export type Node<T = {}> = InternalNode<T> | LeafNode<T>;
+
+export type InternalNode<T = {}> = T & {
+  type: "internal";
+  name: string;
+  isExpanded: boolean;
+  children: Node<T>[];
+};
+
+export type LeafNode<T = {}> = T & {
+  type: "leaf";
+  name: string;
+};
+
+/**
+ * Props for a node label in a collapsible tree.
+ * The generic determines the type of node used.
+ */
+export interface NodeLabelProps<T = Node> {
+  node: T;
+  path: string;
+  level: number;
+  toggleButton: React.ReactNode;
+}
+
+/**
+ * Props for the children of a node in a collapsible tree.
+ * The generic determines the type of node used.
+ */
+export interface NodeContentProps<T = Node> {
+  node: T;
+  path: string;
+  level: number;
+  children: () => React.ReactNode;
+}
+
+/** Component to render a label for a node in a collapsible tree */
+export type NodeLabelComponentType<T = {}> = React.ComponentType<NodeLabelProps<Node<T>>>;
+
+/** Component to render the children for a node in a collapsible tree */
+export type NodeContentComponentType<T = {}> = React.ComponentType<NodeContentProps<Node<T>>>;

--- a/nusight2/src/client/hooks/use_auto_select_data_source.ts
+++ b/nusight2/src/client/hooks/use_auto_select_data_source.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useMemo } from "react";
+import { autorun } from "mobx";
+import { useSearchParams } from "react-router-dom";
+
+function useSearchParam(key: string) {
+  const [searchParams] = useSearchParams();
+  return useMemo(() => searchParams.get(key)?.trim(), [searchParams, key]);
+}
+
+/**
+ * Get the selected robot ID and name from the current URL parameters.
+ * Returns undefined if no robot parameters are present in the URL.
+ *
+ * URL params: `robotId` (string) and/or `robotName` (string).
+ */
+export function useUrlSelectedDataSource(): { id?: string; name?: string } | undefined {
+  const id = useSearchParam("robotId");
+  const name = useSearchParam("robotName");
+  return useMemo(() => (id || name ? { id: id ?? undefined, name: name ?? undefined } : undefined), [id, name]);
+}
+
+/**
+ * Automatically select the first data source (robot) for which the given callback returns true.
+ * If no callback is given, the first available (connected) robot is selected.
+ *
+ * The given `model` should have observable `robots` and `selectedRobot` properties.
+ */
+export function useAutoSelectMatchingDataSource<T extends { connected: boolean }>(
+  model: { robots: T[]; selectedRobot?: T },
+  setSelected: (dataSource?: T) => void,
+  matchDataSource?: (dataSource: T) => boolean,
+) {
+  useEffect(() => {
+    return autorun(() => {
+      // Do nothing if there is already a valid (connected) selection
+      if (model.selectedRobot && model.selectedRobot.connected) {
+        return;
+      }
+
+      const matched: T | undefined = matchDataSource
+        ? model.robots.find(matchDataSource)
+        : model.robots.find((r) => r.connected);
+      setSelected(matched);
+    });
+  }, [model, setSelected, matchDataSource]);
+}
+
+/**
+ * Automatically select a robot as follows (in order of precedence):
+ * - if there's a `robotId` parameter in the current URL, select the robot with that ID
+ * - if there's a `robotName` parameter in the current URL, select the robot with that name
+ * - if neither parameter is present, select the first connected robot unless `opts.fallbackToFirst` is false
+ *
+ * The given `model` should have observable `robots` and `selectedRobot` properties.
+ *
+ * @return The URL selected data source, if any
+ */
+export function useAutoSelectDataSourceFromUrl<T extends { id: string; name: string; connected: boolean }>(
+  model: { robots: T[]; selectedRobot?: T },
+  setSelected: (dataSource?: T) => void,
+  opts?: { fallbackToFirst?: boolean },
+) {
+  const expectedDataSource = useUrlSelectedDataSource();
+
+  const matchDataSource = useCallback(
+    (dataSource: T) => {
+      if (!dataSource.connected) {
+        return false;
+      }
+
+      if (expectedDataSource?.id !== undefined) {
+        return dataSource.id === expectedDataSource.id;
+      }
+
+      if (expectedDataSource?.name) {
+        return dataSource.name === expectedDataSource.name;
+      }
+
+      return opts?.fallbackToFirst ?? true;
+    },
+    [expectedDataSource?.id, expectedDataSource?.name, opts?.fallbackToFirst],
+  );
+
+  useAutoSelectMatchingDataSource(model, setSelected, matchDataSource);
+
+  return expectedDataSource;
+}

--- a/nusight2/src/client/hooks/use_timed_state.ts
+++ b/nusight2/src/client/hooks/use_timed_state.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * A hook similar to `useState`, but each time the value is set, it is reset back to the initial
+ * value after a timeout.
+ */
+export function useTimedState<T>(initialState: T, timeout: number): [T, (value: T) => void] {
+  const [value, setValueInternal] = useState(initialState);
+  const [valueKey, setValueKey] = useState(0);
+
+  // Set the value and increment the key to reset the timeout
+  const setValue = useCallback(
+    (value: T) => {
+      setValueInternal(value);
+      setValueKey((key) => key + 1);
+    },
+    [setValueInternal, setValueKey],
+  );
+
+  // If the value is different to the default, set a timeout to reset it.
+  // This uses the key as dependency so the timeout gets reset when the same value is set multiple times.
+  useEffect(() => {
+    if (value !== initialState) {
+      const id = setTimeout(() => setValue(initialState), timeout);
+      return () => clearTimeout(id);
+    }
+  }, [value, valueKey, timeout]);
+
+  return [value, setValue];
+}

--- a/nusight2/src/client/main.tsx
+++ b/nusight2/src/client/main.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { configure } from "mobx";
 import { createRoot } from "react-dom/client";
 
+import { installStandaloneAdvancedScrubber } from "./components/advanced_scrubber/install";
 import { setAppContext } from "./components/app/context";
 import { AppController } from "./components/app/controller";
 import { AppModel } from "./components/app/model";
@@ -38,6 +39,7 @@ installVision({ nav, appModel, nusightNetwork, Menu });
 installLogs({ nav, appModel, nusightNetwork, Menu });
 installServos({ nav, appModel, nusightNetwork, Menu });
 installDirector({ nav, appModel, nusightNetwork, Menu });
+installStandaloneAdvancedScrubber({ nav, appModel, nusightNetwork });
 
 configure({ enforceActions: "observed" });
 createRoot(document.getElementById("root")!).render(<AppView nav={nav} />);

--- a/shared/message/eye/Scrubber.proto
+++ b/shared/message/eye/Scrubber.proto
@@ -152,3 +152,41 @@ message ScrubberClosed {
     /// The ID of the scrubber that was closed
     uint32 id = 1;
 }
+
+message ScrubberIndex {
+    message TypeIndex {
+        /// Hash of the message type
+        string type_hash = 1;
+        /// Name of the message type
+        string type_name = 2;
+        /// Subtype of the message
+        uint32 subtype = 3;
+        /// Timestamps of this (type, subtype) pair in the scrubber's file(s)
+        repeated google.protobuf.Timestamp timestamps = 4;
+    }
+
+    /// Id of the scrubber this index belongs to
+    uint32 id = 1;
+    /// Index for each (type, subtype) pair in the message
+    repeated TypeIndex indices = 2;
+}
+
+message ScrubberPacketRequest {
+    message Response {
+        /// Metadata for the RPC response
+        RpcResponseMeta rpc = 1;
+        /// Payload of the message matching the request
+        bytes data = 2;
+    }
+
+    /// Metadata for the RPC request
+    RpcRequestMeta rpc = 1;
+    /// ID of the scrubber
+    uint32 id = 2;
+    /// Type hash of the message
+    string type_hash = 3;
+    /// Subtype of the message
+    uint32 subtype = 4;
+    /// Offset of the requested packet
+    uint32 offset = 5;
+}


### PR DESCRIPTION
Part of the advanced scrubber work, stacked on the timeline component (#1802) and popouts/windows infrastructure (#1800). Targets the `houliston/advanced-scrubber` integration branch.

## What this adds

- **Advanced Scrubber component** (`nusight2/src/client/components/advanced_scrubber/`) — a packet inspector view for scrubbing NBS recordings: component, create/install wiring, model, and network layer.
- **Packet timeline** (`advanced_scrubber/packet_timeline/`) — controller + model driving a per-type packet timeline, with a message inspector (model/view) and custom value formatters for bytes, images, and math types (vectors/matrices).
- **Reusable UI primitives** used by the inspector:
  - `components/blank_state.tsx` — empty-state placeholder
  - `components/collapsible_tree/` — generic collapsible tree for message field display
  - `hooks/use_auto_select_data_source.ts`, `hooks/use_timed_state.ts`
- **`shared/message/eye/Scrubber.proto`** — scrubber index/packet request messages.
- `main.tsx` wiring to register the component.

## Notes

- Consumes the timeline from #1802 and the popouts/windows infrastructure from #1800.

## Verification

- `yarn eslint` — clean (no errors in these files)
- `yarn tscheck` — 0 errors
- `yarn vitest run` — 37 files / 273 tests passing