### PR TITLE
Launch advanced scrubber as a scrub-bar popout window

### DIFF
--- a/nusight2/src/client/components/nbs_scrubbers/nbs_scrubber/view.tsx
+++ b/nusight2/src/client/components/nbs_scrubbers/nbs_scrubber/view.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
+import { usePopout } from "@client/popouts/popout";
+import { ChildWindowOpts } from "@client/windows/child_window";
 import { observer } from "mobx-react";
 
 import { useRpcController } from "../../../hooks/use_rpc_controller";
@@ -23,11 +25,35 @@ export const NbsScrubberView = observer(({ model, onFocus }: NbsScrubberViewProp
       <NbsScrubberRangeSlider model={model} controller={controller} />
       {buttonDivider}
       <NbsScrubberRightControls model={model} controller={controller}>
+        <NbsScrubberPopoutButton model={model} />
         <IconButton title="Close scrubber" onClick={controller.close}>
           close
         </IconButton>
       </NbsScrubberRightControls>
     </div>
+  );
+});
+
+const NbsScrubberPopoutButton = observer(({ model }: { model: NbsScrubberModel }) => {
+  const windowOpts = useMemo<ChildWindowOpts>(
+    () => ({
+      name: `scrubber/${model.id}`,
+      url: `/standalone/scrubber?robotName=${encodeURIComponent(model.name)}`,
+      size: { height: `${Math.floor(screen.height / 1.5)}px`, width: "90%" },
+    }),
+    [model.id, model.name],
+  );
+
+  const popout = usePopout(windowOpts);
+
+  return popout.isOpen ? (
+    <IconButton color="primary" title="Focus scrubber window" onClick={popout.focus}>
+      open_in_new
+    </IconButton>
+  ) : (
+    <IconButton title="Pop scrubber out into a standalone window" onClick={() => popout.open()}>
+      open_in_new
+    </IconButton>
   );
 });
 

--- a/nusight2/src/client/hooks/use_auto_close.ts
+++ b/nusight2/src/client/hooks/use_auto_close.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+/** Close the current window when the parent window closes */
+export function useAutoCloseOnParentClose(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    // There's no event for when the parent window closes,
+    // so we setup a polling interval to check if it's closed
+    const closeInterval = setInterval(() => {
+      if (!window.opener || window.opener.closed) {
+        clearInterval(closeInterval);
+        window.close();
+      }
+    }, 1000);
+
+    return () => clearInterval(closeInterval);
+  }, [enabled]);
+}

--- a/nusight2/src/client/main.tsx
+++ b/nusight2/src/client/main.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import { configure } from "mobx";
 import { createRoot } from "react-dom/client";
 
-import { installStandaloneAdvancedScrubber } from "./components/advanced_scrubber/install";
 import { setAppContext } from "./components/app/context";
 import { AppController } from "./components/app/controller";
 import { AppModel } from "./components/app/model";
@@ -39,7 +38,6 @@ installVision({ nav, appModel, nusightNetwork, Menu });
 installLogs({ nav, appModel, nusightNetwork, Menu });
 installServos({ nav, appModel, nusightNetwork, Menu });
 installDirector({ nav, appModel, nusightNetwork, Menu });
-installStandaloneAdvancedScrubber({ nav, appModel, nusightNetwork });
 
 configure({ enforceActions: "observed" });
 createRoot(document.getElementById("root")!).render(<AppView nav={nav} />);

