### PR TITLE
Render advanced scrubber image preview with react-three-fiber

### DIFF
--- a/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/image.tsx
+++ b/nusight2/src/client/components/advanced_scrubber/packet_timeline/message/custom_formats/image.tsx
@@ -1,4 +1,8 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useState } from "react";
+import { Image, ImageFormat, jpegBufferToBitmap } from "@components/camera/image";
+import { ObjectFitContain } from "@components/three/object_fit";
+import { ImageView } from "@components/three/objects/image/image";
+import { ThreeFiber } from "@components/three/three_fiber";
 import { CompressedImage } from "@proto/message/output/CompressedImage";
 
 export interface CompressedImageViewProps {
@@ -6,43 +10,41 @@ export interface CompressedImageViewProps {
   children?: React.ReactNode;
 }
 
-/**
- * Renders a CompressedImage message as an image preview.
- *
- * Uses a canvas element with createImageBitmap for JPEG decoding.
- */
 export function CompressedImageView(props: CompressedImageViewProps) {
   const { msg, children } = props;
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [image, setImage] = useState<Image | null>(null);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas || !msg.data?.length) {
-      return;
-    }
-
-    const blob = new Blob([msg.data], { type: "image/jpeg" });
-    createImageBitmap(blob, { colorSpaceConversion: "none", premultiplyAlpha: "none" })
-      .then((bitmap) => {
-        const ctx = canvas.getContext("2d");
-        if (!ctx) return;
-        canvas.width = bitmap.width;
-        canvas.height = bitmap.height;
-        ctx.drawImage(bitmap, 0, 0);
+    let cancelled = false;
+    jpegBufferToBitmap(msg.data).then((bitmap) => {
+      if (cancelled) {
         bitmap.close();
-      })
-      .catch(() => {
-        // Non-JPEG formats are not decoded here; show nothing
+        return;
+      }
+      setImage({
+        type: "bitmap",
+        bitmap,
+        width: msg.dimensions?.x ?? 0,
+        height: msg.dimensions?.y ?? 0,
+        format: ImageFormat.JPEG,
       });
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [msg]);
 
   return (
     <>
-      <canvas
-        ref={canvasRef}
-        className="my-0.5 max-h-60 w-full object-contain bg-black"
-        style={{ imageRendering: "pixelated" }}
-      />
+      <div className="relative my-0.5 aspect-video max-h-60 w-full">
+        <ThreeFiber orthographic>
+          {image ? (
+            <ObjectFitContain width={image.width} height={image.height}>
+              <ImageView image={image} />
+            </ObjectFitContain>
+          ) : null}
+        </ThreeFiber>
+      </div>
       {children}
     </>
   );

--- a/nusight2/src/client/components/camera/image.ts
+++ b/nusight2/src/client/components/camera/image.ts
@@ -56,3 +56,8 @@ export type BayerImageFormat =
   | ImageFormat.PJGB
   | ImageFormat.PJBG
   | ImageFormat.JPGB;
+
+export async function jpegBufferToBitmap(buffer: Uint8Array): Promise<ImageBitmap> {
+  const blob = new Blob([buffer], { type: "image/jpeg" });
+  return createImageBitmap(blob, { colorSpaceConversion: "none", premultiplyAlpha: "none" });
+}

--- a/nusight2/src/client/components/three/object_fit.tsx
+++ b/nusight2/src/client/components/three/object_fit.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { useThree } from "@react-three/fiber";
+
+/**
+ * Component scales children so that an object with the given width and height is as large
+ * as possible while being contained by the canvas and maintaining its aspect ratio.
+ *
+ * Based on CSS 'object-fit' property.
+ */
+export function ObjectFitContain(props: { width: number; height: number; children: React.ReactNode }) {
+  const { width, height, children } = props;
+  const canvas = useThree((state) => state.size);
+
+  const objectAspectRatio = width / height;
+  const canvasAspectRatio = canvas.width / canvas.height;
+
+  // Depending on which has a wider aspect ratio, scale using the width ratio or height ratio
+  const scale = objectAspectRatio > canvasAspectRatio ? canvas.width / width : canvas.height / height;
+
+  return <group scale={scale}>{children}</group>;
+}

--- a/nusight2/src/client/components/three/objects/image/image.tsx
+++ b/nusight2/src/client/components/three/objects/image/image.tsx
@@ -71,7 +71,10 @@ export function useImageTexture(image: Image, opts?: { filtering?: THREE.Magnifi
     return texture;
   };
 
-  const update = (texture: THREE.Texture, [image, filtering]: [Image, THREE.MagnificationTextureFilter | undefined]) => {
+  const update = (
+    texture: THREE.Texture,
+    [image, filtering]: [Image, THREE.MagnificationTextureFilter | undefined],
+  ) => {
     // Close the previous bitmap to avoid GPU memory leaks
     if (texture.image instanceof ImageBitmap) {
       texture.image.close();
@@ -87,7 +90,10 @@ export function useImageTexture(image: Image, opts?: { filtering?: THREE.Magnifi
     texture.flipY = false;
   };
 
-  return useUpdatable(create, update, [image, opts?.filtering] as [Image, THREE.MagnificationTextureFilter | undefined]);
+  return useUpdatable(create, update, [image, opts?.filtering] as [
+    Image,
+    THREE.MagnificationTextureFilter | undefined,
+  ]);
 }
 
 /** Material for images with a non-bayer pixel format */

--- a/nusight2/src/client/components/three/objects/image/image.tsx
+++ b/nusight2/src/client/components/three/objects/image/image.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo } from "react";
+import { BayerImageFormat, Image, ImageFormat } from "@components/camera/image";
+import { ShaderUniform } from "@components/three/shader_uniform";
+import { useUpdatable } from "@hooks/use_updatable";
+import { UnreachableError } from "@shared/base/unreachable_error";
+import * as THREE from "three";
+
+import fragmentShader from "./shaders/bayer.frag";
+import vertexShader from "./shaders/bayer.vert";
+import { getFirstRed, getImageData, getMosaicSize, getTextureFormat } from "./utils";
+
+/**
+ * Renders an image.
+ *
+ * The center of the geometry is at (0, 0) and the width and height are those of the image's.
+ *
+ * Children of this component are transformed to be in the image's pixel coordinate
+ * space so that (0, 0) is at the top-left of the image and (image.width, image.height)
+ * is at the bottom right of the image.
+ */
+export function ImageView(props: { image: Image; visible?: boolean; children?: React.ReactNode }) {
+  const { image, visible = true, children } = props;
+  return (
+    // Transform to center the image and set the positive direction down
+    <group position={[-image.width / 2, image.height / 2, 0]} scale={[1, -1, 1]}>
+      <mesh visible={visible} frustumCulled={false}>
+        <ImageGeometry width={image.width} height={image.height} />
+        <ImageMaterial image={image} />
+      </mesh>
+      {children}
+    </group>
+  );
+}
+
+function ImageGeometry(props: { width: number; height: number }) {
+  const { width, height } = props;
+
+  // Build geometry such that the width and height equal the image dimensions and (0, 0) is the
+  // top-left corner of the geometry
+  const geometry = useMemo(() => {
+    // prettier-ignore
+    return {
+      vertices: [[0, 0, 0], [width, 0, 0], [width, height, 0], [0, height, 0]].flat(),
+      uv: [[0, 0], [1, 0], [1, 1], [0, 1]].flat(),
+      indices: [0, 1, 2, 0, 2, 3],
+    };
+  }, [width, height]);
+
+  return (
+    <bufferGeometry>
+      <float32BufferAttribute attach="attributes-position" args={[geometry.vertices, 3]} />
+      <float32BufferAttribute attach="attributes-uv" args={[geometry.uv, 2]} />
+      <uint16BufferAttribute attach="index" args={[geometry.indices, 1]} />
+    </bufferGeometry>
+  );
+}
+
+/** Get a texture that updates its properties each time the given image changes */
+export function useImageTexture(image: Image, opts?: { filtering?: THREE.MagnificationTextureFilter }) {
+  const create = ([image, filtering]: [Image, THREE.MagnificationTextureFilter | undefined]): THREE.Texture => {
+    const texture = new THREE.Texture();
+    texture.image = getImageData(image);
+    texture.format = getTextureFormat(image.format);
+    texture.generateMipmaps = false;
+    texture.format = THREE.RGBAFormat;
+    texture.type = THREE.UnsignedByteType;
+    texture.magFilter = filtering ?? THREE.NearestFilter;
+    texture.minFilter = filtering ?? THREE.NearestFilter;
+    texture.needsUpdate = true;
+    texture.flipY = false;
+    return texture;
+  };
+
+  const update = (texture: THREE.Texture, [image, filtering]: [Image, THREE.MagnificationTextureFilter | undefined]) => {
+    // Close the previous bitmap to avoid GPU memory leaks
+    if (texture.image instanceof ImageBitmap) {
+      texture.image.close();
+    }
+    texture.image = getImageData(image);
+    texture.format = getTextureFormat(image.format);
+    texture.generateMipmaps = false;
+    texture.format = THREE.RGBAFormat;
+    texture.type = THREE.UnsignedByteType;
+    texture.magFilter = filtering ?? THREE.NearestFilter;
+    texture.minFilter = filtering ?? THREE.NearestFilter;
+    texture.needsUpdate = true;
+    texture.flipY = false;
+  };
+
+  return useUpdatable(create, update, [image, opts?.filtering] as [Image, THREE.MagnificationTextureFilter | undefined]);
+}
+
+/** Material for images with a non-bayer pixel format */
+function BasicMaterial(props: { image: Image }) {
+  const { image } = props;
+  const texture = useImageTexture(image);
+
+  return <meshBasicMaterial map={texture} />;
+}
+
+/** Material for images with a bayer pixel format */
+function BayerMaterial(props: { image: Image; format: BayerImageFormat }) {
+  const { image, format } = props;
+  const texture = useImageTexture(image);
+
+  const { firstRed, mosaicSize } = useMemo(
+    () => ({ firstRed: getFirstRed(format), mosaicSize: getMosaicSize(format) }),
+    [format],
+  );
+
+  return (
+    <rawShaderMaterial vertexShader={vertexShader} fragmentShader={fragmentShader} transparent>
+      <ShaderUniform name="image" value={texture} />
+      <ShaderUniform name="sourceSize" value={[image.width, image.height, 1 / image.width, 1 / image.height]} />
+      <ShaderUniform name="firstRed" value={firstRed} />
+      <ShaderUniform name="mosaicSize" value={mosaicSize} />
+    </rawShaderMaterial>
+  );
+}
+
+function ImageMaterial(props: { image: Image }) {
+  const { image } = props;
+  switch (image.format) {
+    case ImageFormat.JPEG:
+    case ImageFormat.RGB8:
+    case ImageFormat.GREY:
+    case ImageFormat.GRAY:
+    case ImageFormat.Y8__:
+      // Use 'key' to force texture to be rebuilt when the width or height change.
+      // Three JS textures can't have their image be replaced by one with a higher
+      // resolution than the initial image.
+      return <BasicMaterial key={image.width + "," + image.height} image={image} />;
+    case ImageFormat.JPBG:
+    case ImageFormat.JPRG:
+    case ImageFormat.JPGR:
+    case ImageFormat.JPGB:
+    case ImageFormat.GRBG:
+    case ImageFormat.RGGB:
+    case ImageFormat.GBRG:
+    case ImageFormat.BGGR:
+    case ImageFormat.PJBG:
+    case ImageFormat.PJRG:
+    case ImageFormat.PJGR:
+    case ImageFormat.PJGB:
+      // Use 'key' to force texture to be rebuilt when the width or height change.
+      // Three JS textures can't have their image be replaced by one with a higher
+      // resolution than the initial image.
+      return <BayerMaterial key={image.width + "," + image.height} image={image} format={image.format} />;
+    default:
+      throw new UnreachableError(image.format);
+  }
+}

--- a/nusight2/src/client/components/three/objects/image/shaders/bayer.frag
+++ b/nusight2/src/client/components/three/objects/image/shaders/bayer.frag
@@ -1,0 +1,104 @@
+precision highp float;
+
+// Source: Efficient, High-Quality Bayer Demosaic Filtering on GPUs
+// Morgan McGuire, Williams College
+// Uses the Malvar-He-Cutler technique
+
+uniform sampler2D image;
+uniform vec4 sourceSize;
+uniform int mosaicSize;  // 1 (non-permutated bayer), 2 (perumutated bayer), or 4 (permutated polarised bayer)
+
+varying vec4 center;
+varying vec4 xCoord;
+varying vec4 yCoord;
+
+ivec2 mod(ivec2 a, int b) {
+    return ivec2(a.x - (int(a.x / b) * b), a.y - (int(a.y / b) * b));
+}
+
+float fetch(vec2 src_point) {
+    // Calculate the sub-image coordinates
+    ivec2 src  = ivec2(src_point * sourceSize.xy);
+    ivec2 dest = (src / ivec2(mosaicSize, mosaicSize))
+                 + mod(src, mosaicSize) * ivec2(ivec2(sourceSize.xy) / ivec2(mosaicSize, mosaicSize));
+    vec2 dest_point = (vec2(dest.x, dest.y) + 0.5) / sourceSize.xy;
+
+    return texture2D(image, dest_point).r;
+}
+
+void main(void) {
+    float C       = fetch(center.xy);  // ( 0, 0)
+    const vec4 kC = vec4(4.0, 6.0, 5.0, 5.0) / 8.0;
+
+    // Determine which of four types of pixels we are on.
+    vec2 alternate = mod(floor(center.zw), 2.0);
+
+    vec4 Dvec = vec4(fetch(vec2(xCoord.y, yCoord.y)),  // (-1,-1)
+                     fetch(vec2(xCoord.y, yCoord.z)),  // (-1, 1)
+                     fetch(vec2(xCoord.z, yCoord.y)),  // ( 1,-1)
+                     fetch(vec2(xCoord.z, yCoord.z))   // ( 1, 1)
+    );
+
+    vec4 PATTERN = (kC.xyz * C).xyzz;
+
+    // Can also be a dot product with (1,1,1,1) on hardware where that is
+    // specially optimized.
+    // Equivalent to: D = Dvec.x + Dvec.y + Dvec.z + Dvec.w;
+    Dvec.xy += Dvec.zw;
+    Dvec.x += Dvec.y;
+
+    vec4 value = vec4(fetch(vec2(center.x, yCoord.x)),  // ( 0,-2)
+                      fetch(vec2(center.x, yCoord.y)),  // ( 0,-1)
+                      fetch(vec2(xCoord.x, center.y)),  // ( 1, 0)
+                      fetch(vec2(xCoord.y, center.y))   // ( 2, 0)
+    );
+
+    vec4 temp = vec4(fetch(vec2(center.x, yCoord.w)),  // ( 0, 2)
+                     fetch(vec2(center.x, yCoord.z)),  // ( 0, 1)
+                     fetch(vec2(xCoord.w, center.y)),  // ( 2, 0)
+                     fetch(vec2(xCoord.z, center.y))   // ( 1, 0)
+    );
+
+    // Even the simplest compilers should be able to constant-fold these to avoid the division.
+    // Note that on scalar processors these constants force computation of some identical products twice.
+    const vec4 kA = vec4(-1.0, -1.5, 0.5, -1.0) / 8.0;
+    const vec4 kB = vec4(2.0, 0.0, 0.0, 4.0) / 8.0;
+    const vec4 kD = vec4(0.0, 2.0, -1.0, -1.0) / 8.0;
+
+// Conserve constant registers and take advantage of free swizzle on load
+#define kE (kA.xywz)
+#define kF (kB.xywz)
+
+    value += temp;
+
+    // There are five filter patterns (identity, cross, checker,
+    // theta, phi). Precompute the terms from all of them and then
+    // use swizzles to assign to color channels.
+    //
+    // Channel Matches
+    // x cross (e.g., EE G)
+    // y checker (e.g., EE B)
+    // z theta (e.g., EO R)
+    // w phi (e.g., EO R)
+
+#define A (value.x)
+#define B (value.y)
+#define D (Dvec.x)
+#define E (value.z)
+#define F (value.w)
+
+    // Avoid zero elements. On a scalar processor this saves two MADDs and it has no
+    // effect on a vector processor.
+    PATTERN.yzw += (kD.yz * D).xyy;
+
+    PATTERN += (kA.xyz * A).xyzx + (kE.xyw * E).xyxz;
+    PATTERN.xw += kB.xw * B;
+    PATTERN.xz += kF.xz * F;
+
+    gl_FragColor.rgb = (alternate.y == 0.0)
+                           ? ((alternate.x == 0.0) ? vec3(C, PATTERN.xy) : vec3(PATTERN.z, C, PATTERN.w))
+                           : ((alternate.x == 0.0) ? vec3(PATTERN.w, C, PATTERN.z) : vec3(PATTERN.yx, C));
+
+    // Set the alpha to 1.0, as chromium browsers are not rendering the image when the alpha is not set
+    gl_FragColor.a = 1.0;
+}

--- a/nusight2/src/client/components/three/objects/image/shaders/bayer.vert
+++ b/nusight2/src/client/components/three/objects/image/shaders/bayer.vert
@@ -1,0 +1,28 @@
+precision highp float;
+
+// Source: Efficient, High-Quality Bayer Demosaic Filtering on GPUs
+// Morgan McGuire, Williams College
+// Uses the Malvar-He-Cutler technique
+attribute vec3 position;
+attribute vec2 uv;
+
+uniform mat4 projectionMatrix;
+uniform mat4 modelViewMatrix;
+
+uniform vec4 sourceSize;
+uniform vec2 firstRed;
+
+varying vec4 center;
+varying vec4 xCoord;
+varying vec4 yCoord;
+
+void main() {
+    center.xy = uv;
+    center.zw = uv * sourceSize.xy + firstRed;
+
+    vec2 invSize = sourceSize.zw;
+    xCoord       = center.x + vec4(-2.0 * invSize.x, -invSize.x, invSize.x, 2.0 * invSize.x);
+    yCoord       = center.y + vec4(-2.0 * invSize.y, -invSize.y, invSize.y, 2.0 * invSize.y);
+
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}

--- a/nusight2/src/client/components/three/objects/image/utils.ts
+++ b/nusight2/src/client/components/three/objects/image/utils.ts
@@ -1,0 +1,86 @@
+import { BayerImageFormat, Image, ImageFormat } from "@components/camera/image";
+import { UnreachableError } from "@shared/base/unreachable_error";
+import * as THREE from "three";
+
+export function getImageData(image: Image) {
+  switch (image.type) {
+    case "bitmap":
+      return image.bitmap;
+    case "data":
+      return image.data;
+    case "element":
+      return image.element;
+  }
+}
+
+export function getTextureFormat(format: ImageFormat): THREE.PixelFormat {
+  switch (format) {
+    case ImageFormat.JPEG:
+    case ImageFormat.JPBG:
+    case ImageFormat.JPRG:
+    case ImageFormat.JPGR:
+    case ImageFormat.JPGB:
+    case ImageFormat.PJBG:
+    case ImageFormat.PJRG:
+    case ImageFormat.PJGR:
+    case ImageFormat.PJGB:
+      return THREE.RGBAFormat;
+    case ImageFormat.RGB8:
+      return THREE.RGBFormat;
+    case ImageFormat.GRBG:
+    case ImageFormat.RGGB:
+    case ImageFormat.GBRG:
+    case ImageFormat.BGGR:
+    case ImageFormat.GREY:
+    case ImageFormat.GRAY:
+    case ImageFormat.Y8__:
+      return THREE.LuminanceFormat;
+    default:
+      throw new UnreachableError(format);
+  }
+}
+
+export function getFirstRed(format: BayerImageFormat): [number, number] {
+  switch (format) {
+    case ImageFormat.JPBG:
+    case ImageFormat.BGGR:
+    case ImageFormat.PJBG:
+      return [1, 1];
+    case ImageFormat.JPGR:
+    case ImageFormat.GRBG:
+    case ImageFormat.PJGR:
+      return [1, 0];
+    case ImageFormat.JPGB:
+    case ImageFormat.GBRG:
+    case ImageFormat.PJGB:
+      return [0, 1];
+    case ImageFormat.JPRG:
+    case ImageFormat.RGGB:
+    case ImageFormat.PJRG:
+      return [0, 0];
+    default:
+      throw new UnreachableError(format);
+  }
+}
+
+export function getMosaicSize(format: BayerImageFormat): number {
+  switch (format) {
+    case ImageFormat.BGGR:
+    case ImageFormat.RGGB:
+    case ImageFormat.GRBG:
+    case ImageFormat.GBRG:
+      return 1; // One value per width/height
+    case ImageFormat.JPBG:
+    case ImageFormat.JPRG:
+    case ImageFormat.JPGR:
+    case ImageFormat.JPGB:
+      return 2; // Two values per width/height
+    case ImageFormat.PJBG:
+    case ImageFormat.PJRG:
+    case ImageFormat.PJGR:
+    case ImageFormat.PJGB:
+      return 4; // Four values per width/height
+    default:
+      throw new UnreachableError(format);
+  }
+}

--- a/nusight2/src/client/components/three/shader_uniform.tsx
+++ b/nusight2/src/client/components/three/shader_uniform.tsx
@@ -1,0 +1,13 @@
+import React, { useMemo } from "react";
+
+/** A uniform for a shader material */
+export function ShaderUniform(props: { name: string; value: any | any[] }) {
+  // If the value is an array, memoize to all its contents, otherwise memoize to the value itself
+  const deps = Array.isArray(props.value) ? props.value : [props.value];
+
+  // Memoize the value(s) to the uniform object
+  const obj = useMemo(() => ({ value: props.value }), deps);
+
+  // Attach the uniform object to the shader uniforms
+  return <primitive attach={"uniforms-" + props.name} object={obj} />;
+}


### PR DESCRIPTION
Replaces the plain-canvas JPEG-only image preview in the advanced scrubber packet inspector with a react-three-fiber ImageView, matching the r3f approach used elsewhere in NUsight and adding Bayer-format support. Targets `houliston/advanced-scrubber`.

## What changed
- `camera/image.ts` — add `jpegBufferToBitmap` helper.
- New reusable r3f helpers under `components/three/`: `shader_uniform.tsx`, `object_fit.tsx` (ObjectFitContain), and `objects/image/` (`ImageView` + utils + bayer shaders, reusing the existing image_view GLSL).
- `custom_formats/image.tsx` — render the compressed image via `ThreeFiber` + `ObjectFitContain` + `ImageView` instead of a bare canvas; closes the previous bitmap to avoid a GPU texture leak.

All generic three.js/r3f — no proprietary coupling.

## Verification
- `yarn tscheck` — 0 errors
- `yarn eslint` — clean
- `yarn vitest run` — 37 files / 273 tests passing
- `yarn vite build` — succeeds (GLSL shaders bundle correctly)