### PR TITLE
Synthesize the scrubber index and serve packet requests

### DIFF
--- a/nusight2/src/server/nbs_scrubber/network.ts
+++ b/nusight2/src/server/nbs_scrubber/network.ts
@@ -2,6 +2,7 @@ import {
   ScrubberClosed,
   ScrubberCloseRequest,
   ScrubberLoadRequest,
+  ScrubberPacketRequest,
   ScrubberPauseRequest,
   ScrubberPlayRequest,
   ScrubberSeekRequest,
@@ -28,6 +29,7 @@ export class NbsScrubberNetwork {
       network.onClientRpc(ScrubberSetPlaybackSpeedRequest, this.onSetPlaybackSpeed),
       network.onClientRpc(ScrubberSetRepeatRequest, this.onSetRepeat),
       network.onClientRpc(ScrubberSeekRequest, this.onSeek),
+      network.onClientRpc(ScrubberPacketRequest, this.onPacketRequest),
     ]);
   }
 
@@ -99,6 +101,21 @@ export class NbsScrubberNetwork {
     });
 
     return new ScrubberSeekRequest.Response({ rpc: { ok: true, token: request.rpc?.token } });
+  };
+
+  /** Handle a request from the client for an individual packet */
+  private onPacketRequest = (request: ScrubberPacketRequest) => {
+    const typeSubtype = {
+      type: Buffer.from(request.typeHash, "hex"),
+      subtype: request.subtype,
+    };
+
+    const data = this.session.scrubberSet.getPacketBytes(request.id, typeSubtype, request.offset);
+
+    return new ScrubberPacketRequest.Response({
+      rpc: { ok: true, token: request.rpc?.token },
+      data,
+    });
   };
 
   /** Handle a request from the client to close a scrubber */

--- a/nusight2/src/server/nbs_scrubber/packet_synthesis.ts
+++ b/nusight2/src/server/nbs_scrubber/packet_synthesis.ts
@@ -1,6 +1,12 @@
-import { ScrubberState, ScrubberState_StateEnum } from "@proto/message/eye/Scrubber";
+import {
+  ScrubberIndex,
+  ScrubberIndex_TypeIndex,
+  ScrubberState,
+  ScrubberState_StateEnum,
+} from "@proto/message/eye/Scrubber";
 import { NbsPacket, NbsTypeSubtypeBuffer } from "nbsdecoder.js";
 
+import { messageHashToName } from "../../shared/messages/generated/hash_converters";
 import { hashType } from "../../shared/nuclearnet/hash_type";
 import { Timestamp } from "../../shared/time/timestamp";
 
@@ -23,6 +29,13 @@ types.set(hashType("message.eye.ScrubberState").toString("hex"), {
   subtype: 0,
 });
 