--- a/nusight2/src/client/navigation.tsx
+++ b/nusight2/src/client/navigation.tsx
@@ -9,13 +9,21 @@ export type Route = {
 
 export class NavigationConfiguration {
   private routes: Route[] = [];
+  private basePath: string;
 
-  static of() {
-    return new NavigationConfiguration();
+  constructor(basePath: string = "") {
+    // Remove any trailing / from the base path
+    this.basePath = basePath.replace(/\/$/, "");
+  }
+
+  static of(basePath: string = "") {
+    return new NavigationConfiguration(basePath);
   }
 
   addRoute(route: Route) {
-    this.routes.push(route);
+    // Trim any leading / from the route path, then prefix with the base path
+    const routePath = route.path.replace(/^\//, "");
+    this.routes.push({ ...route, path: `${this.basePath}/${routePath}` });
   }
 
   getRoutes() {

--- a/nusight2/src/client/standalone.tsx
+++ b/nusight2/src/client/standalone.tsx
@@ -1,0 +1,61 @@
+import "./tailwind.css";
+
+import React, { Suspense } from "react";
+import { configure } from "mobx";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+
+import { installStandaloneAdvancedScrubber } from "./components/advanced_scrubber/install";
+import { setAppContext } from "./components/app/context";
+import { AppModel } from "./components/app/model";
+import { AppNetwork } from "./components/app/network";
+import { BlankState } from "./components/blank_state";
+import { useAutoCloseOnParentClose } from "./hooks/use_auto_close";
+import { NavigationConfiguration } from "./navigation";
+import { NUsightNetwork } from "./network/nusight_network";
+import { usePopoutChild } from "./popouts/popout";
+
+const appModel = AppModel.of();
+const nusightNetwork = NUsightNetwork.of(appModel);
+nusightNetwork.connect({ name: "nusight" });
+
+setAppContext({ nusightNetwork });
+
+AppNetwork.of(nusightNetwork, appModel);
+
+const nav = NavigationConfiguration.of("/standalone");
+
+// Install the standalone routes
+installStandaloneAdvancedScrubber({ nav, appModel, nusightNetwork });
+
+function AppView() {
+  // If this is a child window, close it when its parent window closes
+  useAutoCloseOnParentClose(location.search.includes("isChild=true"));
+
+  // Connect to the popout parent if this is a child window
+  usePopoutChild();
+
+  return (
+    <BrowserRouter>
+      <div className="bg-gray-900 text-white/90 h-screen w-screen">
+        <Suspense fallback={<div className="p-2">Loading...</div>}>
+          <Routes>
+            {nav.getRoutes().map((route) => (
+              <Route key={route.path} path={route.path} element={<route.Content />} />
+            ))}
+            <Route path="*" element={<BlankState title="404: Not found" icon="warning" />} />
+          </Routes>
+        </Suspense>
+      </div>
+    </BrowserRouter>
+  );
+}
+
+configure({ enforceActions: "observed" });
+
+// Create the React root at most once (even if this module is hot reloaded) and render
+const container = document.getElementById("root") as HTMLElement & {
+  __reactRoot?: ReturnType<typeof createRoot>;
+};
+container.__reactRoot = container.__reactRoot ?? createRoot(container);
+container.__reactRoot.render(<AppView />);

--- a/nusight2/src/server/dev.ts
+++ b/nusight2/src/server/dev.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import compression from "compression";
 import express from "express";
 import http from "http";
@@ -38,6 +41,25 @@ async function main() {
 
   app.use(compression());
   app.use(favicon(faviconPath));
+
+  // Configure extra client entry points in addition to the main `index.html`.
+  // Entries specified here should also be configured in `vite.config.ts` and in `prod.ts`.
+  const additionalEntryPoints = {
+    "/standalone": path.resolve("standalone.html"),
+  } as const;
+
+  for (const [url, htmlFilePath] of Object.entries(additionalEntryPoints)) {
+    app.use(url, async (_req, res, next) => {
+      try {
+        const template = await fs.promises.readFile(htmlFilePath, "utf-8");
+        const html = await viteDevServer.transformIndexHtml(url, template);
+        res.status(200).set({ "Content-Type": "text/html" }).end(html);
+      } catch (e) {
+        next(e);
+      }
+    });
+  }
+
   app.use(viteDevServer.middlewares);
 
   const port = process.env.PORT || 3000;

--- a/nusight2/src/server/prod.ts
+++ b/nusight2/src/server/prod.ts
@@ -27,6 +27,9 @@ app.use(
     rewrites: [
       // Allows user to navigate to /storybook/ without needing to type /index.html
       { from: /\/storybook\/$/, to: "storybook/index.html" },
+      // Additional entry points that are not the main `index.html`.
+      // Entries here should also be configured in `vite.config.ts` and in `dev.ts`.
+      { from: /\/standalone(?!.*\..*)/, to: "standalone.html" },
     ],
   }),
 );

--- a/nusight2/standalone.html
+++ b/nusight2/standalone.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="color-scheme" content="dark light" />
+    <title>NUsight</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="stylesheet" href="/fonts/roboto/roboto-stylesheet.css" />
+    <link rel="stylesheet" href="/fonts/material-symbols/outlined.css" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/client/standalone.tsx"></script>
+  </body>
+</html>

--- a/nusight2/vite.config.ts
+++ b/nusight2/vite.config.ts
@@ -1,4 +1,6 @@
 /* eslint-env node */
+import { fileURLToPath } from "node:url";
+
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
@@ -36,6 +38,10 @@ export default defineConfig({
       // that require geotiff, so we can safely mark these as external for
       // rollup to avoid bundling them.
       external: ["geotiff", "geotiff/src/compression", "fs", "http", "https", "url"],
+      input: {
+        main: fileURLToPath(new URL("./index.html", import.meta.url)),
+        standalone: fileURLToPath(new URL("./standalone.html", import.meta.url)),
+      },
     },
   },
   test: {


### PR DESCRIPTION
Reworks how the advanced scrubber is launched so it matches the intended UX: instead of a permanent left-sidebar nav item, it is opened from a **pop-out button on the NBS scrubber control bar** into a **standalone browser window**.

Stacked on the advanced scrubber inspector (#1803), timeline (#1802), and popouts/windows infrastructure (#1800). Targets `houliston/advanced-scrubber`.

## What changed

**New standalone client entry**
- `standalone.html` + `src/client/standalone.tsx` — a lean second bundle that registers **only** the advanced scrubber on a `/standalone` navigation, connects its own NUClearNet client, and re-derives its data source from the URL.
- Served for `/standalone/*` in dev (`dev.ts` Vite middleware) and prod (`prod.ts` history rewrite), and wired as a second Vite build input (`vite.config.ts`).

**Scrub-bar launch**
- `nbs_scrubber/view.tsx` — adds `NbsScrubberPopoutButton` (an `open_in_new` button that becomes a Focus button while the window is open), using the existing popouts/windows infrastructure.
- Removed the advanced scrubber from the main sidebar (`main.tsx`).

**Supporting**
- `hooks/use_auto_close.ts` — `useAutoCloseOnParentClose` closes the popped-out window when its parent closes.
- `navigation.tsx` — optional base path support for the `/standalone` routes (backward compatible; the main app passes no base path).

## Notes
- The data source is passed to the popout via the `robotName` URL param (NUsight's existing convention), consumed by `useAutoSelectDataSourceFromUrl`.
- The advanced scrubber is now reachable **only** via the scrub-bar popout button (no sidebar footprint).

## Verification
- `yarn tscheck` — 0 errors
- `yarn eslint` — clean
- `yarn vitest run` — 37 files / 273 tests passing
- `yarn vite build` — emits both `main` and `standalone` bundles