+// Add the ScrubberIndex type
+types.set(hashType("message.eye.ScrubberIndex").toString("hex"), {
+  event: "message.eye.ScrubberIndex",
+  type: hashType("message.eye.ScrubberIndex"),
+  subtype: 0,
+});
+
 /** Get a list of all the types we can synthesize */
 export function availableSyntheticTypes(): NbsTypeSubtypeBuffer[] {
   return Array.from(types.values());
@@ -31,6 +44,51 @@ export function availableSyntheticTypes(): NbsTypeSubtypeBuffer[] {
 /** Check if the given type can be synthesized */
 export function isSynthesizable(type: NbsTypeSubtypeBuffer) {
   return types.has(type.type.toString("hex"));
+}
+
+/** The hash of the ScrubberIndex type, which is synthesized once and never changes */
+const scrubberIndexTypeHash = hashType("message.eye.ScrubberIndex").toString("hex");
+
+/**
+ * Check if the given type is a static synthetic type: one that is synthesized once and
+ * does not change over time, so it does not need to be re-emitted during playback.
+ */
+export function isStaticSyntheticType(type: NbsTypeSubtypeBuffer): boolean {
+  return type.type.toString("hex") === scrubberIndexTypeHash;
+}
+
+/** Cache of the built scrubber index payload, keyed by scrubber */
+const indexPayloadCache = new WeakMap<Scrubber, Buffer>();
+
+/** Build, or get the cached, ScrubberIndex payload for the given scrubber */
+function getIndexPayload(scrubber: Scrubber): Buffer {
+  const cached = indexPayloadCache.get(scrubber);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const getMessageName = (hash: Buffer | string) => {
+    try {
+      return messageHashToName(hash);
+    } catch {
+      // Empty string indicates that we don't know the message name
+      return "";
+    }
+  };
+
+  const indices = scrubber.decoder.getAvailableTypes().map((typeSubtype) => {
+    const timestamps = scrubber.decoder.getTypeIndex(typeSubtype);
+    return new ScrubberIndex_TypeIndex({
+      typeName: getMessageName(typeSubtype.type),
+      typeHash: typeSubtype.type.toString("hex"),
+      subtype: typeSubtype.subtype,
+      timestamps: timestamps as unknown as ScrubberIndex_TypeIndex["timestamps"],
+    });
+  });
+
+  const payload = Buffer.from(new ScrubberIndex({ id: scrubber.data.id, indices }).toBinary());
+  indexPayloadCache.set(scrubber, payload);
+  return payload;
 }
 
 const ScrubberPlaybackStateToEnum = {
@@ -67,6 +125,14 @@ export function synthesize(typeSubtype: NbsTypeSubtypeBuffer, scrubber: Scrubber
         timestamp,
         ...typeSubtype,
         payload: Buffer.from(scrubberState),
+      };
+    }
+
+    case "message.eye.ScrubberIndex": {
+      return {
+        timestamp,
+        ...typeSubtype,
+        payload: getIndexPayload(scrubber),
       };
     }
 

--- a/nusight2/src/server/nbs_scrubber/scrubber.ts
+++ b/nusight2/src/server/nbs_scrubber/scrubber.ts
@@ -44,7 +44,12 @@ export class Scrubber {
     // Create a decoder for the files and set the available types to what's
     // in the files and what we can synthesize
     this.decoder = new NbsDecoder(files);
-    this.availableTypes = [...this.decoder.getAvailableTypes(), ...availableSyntheticTypes()];
+    this.availableTypes = [
+      ...this.decoder.getAvailableTypes(),
+      // Present synthetic types per-scrubber, using the scrubber's id as the subtype so that
+      // clients can subscribe to a specific scrubber's synthetic messages (e.g. its index).
+      ...availableSyntheticTypes().map((type) => ({ ...type, subtype: opts.id })),
+    ];
 
     // Get the timestamp range and set our playback start in NBS time
     const timestampRange = this.decoder.getTimestampRange();
@@ -188,6 +193,15 @@ export class Scrubber {
     this.resetPlaybackStart(this.timestamp());
     this.data.playbackSpeed = speed;
   };
+
+  /** Get the raw bytes of the packet of the given type at the given index/offset in the scrubber's file(s) */
+  getPacketBytes(typeSubtype: NbsTypeSubtypeBuffer, offset: number): Uint8Array {
+    const packet = this.decoder.getPacketByIndex(offset, typeSubtype);
+    if (packet && packet.payload) {
+      return Uint8Array.from(packet.payload);
+    }
+    return new Uint8Array();
+  }
 
   /** Destroy the scrubber and prevent further interaction */
   destroy() {

--- a/nusight2/src/server/nbs_scrubber/scrubber_set.ts
+++ b/nusight2/src/server/nbs_scrubber/scrubber_set.ts
@@ -1,4 +1,4 @@
-import { NbsTimestamp } from "nbsdecoder.js";
+import { NbsTimestamp, NbsTypeSubtypeBuffer } from "nbsdecoder.js";
 
 import { NbsScrubber } from "../../shared/nbs_scrubber";
 import { hashType } from "../../shared/nuclearnet/hash_type";
@@ -7,7 +7,7 @@ import { Clock } from "../../shared/time/clock";
 import { parseEventString } from "../nuclearnet/parse_event_string";
 import { NodeSystemClock } from "../time/node_clock";
 
-import { isSynthesizable, synthesize } from "./packet_synthesis";
+import { isStaticSyntheticType, isSynthesizable, synthesize } from "./packet_synthesis";
 import { Scrubber } from "./scrubber";
 
 export type ScrubberUpdateOpts =
@@ -193,6 +193,15 @@ export class ScrubberSet {
     return this.scrubbers.get(id);
   }
 
+  /** Get the raw bytes of a packet from the scrubber with the given id */
+  getPacketBytes(id: NbsScrubber["id"], typeSubtype: NbsTypeSubtypeBuffer, offset: number) {
+    const scrubber = this.scrubbers.get(id);
+    if (!scrubber) {
+      throw new Error(`scrubber ${id} not found to get packet bytes`);
+    }
+    return scrubber.getPacketBytes(typeSubtype, offset);
+  }
+
   /** Load a new scrubber into the set, with the given NBS files and optional name */
   load(opts: { files: string[]; name?: string; onCreate?: (scrubber: Scrubber) => void }) {
     // Generate a unique ID and create the scrubber
@@ -292,6 +301,11 @@ export class ScrubberSet {
     for (const { listenersByScrubber } of this.callbacks.values()) {
       const listeners = listenersByScrubber.get(scrubber) ?? [];
       for (const listener of listeners) {
+        // Static synthetic types (like the index) don't change with the scrubber's
+        // state, so there's no need to re-emit them when the scrubber changes.
+        if (isStaticSyntheticType({ type: listener.type, subtype: listener.subtype })) {
+          continue;
+        }
         this.loadAndEmitToListener(listener, timestamp);
       }
     }
@@ -335,6 +349,12 @@ export class ScrubberSet {
 
       // Abort if the listener was removed while it was processing the packet
       if (listener.removed) {
+        return;
+      }
+
+      // Static synthetic types (like the scrubber index) are emitted once and do not change
+      // over time, so we don't re-arm the listener to re-emit them during playback.
+      if (typeIsSynthesizable && isStaticSyntheticType(typeSubtype)) {
         return;
       }
 


### PR DESCRIPTION
Ports the server side of the advanced scrubber that the client already expects but was never implemented, so the packet index actually loads and individual packets can be fetched. Fixes the advanced scrubber's packet timeline showing no data.

Targets `houliston/advanced-scrubber`.

## Problem

The advanced scrubber client (#1803) subscribes to a `ScrubberIndex` and requests packets via `ScrubberPacketRequest`, but the server never produced either — so the packet index never loaded and packet selection returned nothing. A subtype mismatch compounded it: the client subscribes to the index with `subtype: scrubber.id`, while the server's synthetic types used a hardcoded `subtype: 0`, so the listener never matched.

## What changed (server `nbs_scrubber`)

- **`packet_synthesis.ts`** — synthesize a `ScrubberIndex` built from the decoder's per-type timestamp index (`getAvailableTypes` + `getTypeIndex`, names via `messageHashToName`), cached per scrubber. Added `isStaticSyntheticType` to mark the index as emit-once.
- **`scrubber.ts`** — present synthetic types **per-scrubber using the scrubber id as the subtype** (the core fix), and add `getPacketBytes` (via `decoder.getPacketByIndex`).
- **`scrubber_set.ts`** — emit static synthetic types (the index) **once** instead of re-emitting during playback or on every seek/play/pause; add a `getPacketBytes` delegator.
- **`network.ts`** — handle the `ScrubberPacketRequest` RPC: read the requested packet by index and return its bytes.

Note: `ScrubberState` is unaffected — the main scrubber UI subscribes without a subtype, so it still matches.

## Verification
- `yarn tscheck` — 0 errors
- `yarn eslint` — clean
- `yarn vitest run` — 37 files / 273 tests passing
- Addresses the reported bug where the popped-out scrubber scrubs but the packet index never loads (server was never sending it). Runtime testing in dev recommended before merge.