### PR TITLE
Use uncertainty measurements for localisation improvements

### DIFF
--- a/module/input/Camera/data/config/frankie/Cameras/Left.yaml
+++ b/module/input/Camera/data/config/frankie/Cameras/Left.yaml
@@ -28,6 +28,6 @@ urdf_path: "models/nugus/robot.urdf"
 
 is_left_camera: true
 
-roll_offset: 1.2174104888990922 * pi / 180
-pitch_offset: -3.218061822631629 * pi / 180
-yaw_offset: 0.5114542745949138 * pi / 180
+roll_offset: 0.030882856157919466 * pi / 180
+pitch_offset: -4.165875284170656 * pi / 180
+yaw_offset: 5.881565263237116 * pi / 180

--- a/module/localisation/FieldLocalisationNLopt/README.md
+++ b/module/localisation/FieldLocalisationNLopt/README.md
@@ -152,6 +152,30 @@ the half of the field the robot was last on during the grid-search fallback (and
 candidates in stage 1), avoiding the mirror field problem structurally. See "Mirror Symmetry Limitation" below
 for why this is a structural constraint rather than a per-frame evidence check.
 
+### Automatic Local-Minimum Escape
+
+The per-frame optimiser is local (seeded from the filter mean), so it re-converges to the same basin every
+frame. The cost landscape has many local minima from parallel-line aliasing: a pose offset that puts most
+observed line points near the *wrong* line still keeps validity above `validity.min_validity`, so the
+invalid-frames reset never triggers, and the filter keeps fusing the same self-consistent biased measurement.
+Symptoms: the estimated field keeps its shape but sits slightly offset from the true field, and a manual
+uncertainty reset instantly fixes it.
+
+The `recovery` block automates that manual reset. Per-frame validity is averaged over windows of
+`recovery.probe_period` frames; once per window the analytic candidate probe (stages 1-2 of the reset, no
+grid search - typically tens of milliseconds) is run unconditionally. The filter jumps to the best candidate
+only if it beats the window's mean validity by `recovery.improvement_margin` **and** lies within
+`window_size` (position + wrapped heading) of the current estimate. The locality gate keeps escapes local
+and rejects mirror flips, which are always at least pi away in heading.
+
+There is deliberately no "stuckness detection" (validity level or oscillation heuristics): the probe
+*compares* against the global candidate alternatives instead of trying to *detect* a bad fit. When
+well-localised, the best candidate refines to (approximately) the current pose, the improvement margin is
+never met, and the probe is a no-op - the margin acts as the sole jump decision. A stable local minimum
+often shows constant mediocre validity rather than oscillation, and validity naturally fluctuates with head
+pose and viewpoint on a well-localised robot, so neither level nor oscillation is a reliable trigger; a
+direct comparison is.
+
 ### Mirror Symmetry Limitation
 
 The field localisation cost function is **exactly invariant** under the mirror transform

--- a/module/localisation/FieldLocalisationNLopt/README.md
+++ b/module/localisation/FieldLocalisationNLopt/README.md
@@ -32,6 +32,14 @@ $$J_{\text{fi}} = \frac{w_{\text{fi}} \sum_{j=1}^{M} \left( \text{dist}(r_{\text
 
 $$J_{\text{sc}} = w_{\text{sc}} \|\textbf{x} - \textbf{x}\_{\text{init}}\|^2$$
 
+   - `state_change_weight` ($w_{\text{sc}}$) now defaults to `0.0`: temporal consistency is instead provided by
+     the probabilistic filter's covariance prior (see "Probabilistic Filter and Validity Gating" below). The
+     term is kept as an escape hatch for degenerate geometry (e.g. sliding along a single visible line) where
+     the filter's flat-direction covariance clamp isn't sufficient on its own. Critically, this term is only
+     ever added on top of `evaluate_cost`'s perception-only terms inside `run_field_line_optimisation` - the
+     Hessian and validity metric always call `evaluate_cost` directly and never see it, since it would inject
+     artificial curvature exactly in the directions the filter needs to identify as unobserved.
+
 ### Constraints
 
 The optimisation is subject to the following constraints:
@@ -68,21 +76,114 @@ Where:
 
 Optimisation is carried out using NLopt's COBYLA (Constrained Optimisation BY Linear Approximations) algorithm, respecting the constraints and bounds set on the changes allowed in the state to ensure plausible and robust field localisation.
 
-### Cost Threshold and Update Acceptance
+### Probabilistic Filter and Validity Gating
 
-The module uses a cost threshold (`cost_threshold`) to determine whether to accept optimisation results:
+The raw NLopt optimisation result is treated as a **measurement** of the (x, y, theta) state, fused into a
+hand-rolled 3-state Kalman filter (`localisation/PoseFilter.hpp`) rather than being smoothed directly with an
+exponential filter:
 
-- **Accepting Updates**: Optimisation results are only applied if their cost is below `cost_threshold`. This prevents poor localisations from corrupting the state estimate.
-- **Rejecting Updates**: When the cost exceeds the threshold, the optimisation result is rejected and the previous filtered state is maintained. A warning is logged and a counter is incremented.
-- **Triggering Resets**: If the cost exceeds the threshold for `max_over_cost` consecutive updates (and `reset_delay` has elapsed), an uncertainty reset is triggered.
+- **Process model**: the state parameterises `Hfw`, which is constant under perfect odometry, so the filter
+  uses an identity transition. The `predict` step instead grows the covariance in proportion to observed
+  odometry motion (`||delta translation|| + |delta yaw|` between consecutive `Sensors::Hrw`), scaled by
+  `kalman.process_noise`.
+- **Measurement covariance from curvature**: after each accepted optimisation, a central-difference Hessian of
+  the perception-only cost (`evaluate_cost`, field-line + intersection + goal-post terms, deliberately
+  excluding the state-change regulariser) is computed at the optimum (`finite_difference_hessian`,
+  `localisation/filter.cpp`). Its eigenvalues are mapped to per-direction measurement variances via
+  `covariance_from_hessian`: `R_i = clamp(kalman.measurement_scale / lambda_i, r_min, r_max)`, with
+  non-positive or near-singular curvature (an unobserved/unreliable direction, e.g. along a single visible
+  line) clamped to `r_max` rather than falling back to a fixed covariance for the whole update. This lets
+  degenerate geometry inflate uncertainty in just the unobserved direction instead of everywhere.
+- **Update**: the filter's Kalman gain fuses the measurement and its covariance into the state estimate; the
+  heading innovation is angle-wrapped (`utility::math::angle::signedDifference`) so it doesn't fight the +-pi
+  seam.
+- **Search box**: each frame's optimisation is seeded from the filter's mean and bounded by a box derived from
+  the filter's current uncertainty (`clamp(3*sigma, 0.1, change_limit)` per axis) rather than always using the
+  full `change_limit` - this tightens the search once the filter is confident and widens it again after a
+  period of poor observations.
 
-This mechanism provides robustness against temporary vision anomalies or ambiguous field features while maintaining accurate localisation when observations are reliable.
+Acceptance is gated on a **validity** metric (`compute_validity`) rather than raw cost, since cost magnitudes
+are not directly comparable across differing numbers/mixes of observations: validity is the fraction of
+field-line points registered within `validity.line_inlier_distance` of the field-line map, blended 50/50 with
+the fraction of field intersections successfully associated with a landmark (when intersections are observed;
+lines-only otherwise). Optimisation results with `validity >= validity.min_validity` are fused into the
+filter; results below threshold are rejected (the filter's predict step still ran, so uncertainty keeps
+growing) and a counter of consecutive invalid frames is incremented.
+
+The `field->cost` emitted in the `Field` message is **unchanged in meaning** - it is still the raw perception
+cost of the accepted/proposed hypothesis - specifically so that downstream consumers gating on
+`field.cost > max_localisation_cost` (`StrategiseLook`, `FieldPlayer`) continue to behave the same way; only
+the *internal* accept/reject decision moved from cost to validity. The emitted `field->covariance` and
+`field->uncertainty` (`trace(cov)`) are now populated from the filter for the first time; they were previously
+always zero.
+
+- **Triggering Resets**: If validity stays below `validity.min_validity` for more than
+  `validity.max_invalid_frames` consecutive updates (and `reset_delay` has elapsed since the last reset), an
+  uncertainty reset is triggered, replacing the old cost-threshold-based `reset_on_cost`/`max_over_cost`
+  mechanism.
 
 ### Reset
 
-A soft reset `ResetFieldLocalisation` is used when the robot is starting on the side of the field (or in a custom position specified in the configuration).
+A soft reset `ResetFieldLocalisation` is used when the robot is starting on the side of the field (or in a
+custom position specified in the configuration); this also resets the pose filter to `change_limit`
+uncertainty around the chosen initial hypothesis.
 
-A more extreme reset `UncertaintyResetFieldLocalisation` is used when the cost of the current field position is high during play and either a local search or field-wide search must be conducted to regain the position. The local search is a grid search using configurable parameters and uses the lowest cost position if it is under the configurable cost threshold. If this fails to find an appropriate position, a global grid search is conducted. This grid search occurs over the half of the field that the robot was last in, so as to ignore mirror states.
+A more extreme reset `UncertaintyResetFieldLocalisation` is used when validity has been too low for too long
+during play. This now runs a staged pipeline (`localisation/candidates.cpp`, `localisation/reset.cpp`):
+
+1. **Analytic candidates** (`reset.use_candidates`): generate one-shot candidate poses without any search -
+   `goal_pair_candidates` from the two observed goal posts (both assignment orders, both field ends, gated by
+   the expected goal-post distance), and `intersection_pair_candidates` (HTWK-style) from every pair of
+   observed field intersections matched against model landmark pairs of the same types and similar separation
+   (`reset.pair_separation_tolerance`). Mirror twins arise automatically from the symmetric landmark layout.
+   Candidates are deduplicated (within 0.3 m / 0.3 rad) and capped at `reset.max_candidates`, preferring
+   widely-separated generating pairs (better angular conditioning). `last_certain_state` is always included as
+   a candidate.
+2. **Short refine**: each candidate is refined with a short SBPLX optimisation and ranked by validity; the best
+   is accepted (and the filter hard-reset to it) if its validity clears `validity.min_validity`.
+3. **Grid-search fallback**: if no candidate is good enough (or candidate generation is disabled/empty), a
+   local-window grid search around `last_certain_state` is tried first, followed by a wider search if that
+   also fails, both now gated on validity instead of raw cost.
+4. On acceptance at any stage, `filter.reset(state, change_limit)` re-initialises the pose filter's mean and
+   covariance to the accepted candidate.
+
+`reset.constrain_to_half` (default `true`) preserves the original behaviour of only ever searching/considering
+the half of the field the robot was last on during the grid-search fallback (and never adding mirrored
+candidates in stage 1), avoiding the mirror field problem structurally. See "Mirror Symmetry Limitation" below
+for why this is a structural constraint rather than a per-frame evidence check.
+
+### Mirror Symmetry Limitation
+
+The field localisation cost function is **exactly invariant** under the mirror transform
+`(x, y, theta) -> (-x, -y, theta + pi)`: the field-line distance map, the typed landmark pairs used for
+intersection association, and the sign-selected goal-post term (`rGFf_left.x() > 0 ? own_goal_posts :
+opp_goal_posts`) are all symmetric about the field centre, so `cost(mirror(s)) === cost(s)` for every state
+`s`. The same is true of the validity metric, since it is built from the same distance map and association
+logic.
+
+**Consequence**: vision alone can never disambiguate which half of the field the robot is actually on - a
+per-frame "evidence ratio" comparing `cost(s)` against `cost(mirror(s))` would be identically 1 for every
+frame and is deliberately **not implemented**. Instead this module relies on structural mitigations:
+
+- `reset.constrain_to_half` (default `true`) never lets a reset search consider the wrong half of the field in
+  the first place.
+- When `reset.constrain_to_half` is `false`, mirror twins are allowed to compete during a reset, and ties are
+  broken explicitly by distance (position + wrapped angle) to `last_certain_state` - see
+  `is_mirror_twin`/`pose_distance` in `localisation/reset.cpp`.
+- The `PenaltyReset` handler logs a `WARN` ("Mirror flip detected via penalty reset") when the mirror image of
+  the current filter estimate is closer to the known penalty-kick position than the current estimate itself -
+  one of the few moments an external positional cue is available. `mirror.auto_flip` (default `false`) gates
+  whether this cue is acted on automatically (flipping the filter's mean) or only logged; it is an extension
+  point for future GameController-sourced evidence (e.g. kickoff/half-time side swaps), not wired up in this
+  change.
+
+### Deferred: Single-Intersection and Line-Direction Candidates
+
+`intersection_pair_candidates` requires *pairs* of observed intersections because a single intersection's
+position alone doesn't fix orientation - `message::vision::FieldIntersection` only carries `{type, rIWw}`, with
+no local line direction. Adding single-intersection candidates (matching one observed intersection plus its
+line direction against a single model landmark) would need a vision-message change to carry that direction,
+which is out of scope for this change. This is deferred alongside upcoming extrinsics/vision work.
 
 ## Usage
 

--- a/module/localisation/FieldLocalisationNLopt/data/config/FieldLocalisationNLopt.yaml
+++ b/module/localisation/FieldLocalisationNLopt/data/config/FieldLocalisationNLopt.yaml
@@ -31,14 +31,8 @@ use_hungarian: true
 # Cost for a point outside the field
 out_of_field_cost: 3.0
 
-# Reset localisation if the cost is above a threshold
-reset_on_cost: true
-# Cost threshold for the optimisation to trigger a reset
-cost_threshold: 2.0
 # Time (s) to wait before allowing a localisation reset again
 reset_delay: 3
-# Maximum number of times the cost can be over threshold before a reset is triggered
-max_over_cost: 100
 # Step size for localisation reset search (m)
 step_size: 0.25
 # Local search window size for localisation reset (m)
@@ -52,11 +46,13 @@ field_line_distance_weight: 1.0
 # Weighting associated with field intersection landmark error
 field_line_intersection_weight: 5.0
 
-# Weighting associated with change between last solution result
-state_change_weight: 2.0
+# Weighting associated with change between last solution result. Default 0.0: the Kalman filter's covariance
+# prior replaces this as the mechanism for temporal consistency; kept as an escape hatch for degenerate
+# geometry (e.g. sliding along a single visible line) where the flat-direction covariance clamp isn't enough.
+state_change_weight: 0.0
 
 # Minimum distance an associated landmark needs to be for measurement update
-max_association_distance: 1.0
+max_association_distance: 0.5
 
 # Weighting associated with goal post distance error
 goal_post_distance_weight: 1.0
@@ -85,8 +81,35 @@ uncertainty_opt: # Quicker optimisation, but less accurate.
   # Maximum number of evaluations for the optimisation
   maxeval: 100
 
-exponential_filter:
-  # Smoothing factor for exponential filter for each state component (0 < alpha <= 1)
-  # [x, y, theta] - Higher values = more responsive to new measurements
-  # Lower values = more smoothed/filtered output
-  alpha: [0.1, 0.1, 0.5]
+kalman:
+  # Process noise variance rate (x^2, y^2, theta^2) per unit odometry motion [m + rad], applied to the pose
+  # filter's covariance each frame, scaled by how much the robot moved since the last frame
+  process_noise: [0.01, 0.01, 0.005]
+  # Scalar mapping inverse Hessian curvature to measurement variance
+  measurement_scale: 1.0
+  # Finite-difference step for the Hessian [m, m, rad] (clamped to >= 2*grid_size in code)
+  hessian_step: [0.05, 0.05, 0.05]
+
+validity:
+  # Field-line point registered as an inlier below this map distance [m]
+  line_inlier_distance: 0.2
+  # Minimum matched-percept validity fraction to accept an optimisation result
+  min_validity: 0.5
+  # Maximum number of consecutive invalid frames before triggering an uncertainty reset
+  max_invalid_frames: 100
+  # Trigger an uncertainty reset after max_invalid_frames consecutive invalid frames
+  reset_on_invalid: true
+
+reset:
+  # Use analytic goal/intersection-pair candidates before falling back to grid search
+  use_candidates: true
+  # Tolerance [m] on pair separation when matching observed intersection pairs to landmark pairs
+  pair_separation_tolerance: 0.3
+  # Maximum number of reset candidates kept after deduplication
+  max_candidates: 30
+  # Constrain resets/searches to the robot's current half of the field (avoids the mirror field problem)
+  constrain_to_half: true
+
+mirror:
+  # Act automatically on detected mirror-flip cues (e.g. PenaltyReset); false = log a warning only
+  auto_flip: false

--- a/module/localisation/FieldLocalisationNLopt/data/config/FieldLocalisationNLopt.yaml
+++ b/module/localisation/FieldLocalisationNLopt/data/config/FieldLocalisationNLopt.yaml
@@ -94,7 +94,7 @@ validity:
   # Field-line point registered as an inlier below this map distance [m]
   line_inlier_distance: 0.2
   # Minimum matched-percept validity fraction to accept an optimisation result
-  min_validity: 0.5
+  min_validity: 0.67
   # Maximum number of consecutive invalid frames before triggering an uncertainty reset
   max_invalid_frames: 100
   # Trigger an uncertainty reset after max_invalid_frames consecutive invalid frames
@@ -113,3 +113,17 @@ reset:
 mirror:
   # Act automatically on detected mirror-flip cues (e.g. PenaltyReset); false = log a warning only
   auto_flip: false
+
+recovery:
+  # Continuously probe the analytic reset candidates to escape local minima of the cost function. The
+  # optimiser is local, so a slightly-offset pose that still explains most percepts is self-reinforcing;
+  # once per window this checks whether a decisively better nearby pose exists and jumps to it (equivalent
+  # to a manual uncertainty reset, but cheap: candidates only, no grid search). No stuckness detection is
+  # needed: when well-localised the best candidate matches the current pose and no jump occurs.
+  enabled: true
+  # Number of frames of validity averaged per probe window; the probe runs once per window
+  probe_period: 30
+  # A candidate must beat the window's mean validity by this margin to accept the escape. The escape must
+  # also be within window_size (position + wrapped heading) of the current estimate, which keeps it local
+  # and rejects mirror flips.
+  improvement_margin: 0.1

--- a/module/localisation/FieldLocalisationNLopt/data/config/webots/FieldLocalisationNLopt.yaml
+++ b/module/localisation/FieldLocalisationNLopt/data/config/webots/FieldLocalisationNLopt.yaml
@@ -1,82 +1,11 @@
 # Controls the minimum log level that NUClear log will display
 log_level: INFO
 
-# Size of each cell in the occupancy map, each cell has an area of grid_size x grid_size [metres]
-grid_size: 1e-2
-
-# Starting side of the field looking towards own goal from centre of field (LEFT, RIGHT, EITHER or CUSTOM)
-starting_side: EITHER
-
-# Our initial guess of where the robot starts on the field (Used if starting_side is selected as CUSTOM)
-initial_state: [0.0, 0.0, 0.0]
-
-# Bool to save a csv file of the generated occupancy grid map
-save_map: false
-
 # Minimum number of field line points for a measurement update
 min_field_line_points: 20
 
 # Minimum number of field line intersections for an update
 min_field_line_intersections: 3
 
-# Delay before the particle filter starts (allows odometry to settle)
-start_time_delay: 1
-
-# Bool to use ground truth for localisation
-use_ground_truth_localisation: false
-
-# Bool to use the Hungarian algorithm for data association
-use_hungarian: true
-
-# Cost for a point outside the field
-out_of_field_cost: 3.0
-
-# Reset localisation if the cost is above a threshold
-reset_on_cost: true
-# Cost threshold for the optimisation to trigger a reset
-cost_threshold: 2.0
-# Time (s) to wait before allowing a localisation reset again
-reset_delay: 3
-# Maximum number of times the cost can be over threshold before a reset is triggered
-max_over_cost: 100
-# Step size for localisation reset search (m)
-step_size: 0.25
-# Local search window size for localisation reset (m)
-window_size: 2.0
-# Number of angles to check during localisation reset search
-num_angles: 8
-
-# Weighting associated with field line distance error cost term
-field_line_distance_weight: 1.0
-
-# Weighting associated with field intersection landmark error
-field_line_intersection_weight: 5.0
-
-# Weighting associated with change between last solution result
-state_change_weight: 2.0
-
 # Minimum distance an associated landmark needs to be for measurement update
 max_association_distance: 2.0
-
-# Weighting associated with goal post distance error
-goal_post_distance_weight: 1.0
-
-# Box constraints on change in state (x, y, theta)
-change_limit: [0.5, 0.5, 0.5]
-
-# Goal post error tolerance [m]
-goal_post_error_tolerance: 0.5
-
-opt:
-  # Relative tolerance on the optimisation parameters
-  xtol_rel: 1e-6
-  # Relative tolerance on the optimisation function value
-  ftol_rel: 1e-6
-  # Maximum number of evaluations for the optimisation
-  maxeval: 1000
-
-exponential_filter:
-  # Smoothing factor for exponential filter for each state component (0 < alpha <= 1)
-  # [x, y, theta] - Higher values = more responsive to new measurements
-  # Lower values = more smoothed/filtered output
-  alpha: [0.1, 0.1, 0.5]

--- a/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
@@ -26,6 +26,7 @@
  */
 #include "FieldLocalisationNLopt.hpp"
 
+#include <algorithm>
 #include <fstream>
 
 #include "extension/Configuration.hpp"
@@ -71,14 +72,11 @@ namespace module::localisation {
             cfg.use_hungarian                 = config["use_hungarian"].as<bool>();
             cfg.out_of_field_cost             = config["out_of_field_cost"].as<double>();
 
-            // Uncertainty reset parameters
-            cfg.reset_on_cost  = config["reset_on_cost"].as<bool>();
-            cfg.cost_threshold = config["cost_threshold"].as<double>();
-            cfg.reset_delay    = config["reset_delay"].as<int>();
-            cfg.max_over_cost  = config["max_over_cost"].as<int>();
-            cfg.step_size      = config["step_size"].as<double>();
-            cfg.window_size    = config["window_size"].as<double>();
-            cfg.num_angles     = config["num_angles"].as<int>();
+            // Uncertainty reset parameters (grid-search fallback)
+            cfg.reset_delay = config["reset_delay"].as<int>();
+            cfg.step_size   = config["step_size"].as<double>();
+            cfg.window_size = config["window_size"].as<double>();
+            cfg.num_angles  = config["num_angles"].as<int>();
 
             // Field line optimisation parameters
             cfg.field_line_distance_weight = config["field_line_distance_weight"].as<double>();
@@ -125,8 +123,25 @@ namespace module::localisation {
                           "', using default");
             }
 
-            // Exponential filter parameters
-            cfg.alpha = Eigen::Vector3d(config["exponential_filter"]["alpha"].as<Expression>());
+            // Kalman filter tuning
+            cfg.kalman_process_noise     = Eigen::Vector3d(config["kalman"]["process_noise"].as<Expression>());
+            cfg.kalman_measurement_scale = config["kalman"]["measurement_scale"].as<double>();
+            cfg.kalman_hessian_step      = Eigen::Vector3d(config["kalman"]["hessian_step"].as<Expression>());
+
+            // Validity-gated acceptance
+            cfg.validity_line_inlier_distance = config["validity"]["line_inlier_distance"].as<double>();
+            cfg.validity_min_validity         = config["validity"]["min_validity"].as<double>();
+            cfg.validity_max_invalid_frames   = config["validity"]["max_invalid_frames"].as<int>();
+            cfg.validity_reset_on_invalid     = config["validity"]["reset_on_invalid"].as<bool>();
+
+            // Reset candidate generation
+            cfg.reset_use_candidates            = config["reset"]["use_candidates"].as<bool>();
+            cfg.reset_pair_separation_tolerance = config["reset"]["pair_separation_tolerance"].as<double>();
+            cfg.reset_max_candidates            = config["reset"]["max_candidates"].as<int>();
+            cfg.reset_constrain_to_half         = config["reset"]["constrain_to_half"].as<bool>();
+
+            // Mirror hygiene
+            cfg.mirror_auto_flip = config["mirror"]["auto_flip"].as<bool>();
         });
 
         on<Startup, Trigger<FieldDescription>>().then("Update Field Line Map", [this](const FieldDescription& fd) {
@@ -184,26 +199,47 @@ namespace module::localisation {
                 default: log<ERROR>("Invalid starting_side specified"); break;
             }
             state = cfg.initial_hypotheses[0];
+            filter.reset(state, cfg.change_limit);
             emit<Scope::DELAY>(std::make_unique<ResetFieldLocalisation>(), cfg.start_time_delay);
             emit(std::make_unique<Stability>(Stability::UNKNOWN));
         });
 
         on<Trigger<ResetFieldLocalisation>>().then([this] {
             log<INFO>("Resetting field localisation");
-            state             = cfg.initial_hypotheses[0];
-            filtered_state    = state;
-            first_measurement = true;
-            startup           = true;
-            last_reset        = NUClear::clock::now();
+            state = cfg.initial_hypotheses[0];
+            filter.reset(state, cfg.change_limit);
+            startup        = true;
+            last_reset     = NUClear::clock::now();
+            last_Hrw_valid = false;  // Motion delta across a hard reset is not meaningful
         });
 
         on<Trigger<PenaltyReset>>().then([this](const PenaltyReset& reset) {
             log<INFO>("Resetting field localisation for penalty kick");
-            state              = reset.penalty_kick_position;
-            filtered_state     = state;
-            first_measurement  = true;
-            last_reset         = NUClear::clock::now();
-            last_certain_state = state;  // Update the last certain state
+            Eigen::Vector3d penalty_state = reset.penalty_kick_position;
+
+            // Mirror-flip detection: PenaltyReset is one of the few moments we get an external positional cue,
+            // so use it to check whether our current estimate has likely flipped to the wrong half of the
+            // field. This is a structural check only (see README for why a per-frame vision-based evidence
+            // ratio is not implemented: the cost function is exactly mirror-symmetric).
+            Eigen::Vector3d mirrored          = mirror_pose(filter.mean);
+            double current_distance_to_reset  = (filter.mean.head<2>() - penalty_state.head<2>()).norm();
+            double mirrored_distance_to_reset = (mirrored.head<2>() - penalty_state.head<2>()).norm();
+            if (mirrored_distance_to_reset < current_distance_to_reset) {
+                log<WARN>("Mirror flip detected via penalty reset (current estimate ",
+                          current_distance_to_reset,
+                          "m from penalty position, mirrored estimate ",
+                          mirrored_distance_to_reset,
+                          "m)");
+                if (cfg.mirror_auto_flip) {
+                    filter.mean = mirrored;
+                }
+            }
+
+            state = penalty_state;
+            filter.reset(state, cfg.change_limit);
+            last_reset          = NUClear::clock::now();
+            last_certain_state  = state;  // Update the last certain state
+            last_Hrw_valid      = false;
         });
 
         on<Trigger<FieldLines>,
@@ -250,6 +286,21 @@ namespace module::localisation {
                         return;
                     }
 
+                    // Predict step: grow the filter's covariance in proportion to the odometry motion since the
+                    // last frame. The state (x,y,theta) parameterises Hfw, which is constant under perfect
+                    // odometry, so there is no motion model beyond this noise injection.
+                    double motion = 0.0;
+                    if (last_Hrw_valid) {
+                        Eigen::Isometry3d delta_Hrw = sensors.Hrw * last_Hrw.inverse();
+                        double dtranslation         = delta_Hrw.translation().head<2>().norm();
+                        double dyaw = std::abs(
+                            utility::math::angle::normalise_angle(mat_to_rpy_intrinsic(delta_Hrw.rotation()).z()));
+                        motion = dtranslation + dyaw;
+                    }
+                    filter.predict(motion, cfg.kalman_process_noise);
+                    last_Hrw       = sensors.Hrw;
+                    last_Hrw_valid = true;
+
                     double chosen_state_cost = 0.0;
                     Eigen::Vector3d proposed_state;
 
@@ -270,58 +321,78 @@ namespace module::localisation {
                         // For startup, always accept the best hypothesis
                         state              = proposed_state;
                         last_certain_state = state;
-                        filtered_state     = state;
-                        first_measurement  = true;
-                        startup            = false;
+                        filter.reset(state, cfg.change_limit);
+                        startup = false;
                     }
                     else {
-                        // Run the optimisation routine
-                        std::pair<Eigen::Vector3d, double> opt_results =
-                            run_field_line_optimisation(filtered_state, field_lines.rPWw, field_intersections, goals);
+                        // Size the search box from the filter's current uncertainty: 3-sigma of (cov + a
+                        // nominal representative measurement covariance), clamped per axis to
+                        // [0.1, change_limit]. This box only bounds *this* optimisation call; the actual
+                        // measurement covariance used for the filter update below is derived from this
+                        // frame's Hessian, not this nominal value.
+                        Eigen::Matrix3d nominal_R_for_bounds = Eigen::Matrix3d::Identity() * cfg.kalman_measurement_scale;
+                        Eigen::Vector3d sigma3 = 3.0 * (filter.cov + nominal_R_for_bounds).diagonal().cwiseSqrt();
+                        Eigen::Vector3d box;
+                        for (int i = 0; i < 3; ++i) {
+                            box(i) = std::clamp(sigma3(i), 0.1, cfg.change_limit(i));
+                        }
+
+                        // Run the optimisation routine, seeded from the filter's current mean
+                        std::pair<Eigen::Vector3d, double> opt_results = run_field_line_optimisation(filter.mean,
+                                                                                                      field_lines.rPWw,
+                                                                                                      field_intersections,
+                                                                                                      goals,
+                                                                                                      false,
+                                                                                                      box);
                         proposed_state    = opt_results.first;
                         chosen_state_cost = opt_results.second;
 
-                        // Only accept the optimisation result if the cost is below the threshold
-                        if (chosen_state_cost < cfg.cost_threshold) {
+                        // Gate acceptance on the matched-percept validity fraction, not raw cost, since cost
+                        // magnitudes are not directly comparable across differing numbers/mixes of
+                        // observations.
+                        double validity = compute_validity(proposed_state, field_lines.rPWw, field_intersections);
+                        emit(graph("Validity", validity));
+
+                        if (validity >= cfg.validity_min_validity) {
                             state = proposed_state;
 
-                            // Apply exponential filter to smooth the state estimate unless it is the first measurement.
-                            filtered_state =
-                                first_measurement
-                                    ? state
-                                    : cfg.alpha.cwiseProduct(state)
-                                          + (Eigen::Vector3d::Ones() - cfg.alpha).cwiseProduct(filtered_state);
+                            // Derive a measurement covariance from the curvature of the cost function at the
+                            // optimum, and fuse it into the filter.
+                            Eigen::Vector3d h = cfg.kalman_hessian_step.cwiseMax(2.0 * cfg.grid_size);
+                            Eigen::Matrix3d H =
+                                finite_difference_hessian(proposed_state, field_lines.rPWw, field_intersections, goals, h);
+                            double r_max = cfg.change_limit.squaredNorm();
+                            double r_min = std::pow(2.0 * cfg.grid_size, 2);
+                            Eigen::Matrix3d R =
+                                covariance_from_hessian(H, cfg.kalman_measurement_scale, r_min, r_max);
 
-                            // Reset the flag.
-                            first_measurement = false;
+                            filter.update(proposed_state, R);
 
                             // Update the last certain state and reset counter
-                            last_certain_state = filtered_state;
-                            num_over_cost      = 0;
+                            last_certain_state = filter.mean;
+                            num_invalid_frames = 0;
                         }
                         else {
-                            // Reject the update, keep previous filtered state
-                            log<DEBUG>("Rejecting optimisation result: cost ",
-                                       chosen_state_cost,
-                                       " exceeds threshold ",
-                                       cfg.cost_threshold);
-                            // Keep the current filtered_state unchanged
-                            // Increment the over-cost counter for potential reset
-                            num_over_cost++;
+                            // Reject the update, keep the current filter estimate (predict step already ran)
+                            log<DEBUG>("Rejecting optimisation result: validity ",
+                                       validity,
+                                       " below threshold ",
+                                       cfg.validity_min_validity);
+                            num_invalid_frames++;
                         }
                     }
 
                     // Check if uncertainty is too high and trigger reset if needed
                     emit(graph("Cost", chosen_state_cost));
-                    if (cfg.reset_on_cost && (num_over_cost > cfg.max_over_cost)
+                    if (cfg.validity_reset_on_invalid && (num_invalid_frames > cfg.validity_max_invalid_frames)
                         && ((NUClear::clock::now() - last_reset) > std::chrono::seconds(cfg.reset_delay))) {
-                        // Cost has been high too many times, reset the localisation
-                        log<WARN>("Cost exceeded threshold ",
-                                  cfg.max_over_cost,
+                        // Validity has been below threshold too many times, reset the localisation
+                        log<WARN>("Validity below threshold ",
+                                  cfg.validity_max_invalid_frames,
                                   " times, triggering uncertainty reset");
                         // Emit that we are resetting, eg for behaviour
                         emit(std::make_unique<UncertaintyResetFieldLocalisation>());
-                        // Reset localisation by finding a new low cost state
+                        // Reset localisation by finding a new valid state
                         const auto reset_start = NUClear::clock::now();
                         uncertainty_reset(fd, field_lines, field_intersections, goals, sensors.Hrw);
                         const auto reset_end = NUClear::clock::now();
@@ -329,15 +400,15 @@ namespace module::localisation {
                             std::chrono::duration_cast<std::chrono::duration<double>>(reset_end - reset_start);
                         log<DEBUG>("Uncertainty reset duration (s): ", reset_duration.count());
                         // Reset variables
-                        num_over_cost = 0;
-                        last_reset    = NUClear::clock::now();
+                        num_invalid_frames = 0;
+                        last_reset          = NUClear::clock::now();
                         // Let other modules know that localisation has finished resetting
                         emit<Scope::DELAY>(std::make_unique<FinishReset>(), std::chrono::seconds(1));
                     }
 
                     // Emit the field message
                     auto field = std::make_unique<Field>();
-                    field->Hfw = compute_Hfw(filtered_state);
+                    field->Hfw = compute_Hfw(filter.mean);
 
                     // Debugging
                     if (log_level <= DEBUG) {
@@ -350,7 +421,9 @@ namespace module::localisation {
                     }
 
                     // Add cost, covariance, and uncertainty to the field message
-                    field->cost = chosen_state_cost;
+                    field->cost        = chosen_state_cost;
+                    field->covariance  = filter.cov;
+                    field->uncertainty = filter.cov.trace();
 
                     emit(field);
                 });
@@ -358,7 +431,7 @@ namespace module::localisation {
 
     void FieldLocalisationNLopt::debug_field_localisation(Eigen::Isometry3d Hfw) {
         emit(graph("opt state", state.x(), state.y(), state.z()));
-        emit(graph("filtered state", filtered_state.x(), filtered_state.y(), filtered_state.z()));
+        emit(graph("filtered state", filter.mean.x(), filter.mean.y(), filter.mean.z()));
         // Determine translational distance error
         Eigen::Vector3d true_rFWw  = ground_truth_Hfw.translation();
         Eigen::Vector3d rFWw       = (Hfw.translation());
@@ -407,77 +480,85 @@ namespace module::localisation {
                                  : greedy_association(field_intersections, Hfw);
     }
 
+    double FieldLocalisationNLopt::evaluate_cost(const Eigen::Vector3d& x,
+                                                 const std::vector<Eigen::Vector3d>& field_lines,
+                                                 const std::shared_ptr<const FieldIntersections>& field_intersections,
+                                                 const std::shared_ptr<const Goals>& goals) {
+        // --- Field line point cost ---
+        double cost = 0.0;
+        for (auto rORr : field_lines) {
+            // Get the position [x, y] of the observation in the map for this particle
+            Eigen::Vector2i map_position = position_in_map(x, rORr);
+            double occupancy_value = fieldline_distance_map.get_occupancy_value(map_position.x(), map_position.y());
+            occupancy_value =
+                occupancy_value == -1 ? cfg.out_of_field_cost : occupancy_value;  // If no value, set to 3.0
+            cost += cfg.field_line_distance_weight * std::pow(occupancy_value, 2);
+        }
+        // Average the cost by the number of field lines
+        cost /= field_lines.size() > 0 ? field_lines.size() : 1;
+
+        // Compute the cost and gradient
+        auto Hfw = compute_Hfw(x);
+
+        // --- Field line intersection cost ---
+        if (field_intersections) {
+            auto associations = data_association(field_intersections, Hfw);
+            for (const auto& association : associations) {
+                // Calculate the distance between the observed intersection and the closest landmark
+                double distance = (association.first - association.second).norm();
+                cost += cfg.field_line_intersection_weight * std::pow(distance, 2);
+            }
+            // Average the cost by the number of associations
+            cost /= associations.size() > 0 ? associations.size() : 1;
+        }
+
+        // --- Goal post cost ---
+        // Only consider goal post cost if there are two goals
+        if (goals && goals->goals.size() == 2) {
+            // Ensure the goal posts are roughly correct distance apart
+            auto Hwc              = Eigen::Isometry3d(goals->Hcw).inverse();
+            auto rGWw_1           = Hwc * (goals->goals[0].post.bottom * goals->goals[0].post.distance);
+            auto rGWw_2           = Hwc * (goals->goals[1].post.bottom * goals->goals[1].post.distance);
+            double distance_apart = (rGWw_1 - rGWw_2).norm();
+            if (std::abs(distance_apart - expected_goal_post_distance) < cfg.goal_post_error_tolerance) {
+
+                auto rGFf_left  = Hfw * rGWw_1;
+                auto rGFf_right = Hfw * rGWw_2;
+                if (rGFf_left.y() < rGFf_right.y()) {
+                    std::swap(rGFf_left, rGFf_right);
+                }
+                auto expected_goal_post_postions = rGFf_left.x() > 0 ? own_goal_posts : opp_goal_posts;
+
+                // Calculate the distance between the goal posts
+                double left_distance  = (rGFf_left - expected_goal_post_postions.left).norm();
+                double right_distance = (rGFf_right - expected_goal_post_postions.right).norm();
+
+                // Add the cost of the distance between the goal posts
+                cost += cfg.goal_post_distance_weight * std::pow(left_distance, 2);
+                cost += cfg.goal_post_distance_weight * std::pow(right_distance, 2);
+            }
+        }
+
+        return cost;
+    }
+
     std::pair<Eigen::Vector3d, double> FieldLocalisationNLopt::run_field_line_optimisation(
         const Eigen::Vector3d& initial_guess,
         const std::vector<Eigen::Vector3d>& field_lines,
         const std::shared_ptr<const FieldIntersections>& field_intersections,
         const std::shared_ptr<const Goals>& goals,
-        bool uncertainty_optimisation) {
-        // Wrap the objective function in a lambda function
+        bool uncertainty_optimisation,
+        const Eigen::Vector3d& box_bounds) {
+        // Wrap the objective function in a lambda function. The state-change regulariser is added here, on
+        // top of the perception-only evaluate_cost, so that the Hessian and validity metric (which both call
+        // evaluate_cost directly) never see the artificial curvature it would inject in otherwise-unobservable
+        // directions.
         ObjectiveFunction<double, 3> obj_fun =
             [&](const Eigen::Matrix<double, 3, 1>& x, Eigen::Matrix<double, 3, 1>& grad, void* data) -> double {
             (void) data;  // Unused in this case
             (void) grad;  // Unused in this case
-
-            // --- Field line point cost ---
-            double cost = 0.0;
-            for (auto rORr : field_lines) {
-                // Get the position [x, y] of the observation in the map for this particle
-                Eigen::Vector2i map_position = position_in_map(x, rORr);
-                double occupancy_value = fieldline_distance_map.get_occupancy_value(map_position.x(), map_position.y());
-                occupancy_value =
-                    occupancy_value == -1 ? cfg.out_of_field_cost : occupancy_value;  // If no value, set to 3.0
-                cost += cfg.field_line_distance_weight * std::pow(occupancy_value, 2);
-            }
-            // Average the cost by the number of field lines
-            cost /= field_lines.size() > 0 ? field_lines.size() : 1;
-
-            // Compute the cost and gradient
-            auto Hfw = compute_Hfw(x);
-
-            // --- Field line intersection cost ---
-            if (field_intersections) {
-                auto associations = data_association(field_intersections, Hfw);
-                for (const auto& association : associations) {
-                    // Calculate the distance between the observed intersection and the closest landmark
-                    double distance = (association.first - association.second).norm();
-                    cost += cfg.field_line_intersection_weight * std::pow(distance, 2);
-                }
-                // Average the cost by the number of associations
-                cost /= associations.size() > 0 ? associations.size() : 1;
-            }
-
-            // --- Goal post cost ---
-            // Only consider goal post cost if there are two goals
-            if (goals && goals->goals.size() == 2) {
-                // Ensure the goal posts are roughly correct distance apart
-                auto Hwc              = Eigen::Isometry3d(goals->Hcw).inverse();
-                auto rGWw_1           = Hwc * (goals->goals[0].post.bottom * goals->goals[0].post.distance);
-                auto rGWw_2           = Hwc * (goals->goals[1].post.bottom * goals->goals[1].post.distance);
-                double distance_apart = (rGWw_1 - rGWw_2).norm();
-                if (std::abs(distance_apart - expected_goal_post_distance) < cfg.goal_post_error_tolerance) {
-
-                    auto rGFf_left  = Hfw * rGWw_1;
-                    auto rGFf_right = Hfw * rGWw_2;
-                    if (rGFf_left.y() < rGFf_right.y()) {
-                        std::swap(rGFf_left, rGFf_right);
-                    }
-                    auto expected_goal_post_postions = rGFf_left.x() > 0 ? own_goal_posts : opp_goal_posts;
-
-                    // Calculate the distance between the goal posts
-                    double left_distance  = (rGFf_left - expected_goal_post_postions.left).norm();
-                    double right_distance = (rGFf_right - expected_goal_post_postions.right).norm();
-
-                    // Add the cost of the distance between the goal posts
-                    cost += cfg.goal_post_distance_weight * std::pow(left_distance, 2);
-                    cost += cfg.goal_post_distance_weight * std::pow(right_distance, 2);
-                }
-            }
-
-            // --- State change cost ---
-            cost += cfg.state_change_weight * (x - initial_guess).squaredNorm();
-
-            return cost;
+            return evaluate_cost(x, field_lines, field_intersections, goals)
+                   + cfg.state_change_weight * (x - initial_guess).squaredNorm();
         };
         // Create the NLopt optimizer and setup the algorithm, tolerances and maximum number of evaluations
         constexpr unsigned int n   = 3;
@@ -498,9 +579,12 @@ namespace module::localisation {
         // Set the objective function
         opt.set_min_objective(eigen_objective_wrapper<double, n>, &obj_fun);
 
-        // Define the upper and lower bounds for the change in state
-        Eigen::Vector3d lower_bounds = initial_guess - cfg.change_limit;
-        Eigen::Vector3d upper_bounds = initial_guess + cfg.change_limit;
+        // Define the upper and lower bounds for the change in state. A zero box_bounds is the sentinel for
+        // "use the configured change_limit" (the common case); callers with a covariance-derived box (see the
+        // main loop) pass a non-zero per-axis bound instead.
+        const Eigen::Vector3d& bounds = box_bounds.isZero() ? cfg.change_limit : box_bounds;
+        Eigen::Vector3d lower_bounds  = initial_guess - bounds;
+        Eigen::Vector3d upper_bounds  = initial_guess + bounds;
 
         // Convert bounds to std::vector for NLopt
         std::vector<double> lb(n), ub(n);

--- a/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.cpp
@@ -142,6 +142,11 @@ namespace module::localisation {
 
             // Mirror hygiene
             cfg.mirror_auto_flip = config["mirror"]["auto_flip"].as<bool>();
+
+            // Automatic local-minimum escape
+            cfg.recovery_enabled            = config["recovery"]["enabled"].as<bool>();
+            cfg.recovery_probe_period       = config["recovery"]["probe_period"].as<int>();
+            cfg.recovery_improvement_margin = config["recovery"]["improvement_margin"].as<double>();
         });
 
         on<Startup, Trigger<FieldDescription>>().then("Update Field Line Map", [this](const FieldDescription& fd) {
@@ -379,6 +384,26 @@ namespace module::localisation {
                                        " below threshold ",
                                        cfg.validity_min_validity);
                             num_invalid_frames++;
+                        }
+
+                        // Automatic local-minimum escape: the optimiser is local and re-converges to the same
+                        // basin every frame, and a biased pose can keep validity above the accept threshold
+                        // indefinitely (most points still land near *some* line). Once per window, probe the
+                        // analytic reset candidates (global, association-free) unconditionally and jump only
+                        // if one is decisively better and nearby. No stuckness detection is needed: when
+                        // well-localised the best candidate matches the current pose and the improvement
+                        // margin is never met, so the probe is a no-op.
+                        recovery_validity_sum += validity;
+                        recovery_frame_count++;
+                        if (cfg.recovery_enabled && recovery_frame_count >= cfg.recovery_probe_period) {
+                            const double mean_validity = recovery_validity_sum / recovery_frame_count;
+                            recovery_validity_sum      = 0.0;
+                            recovery_frame_count       = 0;
+                            if ((NUClear::clock::now() - last_reset) > std::chrono::seconds(cfg.reset_delay)
+                                && try_local_minimum_escape(field_lines, field_intersections, goals, mean_validity)) {
+                                num_invalid_frames = 0;
+                                last_reset         = NUClear::clock::now();
+                            }
                         }
                     }
 

--- a/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.hpp
+++ b/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.hpp
@@ -39,8 +39,11 @@
 #include "message/vision/FieldLines.hpp"
 #include "message/vision/Goal.hpp"
 
+#include "localisation/PoseFilter.hpp"
+
 #include "utility/localisation/FieldLineOccupanyMap.hpp"
 #include "utility/localisation/OccupancyMap.hpp"
+#include "utility/math/angle.hpp"
 #include "utility/nusight/NUhelpers.hpp"
 #include "utility/support/yaml_expression.hpp"
 
@@ -178,6 +181,30 @@ namespace module::localisation {
         Eigen::Vector3d right;
     };
 
+    /**
+     * @brief Compute the rigid 2D transform (x, y, theta) that maps an observed world-space point pair
+     * (p1w, p2w) onto a model field-space point pair (q1f, q2f). Pure geometry, used to turn a matched pair
+     * of landmarks/observations directly into a candidate pose without any search.
+     * @param p1w First observed point in world space (x, y)
+     * @param p2w Second observed point in world space (x, y)
+     * @param q1f Field-space model point corresponding to p1w
+     * @param q2f Field-space model point corresponding to p2w
+     * @return The candidate state (x, y, theta) of Hfw
+     */
+    Eigen::Vector3d pose_from_point_pair(const Eigen::Vector2d& p1w,
+                                         const Eigen::Vector2d& p2w,
+                                         const Eigen::Vector2d& q1f,
+                                         const Eigen::Vector2d& q2f);
+
+    /**
+     * @brief Mirror a state across the field's central symmetry: (x,y,theta) -> (-x,-y,theta+pi). The field
+     * localisation cost function is exactly invariant under this transform (see README), so mirrored states
+     * are indistinguishable from vision alone and must be disambiguated structurally.
+     * @param s The state to mirror
+     * @return The mirrored state
+     */
+    Eigen::Vector3d mirror_pose(const Eigen::Vector3d& s);
+
     class FieldLocalisationNLopt : public NUClear::Reactor {
     private:
         // Define the model dimensions
@@ -263,14 +290,8 @@ namespace module::localisation {
             /// @brief Cost for a point being outside of the field
             double out_of_field_cost = 0.0;
 
-            /// @brief When this is enabled, the field localisation will reset if the cost is too high
-            bool reset_on_cost = false;
-            /// @brief Cost threshold for resetting the filter
-            double cost_threshold = 0.0;
             /// @brief Reset delay in seconds
             int reset_delay = 0;
-            /// @brief Maximum number of times the cost can be over the threshold before resetting
-            int max_over_cost = 0;
             /// @brief Step size for the grid search during uncertainty reset
             double step_size = 0.0;
             /// @brief The window size for the local search during uncertainty reset
@@ -278,19 +299,59 @@ namespace module::localisation {
             /// @brief Number of yaw angles to try during uncertainty reset
             int num_angles = 0;
 
-            /// @brief Exponential filter smoothing factor for each state component (0 < alpha <= 1)
-            /// @brief [x, y, theta] - Higher values = more responsive, Lower values = more smoothed
-            Eigen::Vector3d alpha = Eigen::Vector3d(0.1, 0.1, 0.1);
+            /// @brief Process noise variance rate (x^2, y^2, theta^2) per unit odometry motion [m + rad] applied
+            /// to the pose filter's covariance each frame, scaled by observed motion
+            Eigen::Vector3d kalman_process_noise = Eigen::Vector3d::Zero();
+            /// @brief Scalar mapping inverse Hessian curvature to measurement variance
+            double kalman_measurement_scale = 1.0;
+            /// @brief Finite-difference step size per axis for the Hessian [m, m, rad], clamped to
+            /// >= 2*grid_size at use time to ride over grid quantisation and optimiser inexactness
+            Eigen::Vector3d kalman_hessian_step = Eigen::Vector3d::Zero();
+
+            /// @brief Field-line point registered as an inlier below this map distance [m]
+            double validity_line_inlier_distance = 0.0;
+            /// @brief Minimum matched-percept validity fraction to accept an optimisation result
+            double validity_min_validity = 0.0;
+            /// @brief Maximum number of consecutive invalid frames before triggering an uncertainty reset
+            int validity_max_invalid_frames = 0;
+            /// @brief Whether to trigger an uncertainty reset after validity_max_invalid_frames consecutive
+            /// invalid frames
+            bool validity_reset_on_invalid = false;
+
+            /// @brief Use analytic goal/intersection-pair candidates before falling back to grid search
+            bool reset_use_candidates = true;
+            /// @brief Tolerance [m] on pair separation when matching observed intersection pairs to landmark
+            /// pairs
+            double reset_pair_separation_tolerance = 0.0;
+            /// @brief Maximum number of reset candidates kept after deduplication
+            int reset_max_candidates = 0;
+            /// @brief Constrain resets/searches to the robot's current half of the field (avoids the mirror
+            /// field problem)
+            bool reset_constrain_to_half = true;
+
+            /// @brief Act automatically on detected mirror-flip cues (e.g. PenaltyReset) rather than only
+            /// logging a warning
+            bool mirror_auto_flip = false;
         } cfg;
 
-        /// @brief State vector (x,y,yaw) of the Hfw transform
+        /// @brief State vector (x,y,yaw) of the Hfw transform, the raw (unfiltered) optimisation result. Kept
+        /// separately from the filter's mean for debugging/graphing purposes.
         Eigen::Vector3d state = Eigen::Vector3d::Zero();
 
-        /// @brief Filtered state vector using exponential filter
-        Eigen::Vector3d filtered_state = Eigen::Vector3d::Zero();
+        /// @brief Probabilistic pose filter over (x,y,theta) of Hfw. The optimisation result is treated as a
+        /// measurement with covariance derived from the cost function's curvature (Hessian) at the optimum.
+        PoseFilter filter{};
 
-        /// @brief Bool indicating if this is the first measurement
-        bool first_measurement = true;
+        /// @brief The last robot-to-world transform (Sensors::Hrw), used to compute the odometry motion delta
+        /// consumed by the filter's predict step
+        Eigen::Isometry3d last_Hrw = Eigen::Isometry3d::Identity();
+
+        /// @brief Whether last_Hrw currently holds a valid previous value (false immediately after a hard
+        /// reset, since the motion delta across a reset is not meaningful)
+        bool last_Hrw_valid = false;
+
+        /// @brief Number of consecutive frames rejected by the validity gate
+        int num_invalid_frames = 0;
 
         /// @brief Field line distance map (encodes the minimum distance to a field line)
         OccupancyMap<double> fieldline_distance_map{};
@@ -326,10 +387,6 @@ namespace module::localisation {
         /// @brief The last certain state of the robot (used for uncertainty reset)
         Eigen::Vector3d last_certain_state = Eigen::Vector3d::Zero();
 
-        /// @brief Number of times the cost has been over the threshold
-        int num_over_cost = 0;
-
-
         /**
          * @brief Compute Hfw, homogenous transformation from world {w} to field {f} space from state vector (x,y,theta)
          * @param state The state vector (x,y,theta)
@@ -352,10 +409,32 @@ namespace module::localisation {
         Eigen::Vector2i position_in_map(const Eigen::Vector3d& particle, const Eigen::Vector3d& rPWw);
 
         /**
+         * @brief Evaluate the perception-only cost (field-line, field-line intersection and goal-post terms)
+         * of a hypothesised state. Deliberately excludes the state-change regulariser: this function is
+         * shared by the optimiser objective, the finite-difference Hessian and the validity metric, none of
+         * which should see the artificial curvature the regulariser would inject in otherwise-unobservable
+         * directions.
+         * @param x The hypothesised state (x,y,theta)
+         * @param field_lines The observations of the field line points
+         * @param field_intersections The field intersections
+         * @param goals The observed goals
+         * @return The perception-only cost of the hypothesis
+         */
+        double evaluate_cost(const Eigen::Vector3d& x,
+                             const std::vector<Eigen::Vector3d>& field_lines,
+                             const std::shared_ptr<const FieldIntersections>& field_intersections,
+                             const std::shared_ptr<const Goals>& goals);
+
+        /**
          * @brief Run the field line optimisation
          * @param initial_guess The initial guess for the field line
          * @param observations The observations of the field line points
          * @param field_intersections The field intersections
+         * @param goals The observed goals
+         * @param uncertainty_optimisation Whether to use the (faster, less accurate) uncertainty optimisation
+         * settings
+         * @param box_bounds Optional per-axis box half-width around initial_guess to bound the optimisation.
+         * If zero (default), falls back to cfg.change_limit.
          * @return Pair <optimisation solution (x,y,theta), final cost>
          */
         std::pair<Eigen::Vector3d, double> run_field_line_optimisation(
@@ -363,7 +442,75 @@ namespace module::localisation {
             const std::vector<Eigen::Vector3d>& field_lines,
             const std::shared_ptr<const FieldIntersections>& field_intersections,
             const std::shared_ptr<const Goals>& goals,
-            bool uncertainty_optimisation = false);
+            bool uncertainty_optimisation                = false,
+            const Eigen::Vector3d& box_bounds             = Eigen::Vector3d::Zero());
+
+        /**
+         * @brief Compute a validity metric in [0, 1] for a hypothesised state: the fraction of matched
+         * percepts (field-line points registered within validity.line_inlier_distance of the field-line map,
+         * blended 50/50 with the fraction of field intersections successfully associated with a landmark
+         * within max_association_distance). Used to gate acceptance instead of raw optimisation cost, since
+         * cost magnitudes are not directly comparable across differing numbers/mixes of observations.
+         * @param state The hypothesised state (x,y,theta)
+         * @param field_lines The observations of the field line points
+         * @param field_intersections The field intersections
+         * @return The validity of the hypothesis in [0, 1]
+         */
+        double compute_validity(const Eigen::Vector3d& state,
+                                const std::vector<Eigen::Vector3d>& field_lines,
+                                const std::shared_ptr<const FieldIntersections>& field_intersections);
+
+        /**
+         * @brief Central-difference Hessian of evaluate_cost at x (perception terms only, no state-change
+         * regulariser). Used to derive a measurement covariance for the pose filter update.
+         * @param x The point at which to evaluate the Hessian
+         * @param field_lines The observations of the field line points
+         * @param field_intersections The field intersections
+         * @param goals The observed goals
+         * @param h Per-axis finite-difference step size
+         * @return The 3x3 Hessian matrix of evaluate_cost at x
+         */
+        Eigen::Matrix3d finite_difference_hessian(const Eigen::Vector3d& x,
+                                                  const std::vector<Eigen::Vector3d>& field_lines,
+                                                  const std::shared_ptr<const FieldIntersections>& field_intersections,
+                                                  const std::shared_ptr<const Goals>& goals,
+                                                  const Eigen::Vector3d& h);
+
+        /**
+         * @brief Map a cost-function Hessian to a measurement covariance. Eigen-decomposes H and maps each
+         * eigenvalue lambda_i to a variance clamp(scale/lambda_i, r_min, r_max); non-positive or
+         * near-singular eigenvalues (unobserved/unreliable directions) are clamped to r_max rather than
+         * triggering a wholesale fallback. Pure/static: needs no reactor state, so it is directly unit
+         * testable.
+         * @param H The Hessian matrix (assumed symmetric)
+         * @param scale Scalar mapping inverse curvature to variance
+         * @param r_min Minimum variance per eigen-direction
+         * @param r_max Maximum variance per eigen-direction (also used for non-positive/tiny eigenvalues)
+         * @return The 3x3 measurement covariance matrix
+         */
+        static Eigen::Matrix3d covariance_from_hessian(const Eigen::Matrix3d& H,
+                                                       double scale,
+                                                       double r_min,
+                                                       double r_max);
+
+        /**
+         * @brief Generate candidate poses from the two observed goal posts, tried against both assignment
+         * orders and both field ends, gated by the expected goal post distance +- tolerance.
+         * @param goals The observed goals
+         * @return Up to 4 candidate states (x,y,theta)
+         */
+        std::vector<Eigen::Vector3d> goal_pair_candidates(const std::shared_ptr<const Goals>& goals);
+
+        /**
+         * @brief Generate candidate poses from pairs of observed field intersections matched against pairs of
+         * model landmarks of matching type and similar separation. Mirror twins arise naturally from the
+         * symmetric landmark layout. Deduplicated and capped at cfg.reset_max_candidates, preferring
+         * widely-separated pairs (better angular conditioning).
+         * @param field_intersections The field intersections
+         * @return The candidate states (x,y,theta)
+         */
+        std::vector<Eigen::Vector3d> intersection_pair_candidates(
+            const std::shared_ptr<const FieldIntersections>& field_intersections);
 
         /**
          * @brief Perform data association between intersection observations and landmarks using nearest neighbour

--- a/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.hpp
+++ b/module/localisation/FieldLocalisationNLopt/src/FieldLocalisationNLopt.hpp
@@ -29,6 +29,7 @@
 
 #include <Eigen/Core>
 #include <nlopt.hpp>
+#include <optional>
 #include <nuclear>
 
 #include "message/eye/DataPoint.hpp"
@@ -332,6 +333,16 @@ namespace module::localisation {
             /// @brief Act automatically on detected mirror-flip cues (e.g. PenaltyReset) rather than only
             /// logging a warning
             bool mirror_auto_flip = false;
+
+            /// @brief Continuously probe reset candidates to escape local minima of the cost function
+            bool recovery_enabled = true;
+            /// @brief Number of frames of validity averaged per local-minimum escape probe window; the probe
+            /// runs once per window
+            int recovery_probe_period = 30;
+            /// @brief A probe candidate must beat the window's mean validity by this margin for the escape to
+            /// be accepted. This margin is the sole jump decision (together with the window_size locality
+            /// bound); when well-localised the best candidate matches the current pose and no jump occurs.
+            double recovery_improvement_margin = 0.1;
         } cfg;
 
         /// @brief State vector (x,y,yaw) of the Hfw transform, the raw (unfiltered) optimisation result. Kept
@@ -352,6 +363,12 @@ namespace module::localisation {
 
         /// @brief Number of consecutive frames rejected by the validity gate
         int num_invalid_frames = 0;
+
+        /// @brief Running sum of per-frame validity over the current local-minimum escape probe window
+        double recovery_validity_sum = 0.0;
+
+        /// @brief Number of frames accumulated in the current local-minimum escape probe window
+        int recovery_frame_count = 0;
 
         /// @brief Field line distance map (encodes the minimum distance to a field line)
         OccupancyMap<double> fieldline_distance_map{};
@@ -539,6 +556,43 @@ namespace module::localisation {
                                const std::shared_ptr<const FieldIntersections>& field_intersections,
                                const std::shared_ptr<const Goals>& goals,
                                const Eigen::Isometry3d& Hrw);
+
+        /**
+         * @brief Generate analytic pose candidates (goal pairs, intersection pairs, last certain state and
+         * mirrors when not constrained to a half), refine each with the uncertainty optimiser, and return the
+         * candidate with the highest validity. Shared by uncertainty_reset (stage 1-2) and the automatic
+         * local-minimum escape.
+         *
+         * @param field_lines Field lines, used to refine and score candidates.
+         * @param field_intersections Field intersections, used to generate and score candidates.
+         * @param goals Goals, used to generate candidates.
+         * @return Best (refined state, validity) pair, or nullopt if no candidates could be generated.
+         */
+        std::optional<std::pair<Eigen::Vector3d, double>> candidate_probe(
+            const FieldLines& field_lines,
+            const std::shared_ptr<const FieldIntersections>& field_intersections,
+            const std::shared_ptr<const Goals>& goals);
+
+        /**
+         * @brief Attempt to escape a local minimum of the cost function by probing the analytic reset
+         * candidates. The optimiser is local (seeded from the filter mean each frame), so a biased pose that
+         * still explains most percepts (validity above the accept threshold but mediocre) is self-reinforcing
+         * and never triggers the invalid-frames reset. The probe candidates are global and association-free,
+         * so they can land in the true basin. The escape is accepted only if the best candidate beats the
+         * probe window's mean validity by cfg.recovery_improvement_margin AND is within cfg.window_size
+         * (position + wrapped angle) of the current estimate - the latter keeps escapes local and, in
+         * particular, rejects mirror flips (a mirror twin is always at least pi away in heading).
+         *
+         * @param field_lines Field lines, used to refine and score candidates.
+         * @param field_intersections Field intersections, used to generate and score candidates.
+         * @param goals Goals, used to generate candidates.
+         * @param mean_validity Mean validity over the probe window, the baseline the candidate must beat.
+         * @return Whether an escape was performed (the filter has been reset to the new pose).
+         */
+        bool try_local_minimum_escape(const FieldLines& field_lines,
+                                      const std::shared_ptr<const FieldIntersections>& field_intersections,
+                                      const std::shared_ptr<const Goals>& goals,
+                                      double mean_validity);
 
 
         /**

--- a/module/localisation/FieldLocalisationNLopt/src/localisation/PoseFilter.hpp
+++ b/module/localisation/FieldLocalisationNLopt/src/localisation/PoseFilter.hpp
@@ -1,0 +1,88 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef MODULE_LOCALISATION_POSEFILTER_HPP
+#define MODULE_LOCALISATION_POSEFILTER_HPP
+
+#include <Eigen/Core>
+#include <Eigen/LU>
+
+#include "utility/math/angle.hpp"
+
+namespace module::localisation {
+
+    /// @brief Minimal 3-state (x, y, theta) Kalman filter over the Hfw pose estimate.
+    ///
+    /// The state (x, y, theta) parameterises Hfw, which is constant under perfect odometry, so the process
+    /// model is identity transition: `predict` grows the covariance in proportion to observed odometry motion
+    /// rather than applying any motion model. The optimisation result from `run_field_line_optimisation` is
+    /// treated as a measurement of the same state, with covariance derived from the cost function's curvature
+    /// (see `covariance_from_hessian` in filter.cpp). The innovation in `update` is angle-wrapped so heading
+    /// estimation doesn't fight the +-pi seam.
+    struct PoseFilter {
+        /// @brief Current state estimate (x, y, theta)
+        Eigen::Vector3d mean = Eigen::Vector3d::Zero();
+
+        /// @brief Current state covariance
+        Eigen::Matrix3d cov = Eigen::Matrix3d::Identity();
+
+        /// @brief Hard reset to a pose with independent per-axis 1-sigma uncertainty.
+        /// @param pose The new mean (x, y, theta)
+        /// @param sigma The new 1-sigma uncertainty per axis (x, y, theta)
+        void reset(const Eigen::Vector3d& pose, const Eigen::Vector3d& sigma) {
+            mean = pose;
+            cov  = sigma.cwiseProduct(sigma).asDiagonal();
+        }
+
+        /// @brief Grow the covariance by odometry-scaled process noise.
+        /// @param motion A scalar summarising how much the robot moved since the last predict, i.e.
+        /// ||delta translation|| + |delta yaw|, from consecutive Sensors::Hrw
+        /// @param process_noise_rate The per-unit-motion variance rate for each state (x^2, y^2, theta^2 per
+        /// metre-or-radian of motion)
+        void predict(double motion, const Eigen::Vector3d& process_noise_rate) {
+            cov.diagonal() += motion * process_noise_rate;
+        }
+
+        /// @brief Fuse a measurement z (x, y, theta) with covariance R into the current estimate.
+        /// @param z The measurement (x, y, theta)
+        /// @param R The measurement covariance
+        void update(const Eigen::Vector3d& z, const Eigen::Matrix3d& R) {
+            Eigen::Vector3d innovation = z - mean;
+            innovation.z()             = utility::math::angle::signedDifference(z.z(), mean.z());
+
+            Eigen::Matrix3d S = cov + R;
+            Eigen::Matrix3d K = cov * S.inverse();
+
+            mean += K * innovation;
+            mean.z() = utility::math::angle::normalise_angle(mean.z());
+
+            cov = (Eigen::Matrix3d::Identity() - K) * cov;
+        }
+    };
+
+}  // namespace module::localisation
+
+#endif  // MODULE_LOCALISATION_POSEFILTER_HPP

--- a/module/localisation/FieldLocalisationNLopt/src/localisation/candidates.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/localisation/candidates.cpp
@@ -1,0 +1,168 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <Eigen/Geometry>
+#include <algorithm>
+#include <array>
+
+#include "FieldLocalisationNLopt.hpp"
+
+#include "utility/math/angle.hpp"
+
+namespace module::localisation {
+
+    using message::vision::FieldIntersection;
+    using message::vision::FieldIntersections;
+
+    namespace {
+        /// @brief Whether two candidate poses are close enough to be considered duplicates: within 0.3 m in
+        /// position and 0.3 rad in (wrapped) heading.
+        bool is_duplicate_pose(const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
+            constexpr double position_tolerance = 0.3;
+            constexpr double angle_tolerance    = 0.3;
+            double position_distance            = (a.head<2>() - b.head<2>()).norm();
+            double angle_distance = std::abs(utility::math::angle::signedDifference(a.z(), b.z()));
+            return position_distance < position_tolerance && angle_distance < angle_tolerance;
+        }
+    }  // namespace
+
+    Eigen::Vector3d pose_from_point_pair(const Eigen::Vector2d& p1w,
+                                         const Eigen::Vector2d& p2w,
+                                         const Eigen::Vector2d& q1f,
+                                         const Eigen::Vector2d& q2f) {
+        Eigen::Vector2d dp = p2w - p1w;
+        Eigen::Vector2d dq = q2f - q1f;
+        double theta = utility::math::angle::normalise_angle(std::atan2(dq.y(), dq.x()) - std::atan2(dp.y(), dp.x()));
+
+        Eigen::Rotation2Dd R(theta);
+        Eigen::Vector2d t = q1f - R * p1w;
+
+        return Eigen::Vector3d(t.x(), t.y(), theta);
+    }
+
+    Eigen::Vector3d mirror_pose(const Eigen::Vector3d& s) {
+        return Eigen::Vector3d(-s.x(), -s.y(), utility::math::angle::normalise_angle(s.z() + M_PI));
+    }
+
+    std::vector<Eigen::Vector3d> FieldLocalisationNLopt::goal_pair_candidates(
+        const std::shared_ptr<const Goals>& goals) {
+        std::vector<Eigen::Vector3d> candidates;
+
+        if (!goals || goals->goals.size() != 2) {
+            return candidates;
+        }
+
+        // Compute the two observed goal post positions in world space (mirrors the goal-post cost term in
+        // evaluate_cost).
+        auto Hwc    = Eigen::Isometry3d(goals->Hcw).inverse();
+        auto rGWw_1 = Hwc * (goals->goals[0].post.bottom * goals->goals[0].post.distance);
+        auto rGWw_2 = Hwc * (goals->goals[1].post.bottom * goals->goals[1].post.distance);
+
+        double distance_apart = (rGWw_1 - rGWw_2).norm();
+        if (std::abs(distance_apart - expected_goal_post_distance) >= cfg.goal_post_error_tolerance) {
+            return candidates;
+        }
+
+        std::array<GoalPost, 2> ends{own_goal_posts, opp_goal_posts};
+        for (const auto& end : ends) {
+            // Both assignment orders: post 1 -> left/post 2 -> right, and the swap.
+            candidates.push_back(
+                pose_from_point_pair(rGWw_1.head<2>(), rGWw_2.head<2>(), end.left.head<2>(), end.right.head<2>()));
+            candidates.push_back(
+                pose_from_point_pair(rGWw_2.head<2>(), rGWw_1.head<2>(), end.left.head<2>(), end.right.head<2>()));
+        }
+
+        return candidates;
+    }
+
+    std::vector<Eigen::Vector3d> FieldLocalisationNLopt::intersection_pair_candidates(
+        const std::shared_ptr<const FieldIntersections>& field_intersections) {
+        std::vector<Eigen::Vector3d> candidates;
+
+        if (!field_intersections || field_intersections->intersections.size() < 2) {
+            return candidates;
+        }
+
+        const auto& intersections = field_intersections->intersections;
+
+        // (candidate pose, generating pair separation) - separation is used both as a matching gate and to
+        // prefer widely-separated (better angularly-conditioned) pairs when capping the candidate count.
+        std::vector<std::pair<Eigen::Vector3d, double>> candidates_with_separation;
+
+        for (size_t i = 0; i < intersections.size(); ++i) {
+            for (size_t j = i + 1; j < intersections.size(); ++j) {
+                const auto& obs_i = intersections[i];
+                const auto& obs_j = intersections[j];
+                double d          = (obs_i.rIWw - obs_j.rIWw).head<2>().norm();
+
+                // Match against every ordered pair of model landmarks with corresponding types. Ordered pairs
+                // naturally cover both assignment orders (and mirror twins arise automatically because the
+                // model landmark set is symmetric about the field centre).
+                for (const auto& landmark_i : landmarks) {
+                    if (landmark_i.type != obs_i.type) {
+                        continue;
+                    }
+                    for (const auto& landmark_j : landmarks) {
+                        if (landmark_j.type != obs_j.type || &landmark_i == &landmark_j) {
+                            continue;
+                        }
+                        double sep = (landmark_i.rLFf - landmark_j.rLFf).head<2>().norm();
+                        if (std::abs(sep - d) < cfg.reset_pair_separation_tolerance) {
+                            candidates_with_separation.emplace_back(
+                                pose_from_point_pair(obs_i.rIWw.head<2>(),
+                                                     obs_j.rIWw.head<2>(),
+                                                     landmark_i.rLFf.head<2>(),
+                                                     landmark_j.rLFf.head<2>()),
+                                d);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Prefer widely-separated pairs (better angular conditioning): sort descending by separation before
+        // deduplicating, so the retained representative of each duplicate cluster is the best-conditioned one.
+        std::sort(candidates_with_separation.begin(),
+                  candidates_with_separation.end(),
+                  [](const auto& a, const auto& b) { return a.second > b.second; });
+
+        for (const auto& [candidate, separation] : candidates_with_separation) {
+            bool duplicate = std::any_of(candidates.begin(), candidates.end(), [&](const Eigen::Vector3d& existing) {
+                return is_duplicate_pose(candidate, existing);
+            });
+            if (!duplicate) {
+                candidates.push_back(candidate);
+            }
+            if (static_cast<int>(candidates.size()) >= cfg.reset_max_candidates) {
+                break;
+            }
+        }
+
+        return candidates;
+    }
+
+}  // namespace module::localisation

--- a/module/localisation/FieldLocalisationNLopt/src/localisation/filter.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/localisation/filter.cpp
@@ -1,0 +1,108 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <Eigen/Eigenvalues>
+#include <algorithm>
+
+#include "FieldLocalisationNLopt.hpp"
+
+namespace module::localisation {
+
+    Eigen::Matrix3d FieldLocalisationNLopt::finite_difference_hessian(
+        const Eigen::Vector3d& x,
+        const std::vector<Eigen::Vector3d>& field_lines,
+        const std::shared_ptr<const FieldIntersections>& field_intersections,
+        const std::shared_ptr<const Goals>& goals,
+        const Eigen::Vector3d& h) {
+
+        Eigen::Matrix3d H = Eigen::Matrix3d::Zero();
+        const double f0    = evaluate_cost(x, field_lines, field_intersections, goals);
+
+        // Diagonal terms: central second difference.
+        for (int i = 0; i < 3; ++i) {
+            Eigen::Vector3d xp = x;
+            Eigen::Vector3d xm = x;
+            xp(i) += h(i);
+            xm(i) -= h(i);
+            const double fp = evaluate_cost(xp, field_lines, field_intersections, goals);
+            const double fm = evaluate_cost(xm, field_lines, field_intersections, goals);
+            H(i, i)         = (fp - 2.0 * f0 + fm) / (h(i) * h(i));
+        }
+
+        // Off-diagonal terms: central mixed partial (4-point stencil), symmetrised by construction.
+        for (int i = 0; i < 3; ++i) {
+            for (int j = i + 1; j < 3; ++j) {
+                Eigen::Vector3d xpp = x;
+                Eigen::Vector3d xpm = x;
+                Eigen::Vector3d xmp = x;
+                Eigen::Vector3d xmm = x;
+                xpp(i) += h(i);
+                xpp(j) += h(j);
+                xpm(i) += h(i);
+                xpm(j) -= h(j);
+                xmp(i) -= h(i);
+                xmp(j) += h(j);
+                xmm(i) -= h(i);
+                xmm(j) -= h(j);
+
+                const double fpp = evaluate_cost(xpp, field_lines, field_intersections, goals);
+                const double fpm = evaluate_cost(xpm, field_lines, field_intersections, goals);
+                const double fmp = evaluate_cost(xmp, field_lines, field_intersections, goals);
+                const double fmm = evaluate_cost(xmm, field_lines, field_intersections, goals);
+
+                const double value = (fpp - fpm - fmp + fmm) / (4.0 * h(i) * h(j));
+                H(i, j)             = value;
+                H(j, i)             = value;
+            }
+        }
+
+        return H;
+    }
+
+    Eigen::Matrix3d FieldLocalisationNLopt::covariance_from_hessian(const Eigen::Matrix3d& H,
+                                                                     double scale,
+                                                                     double r_min,
+                                                                     double r_max) {
+        // Non-positive or near-singular curvature is treated as "this direction wasn't observed", so is
+        // clamped to r_max ("don't trust this direction") rather than triggering a wholesale fallback.
+        constexpr double min_trustworthy_eigenvalue = 1e-9;
+
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(H);
+        const Eigen::Vector3d& eigenvalues  = solver.eigenvalues();
+        const Eigen::Matrix3d& eigenvectors = solver.eigenvectors();
+
+        Eigen::Vector3d clamped_variances;
+        for (int i = 0; i < 3; ++i) {
+            const double lambda = eigenvalues(i);
+            clamped_variances(i) =
+                (lambda <= min_trustworthy_eigenvalue) ? r_max : std::clamp(scale / lambda, r_min, r_max);
+        }
+
+        return eigenvectors * clamped_variances.asDiagonal() * eigenvectors.transpose();
+    }
+
+}  // namespace module::localisation

--- a/module/localisation/FieldLocalisationNLopt/src/localisation/reset.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/localisation/reset.cpp
@@ -54,12 +54,11 @@ namespace module::localisation {
         }
     }  // namespace
 
-    void FieldLocalisationNLopt::uncertainty_reset(const FieldDescription& fd,
-                                                   const FieldLines& field_lines,
-                                                   const std::shared_ptr<const FieldIntersections>& field_intersections,
-                                                   const std::shared_ptr<const Goals>& goals,
-                                                   const Eigen::Isometry3d& Hrw) {
-        // --- Stage 1: gather one-shot analytic candidates ---
+    std::optional<std::pair<Eigen::Vector3d, double>> FieldLocalisationNLopt::candidate_probe(
+        const FieldLines& field_lines,
+        const std::shared_ptr<const FieldIntersections>& field_intersections,
+        const std::shared_ptr<const Goals>& goals) {
+        // Gather one-shot analytic candidates
         std::vector<Eigen::Vector3d> candidates;
         if (cfg.reset_use_candidates) {
             auto goal_candidates         = goal_pair_candidates(goals);
@@ -80,22 +79,64 @@ namespace module::localisation {
             candidates.insert(candidates.end(), mirrored.begin(), mirrored.end());
         }
 
-        // --- Stage 2: short SBPLX refine per candidate, rank by validity ---
-        if (!candidates.empty()) {
-            std::vector<std::pair<Eigen::Vector3d, double>> refined;  // (refined state, validity)
-            refined.reserve(candidates.size());
-            for (const auto& candidate : candidates) {
-                auto [refined_state, cost] =
-                    run_field_line_optimisation(candidate, field_lines.rPWw, field_intersections, goals, true);
-                (void) cost;
-                double validity = compute_validity(refined_state, field_lines.rPWw, field_intersections);
-                refined.emplace_back(refined_state, validity);
+        if (candidates.empty()) {
+            return std::nullopt;
+        }
+
+        // Short SBPLX refine per candidate, keep the highest validity
+        std::optional<std::pair<Eigen::Vector3d, double>> best;
+        for (const auto& candidate : candidates) {
+            auto [refined_state, cost] =
+                run_field_line_optimisation(candidate, field_lines.rPWw, field_intersections, goals, true);
+            (void) cost;
+            double validity = compute_validity(refined_state, field_lines.rPWw, field_intersections);
+            if (!best || validity > best->second) {
+                best = std::make_pair(refined_state, validity);
             }
+        }
+        return best;
+    }
 
-            auto best = std::max_element(refined.begin(), refined.end(), [](const auto& a, const auto& b) {
-                return a.second < b.second;
-            });
+    bool FieldLocalisationNLopt::try_local_minimum_escape(
+        const FieldLines& field_lines,
+        const std::shared_ptr<const FieldIntersections>& field_intersections,
+        const std::shared_ptr<const Goals>& goals,
+        double mean_validity) {
+        auto best = candidate_probe(field_lines, field_intersections, goals);
+        if (!best) {
+            return false;
+        }
 
+        // Only escape to a decisively better pose that is local to the current estimate. The locality gate
+        // (position + wrapped angle) also rejects mirror flips, which are always at least pi away in heading.
+        bool decisively_better = best->second >= mean_validity + cfg.recovery_improvement_margin;
+        bool local             = pose_distance(best->first, filter.mean) <= cfg.window_size;
+        if (!decisively_better || !local) {
+            return false;
+        }
+
+        log<INFO>("Local-minimum escape: candidate validity ",
+                  best->second,
+                  " beats window mean ",
+                  mean_validity,
+                  ", jumping from (",
+                  filter.mean.transpose(),
+                  ") to (",
+                  best->first.transpose(),
+                  ")");
+        state = best->first;
+        filter.reset(state, cfg.change_limit);
+        last_certain_state = state;
+        return true;
+    }
+
+    void FieldLocalisationNLopt::uncertainty_reset(const FieldDescription& fd,
+                                                   const FieldLines& field_lines,
+                                                   const std::shared_ptr<const FieldIntersections>& field_intersections,
+                                                   const std::shared_ptr<const Goals>& goals,
+                                                   const Eigen::Isometry3d& Hrw) {
+        // --- Stage 1 + 2: analytic candidates, refined and ranked by validity ---
+        if (auto best = candidate_probe(field_lines, field_intersections, goals)) {
             if (best->second >= cfg.validity_min_validity) {
                 log<INFO>("Uncertainty reset (candidates): accepted with validity ", best->second);
                 state = best->first;

--- a/module/localisation/FieldLocalisationNLopt/src/localisation/reset.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/localisation/reset.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2025 NUbots
+ * Copyright (c) 2026 NUbots
  *
  * This file is part of the NUbots codebase.
  * See https://github.com/NUbots/NUbots for further info.
@@ -36,11 +36,84 @@ namespace module::localisation {
     using message::vision::FieldLines;
     using message::vision::Goals;
 
+    namespace {
+        /// @brief Combined position + wrapped-angle distance between two poses, used for the mirror-twin
+        /// tie-break (an explicit, documented tie-break rather than the implicit search-boundary one that
+        /// constrain_to_half normally provides).
+        double pose_distance(const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
+            double position_distance = (a.head<2>() - b.head<2>()).norm();
+            double angle_distance    = std::abs(utility::math::angle::signedDifference(a.z(), b.z()));
+            return position_distance + angle_distance;
+        }
+
+        /// @brief Whether pose b is approximately the mirror image of pose a (position within 0.5 m, heading
+        /// within 0.3 rad of the exact mirror).
+        bool is_mirror_twin(const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
+            Eigen::Vector3d mirrored = mirror_pose(a);
+            return pose_distance(mirrored, b) < 0.8;
+        }
+    }  // namespace
+
     void FieldLocalisationNLopt::uncertainty_reset(const FieldDescription& fd,
                                                    const FieldLines& field_lines,
                                                    const std::shared_ptr<const FieldIntersections>& field_intersections,
                                                    const std::shared_ptr<const Goals>& goals,
                                                    const Eigen::Isometry3d& Hrw) {
+        // --- Stage 1: gather one-shot analytic candidates ---
+        std::vector<Eigen::Vector3d> candidates;
+        if (cfg.reset_use_candidates) {
+            auto goal_candidates         = goal_pair_candidates(goals);
+            auto intersection_candidates = intersection_pair_candidates(field_intersections);
+            candidates.insert(candidates.end(), goal_candidates.begin(), goal_candidates.end());
+            candidates.insert(candidates.end(), intersection_candidates.begin(), intersection_candidates.end());
+        }
+        candidates.push_back(last_certain_state);
+
+        // When not constraining to the robot's current half, also consider the mirror image of every
+        // candidate so far - mirror twins compete on validity like any other candidate.
+        if (!cfg.reset_constrain_to_half) {
+            std::vector<Eigen::Vector3d> mirrored;
+            mirrored.reserve(candidates.size());
+            for (const auto& candidate : candidates) {
+                mirrored.push_back(mirror_pose(candidate));
+            }
+            candidates.insert(candidates.end(), mirrored.begin(), mirrored.end());
+        }
+
+        // --- Stage 2: short SBPLX refine per candidate, rank by validity ---
+        if (!candidates.empty()) {
+            std::vector<std::pair<Eigen::Vector3d, double>> refined;  // (refined state, validity)
+            refined.reserve(candidates.size());
+            for (const auto& candidate : candidates) {
+                auto [refined_state, cost] =
+                    run_field_line_optimisation(candidate, field_lines.rPWw, field_intersections, goals, true);
+                (void) cost;
+                double validity = compute_validity(refined_state, field_lines.rPWw, field_intersections);
+                refined.emplace_back(refined_state, validity);
+            }
+
+            auto best = std::max_element(refined.begin(), refined.end(), [](const auto& a, const auto& b) {
+                return a.second < b.second;
+            });
+
+            if (best->second >= cfg.validity_min_validity) {
+                log<INFO>("Uncertainty reset (candidates): accepted with validity ", best->second);
+                state = best->first;
+                filter.reset(state, cfg.change_limit);
+                last_certain_state = state;
+                return;
+            }
+            log<INFO>("Uncertainty reset (candidates): best validity ",
+                      best->second,
+                      " below threshold ",
+                      cfg.validity_min_validity,
+                      ", falling back to grid search");
+        }
+        else {
+            log<INFO>("Uncertainty reset (candidates): no candidates generated, falling back to grid search");
+        }
+
+        // --- Stage 3: grid-search fallback (local window around last_certain_state, then a wider search) ---
         // Get robot position in field space
         Eigen::Isometry3d Hrf = Hrw * compute_Hfw(last_certain_state).inverse();
         Eigen::Vector3d rRFf  = Hrf.inverse().translation();
@@ -54,10 +127,14 @@ namespace module::localisation {
         double y_min = -(fd.dimensions.field_width / 2 + 0.2) + rRWf.y();
         double y_max = (fd.dimensions.field_width / 2 + 0.2) + rRWf.y();
 
-        // Handle the mirror field problem by halving the x boundary to the robot's current side
-        // This also avoids unnecessary computations
-        x_max = rRFf.x() < 0 ? rRWf.x() : x_max;
-        x_min = rRFf.x() > 0 ? rRWf.x() : x_min;
+        // Handle the mirror field problem by halving the x boundary to the robot's current side. This also
+        // avoids unnecessary computations. Only applied when reset.constrain_to_half is true (the default);
+        // when false, the search covers the whole field and mirror twins are disambiguated by the tie-break
+        // below instead of by never considering the other half.
+        if (cfg.reset_constrain_to_half) {
+            x_max = rRFf.x() < 0 ? rRWf.x() : x_max;
+            x_min = rRFf.x() > 0 ? rRWf.x() : x_min;
+        }
 
         std::vector<double> angles{};
         for (int i = 0; i < cfg.num_angles; ++i) {
@@ -93,13 +170,24 @@ namespace module::localisation {
             return a.second < b.second;
         });
 
-        // If local search is valid, use the lowest cost hypothesis
-        if (!hypotheses.empty() && hypotheses[0].second < cfg.cost_threshold) {
-            log<INFO>("Uncertainty reset (local): using best hypothesis", hypotheses[0].second);
+        // Mirror-twin tie-break: if the best two hypotheses are mirror images of each other, prefer whichever
+        // is closer (position + wrapped angle) to last_certain_state - an explicit, documented tie-break
+        // instead of the implicit one that constrain_to_half normally provides by never searching the other
+        // half at all.
+        if (!cfg.reset_constrain_to_half && hypotheses.size() >= 2
+            && is_mirror_twin(hypotheses[0].first, hypotheses[1].first)
+            && pose_distance(hypotheses[1].first, last_certain_state)
+                   < pose_distance(hypotheses[0].first, last_certain_state)) {
+            std::swap(hypotheses[0], hypotheses[1]);
+        }
+
+        // If local search is valid, use the best hypothesis
+        if (!hypotheses.empty()
+            && compute_validity(hypotheses[0].first, field_lines.rPWw, field_intersections) >= cfg.validity_min_validity) {
+            log<INFO>("Uncertainty reset (local): using best hypothesis, cost ", hypotheses[0].second);
             // Set the state to the best hypothesis
-            state              = hypotheses[0].first;
-            filtered_state     = state;
-            first_measurement  = true;
+            state = hypotheses[0].first;
+            filter.reset(state, cfg.change_limit);
             last_certain_state = state;  // Update the last certain state
             return;
         }
@@ -109,7 +197,7 @@ namespace module::localisation {
             log<INFO>("Uncertainty reset (global): No hypotheses found, searching whole field");
         }
         else {
-            log<INFO>("Uncertainty reset (global): Cost too high, searching whole field", hypotheses[0].second);
+            log<INFO>("Uncertainty reset (global): Validity too low, searching whole field");
         }
 
         // Iterate over the entire field area with a grid search
@@ -133,10 +221,17 @@ namespace module::localisation {
             return a.second < b.second;
         });
 
+        // Mirror-twin tie-break, as above.
+        if (!cfg.reset_constrain_to_half && hypotheses.size() >= 2
+            && is_mirror_twin(hypotheses[0].first, hypotheses[1].first)
+            && pose_distance(hypotheses[1].first, last_certain_state)
+                   < pose_distance(hypotheses[0].first, last_certain_state)) {
+            std::swap(hypotheses[0], hypotheses[1]);
+        }
+
         // Set the state to the best hypothesis
-        state              = hypotheses[0].first;
-        filtered_state     = state;
-        first_measurement  = true;
+        state = hypotheses[0].first;
+        filter.reset(state, cfg.change_limit);
         last_certain_state = state;  // Update the last certain state
     }
 

--- a/module/localisation/FieldLocalisationNLopt/src/localisation/validity.cpp
+++ b/module/localisation/FieldLocalisationNLopt/src/localisation/validity.cpp
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "FieldLocalisationNLopt.hpp"
+
+namespace module::localisation {
+
+    using message::vision::FieldIntersections;
+
+    double FieldLocalisationNLopt::compute_validity(
+        const Eigen::Vector3d& state,
+        const std::vector<Eigen::Vector3d>& field_lines,
+        const std::shared_ptr<const FieldIntersections>& field_intersections) {
+
+        // Fraction of field-line points that land within line_inlier_distance of the field-line map.
+        double line_validity = 0.0;
+        if (!field_lines.empty()) {
+            size_t inliers = 0;
+            for (const auto& rPWw : field_lines) {
+                Eigen::Vector2i map_position = position_in_map(state, rPWw);
+                double distance = fieldline_distance_map.get_occupancy_value(map_position.x(), map_position.y());
+                if (distance >= 0.0 && distance < cfg.validity_line_inlier_distance) {
+                    ++inliers;
+                }
+            }
+            line_validity = static_cast<double>(inliers) / static_cast<double>(field_lines.size());
+        }
+
+        // No intersections observed: fall back to a lines-only validity.
+        if (!field_intersections || field_intersections->intersections.empty()) {
+            return line_validity;
+        }
+
+        // Fraction of observed intersections successfully associated with a landmark (data_association()
+        // already rejects associations beyond max_association_distance).
+        Eigen::Isometry3d Hfw = compute_Hfw(state);
+        auto associations     = data_association(field_intersections, Hfw);
+        double intersection_validity =
+            static_cast<double>(associations.size()) / static_cast<double>(field_intersections->intersections.size());
+
+        // Blend 50/50 when both modalities are present; lines-only if there were no field line points at all.
+        return field_lines.empty() ? intersection_validity : 0.5 * line_validity + 0.5 * intersection_validity;
+    }
+
+}  // namespace module::localisation

--- a/module/localisation/FieldLocalisationNLopt/tests/candidates.cpp
+++ b/module/localisation/FieldLocalisationNLopt/tests/candidates.cpp
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <Eigen/Geometry>
+#include <cmath>
+
+#include "FieldLocalisationNLopt.hpp"
+
+using module::localisation::mirror_pose;
+using module::localisation::pose_from_point_pair;
+
+// pose_from_point_pair and mirror_pose are pure free functions (no reactor/PowerPlant required), so they are
+// exercised directly here. goal_pair_candidates and intersection_pair_candidates are member functions that
+// touch cfg/landmarks/goal posts populated by the Startup handler, so (per the module's "no PowerPlant in
+// tests" constraint) they are not unit tested here - they are exercised via the Webots forced-delocalisation
+// verification instead (see README / verification notes).
+
+TEST_CASE("pose_from_point_pair recovers the identity transform", "[candidates]") {
+    Eigen::Vector2d p1w(0.0, 0.0);
+    Eigen::Vector2d p2w(1.0, 0.0);
+    Eigen::Vector2d q1f(0.0, 0.0);
+    Eigen::Vector2d q2f(1.0, 0.0);
+
+    Eigen::Vector3d pose = pose_from_point_pair(p1w, p2w, q1f, q2f);
+
+    REQUIRE(std::abs(pose.x()) < 1e-9);
+    REQUIRE(std::abs(pose.y()) < 1e-9);
+    REQUIRE(std::abs(pose.z()) < 1e-9);
+}
+
+TEST_CASE("pose_from_point_pair recovers a known rotation and translation", "[candidates]") {
+    // Ground truth pose we want pose_from_point_pair to recover: Hfw with translation (dx, dy) and yaw dtheta.
+    const double dx     = 1.5;
+    const double dy     = -0.7;
+    const double dtheta = 0.4;
+
+    Eigen::Rotation2Dd R(dtheta);
+    Eigen::Vector2d t(dx, dy);
+
+    // Pick two arbitrary world-space points and transform them through the ground truth pose to get their
+    // field-space counterparts: q = R*p + t.
+    Eigen::Vector2d p1w(0.3, 0.2);
+    Eigen::Vector2d p2w(-0.4, 0.9);
+    Eigen::Vector2d q1f = R * p1w + t;
+    Eigen::Vector2d q2f = R * p2w + t;
+
+    Eigen::Vector3d recovered = pose_from_point_pair(p1w, p2w, q1f, q2f);
+
+    REQUIRE(std::abs(recovered.x() - dx) < 1e-6);
+    REQUIRE(std::abs(recovered.y() - dy) < 1e-6);
+    REQUIRE(std::abs(recovered.z() - dtheta) < 1e-6);
+}
+
+TEST_CASE("mirror_pose is an involution", "[candidates]") {
+    std::vector<Eigen::Vector3d> poses = {Eigen::Vector3d(1.0, 2.0, 0.3),
+                                          Eigen::Vector3d(-2.0, 0.5, -1.2),
+                                          Eigen::Vector3d(0.0, 0.0, 0.0),
+                                          Eigen::Vector3d(3.0, -1.0, M_PI - 0.1)};
+
+    for (const auto& pose : poses) {
+        Eigen::Vector3d twice_mirrored = mirror_pose(mirror_pose(pose));
+        REQUIRE(std::abs(twice_mirrored.x() - pose.x()) < 1e-9);
+        REQUIRE(std::abs(twice_mirrored.y() - pose.y()) < 1e-9);
+        REQUIRE(std::abs(std::abs(twice_mirrored.z() - pose.z())) < 1e-9);
+    }
+}
+
+TEST_CASE("mirror_pose maps a known pose across the field centre", "[candidates]") {
+    Eigen::Vector3d pose     = Eigen::Vector3d(1.0, 2.0, 0.3);
+    Eigen::Vector3d mirrored = mirror_pose(pose);
+
+    REQUIRE(std::abs(mirrored.x() - (-1.0)) < 1e-9);
+    REQUIRE(std::abs(mirrored.y() - (-2.0)) < 1e-9);
+    // 0.3 + pi wraps to 0.3 - pi once normalised into (-pi, pi].
+    REQUIRE(std::abs(mirrored.z() - (0.3 - M_PI)) < 1e-9);
+}

--- a/module/localisation/FieldLocalisationNLopt/tests/hessian.cpp
+++ b/module/localisation/FieldLocalisationNLopt/tests/hessian.cpp
@@ -1,0 +1,110 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <Eigen/Eigenvalues>
+#include <algorithm>
+#include <vector>
+
+#include "FieldLocalisationNLopt.hpp"
+
+using module::localisation::FieldLocalisationNLopt;
+
+// covariance_from_hessian is a static, pure member function (no reactor/PowerPlant required), so it can be
+// exercised directly with hand-built Hessians. finite_difference_hessian itself requires a constructed
+// FieldLocalisationNLopt (it calls evaluate_cost, position_in_map, data_association, all of which need the
+// module's runtime state such as the field-line distance map and landmark list), so it is not unit tested
+// here; it is exercised indirectly via the main loop / Webots verification instead.
+
+TEST_CASE("covariance_from_hessian clamps large and small eigenvalues into [r_min, r_max]", "[Hessian]") {
+    Eigen::Matrix3d H  = Eigen::Matrix3d::Zero();
+    H(0, 0)            = 100.0;
+    H(1, 1)            = 1.0;
+    H(2, 2)            = -5.0;  // Non-positive curvature: should clamp to r_max regardless of scale.
+    const double scale = 1.0;
+    const double r_min = 0.01;
+    const double r_max = 10.0;
+
+    Eigen::Matrix3d R = FieldLocalisationNLopt::covariance_from_hessian(H, scale, r_min, r_max);
+
+    REQUIRE(std::abs(R(0, 0) - std::clamp(scale / 100.0, r_min, r_max)) < 1e-9);
+    REQUIRE(std::abs(R(1, 1) - std::clamp(scale / 1.0, r_min, r_max)) < 1e-9);
+    REQUIRE(std::abs(R(2, 2) - r_max) < 1e-9);
+}
+
+TEST_CASE("covariance_from_hessian on an identity Hessian applies the scale uniformly", "[Hessian]") {
+    Eigen::Matrix3d H  = Eigen::Matrix3d::Identity();
+    const double scale = 2.0;
+    const double r_min = 0.001;
+    const double r_max = 100.0;
+
+    Eigen::Matrix3d R = FieldLocalisationNLopt::covariance_from_hessian(H, scale, r_min, r_max);
+
+    Eigen::Matrix3d expected = Eigen::Matrix3d::Identity() * std::clamp(scale, r_min, r_max);
+    REQUIRE((R - expected).norm() < 1e-9);
+}
+
+TEST_CASE("covariance_from_hessian result is symmetric and matches clamped eigenvalues on a coupled Hessian",
+          "[Hessian]") {
+    // A symmetric Hessian with x/y coupling.
+    Eigen::Matrix3d H;
+    // clang-format off
+    H << 4.0, 1.0, 0.0,
+         1.0, 2.0, 0.0,
+         0.0, 0.0, 0.5;
+    // clang-format on
+
+    const double scale = 1.0;
+    const double r_min = 0.01;
+    const double r_max = 5.0;
+
+    Eigen::Matrix3d R = FieldLocalisationNLopt::covariance_from_hessian(H, scale, r_min, r_max);
+
+    // Symmetric output.
+    REQUIRE((R - R.transpose()).norm() < 1e-9);
+
+    // Round-trip: the eigenvalues of R should be the clamped inverse-scaled eigenvalues of H.
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> h_solver(H);
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> r_solver(R);
+
+    std::vector<double> expected_variances;
+    for (int i = 0; i < 3; ++i) {
+        double lambda = h_solver.eigenvalues()(i);
+        expected_variances.push_back(lambda <= 1e-9 ? r_max : std::clamp(scale / lambda, r_min, r_max));
+    }
+    std::sort(expected_variances.begin(), expected_variances.end());
+
+    std::vector<double> actual_variances;
+    for (int i = 0; i < 3; ++i) {
+        actual_variances.push_back(r_solver.eigenvalues()(i));
+    }
+    std::sort(actual_variances.begin(), actual_variances.end());
+
+    for (int i = 0; i < 3; ++i) {
+        REQUIRE(std::abs(actual_variances[i] - expected_variances[i]) < 1e-9);
+    }
+}

--- a/module/localisation/FieldLocalisationNLopt/tests/pose_filter.cpp
+++ b/module/localisation/FieldLocalisationNLopt/tests/pose_filter.cpp
@@ -1,0 +1,103 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 NUbots
+ *
+ * This file is part of the NUbots codebase.
+ * See https://github.com/NUbots/NUbots for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+
+#include "localisation/PoseFilter.hpp"
+
+using module::localisation::PoseFilter;
+
+TEST_CASE("PoseFilter converges to a constant measurement", "[PoseFilter]") {
+    PoseFilter filter;
+    filter.reset(Eigen::Vector3d(0.0, 0.0, 0.0), Eigen::Vector3d(1.0, 1.0, 1.0));
+
+    const Eigen::Vector3d z(1.0, 2.0, 0.5);
+    const Eigen::Matrix3d R = Eigen::Matrix3d::Identity() * 0.01;
+
+    double previous_trace = filter.cov.trace();
+    for (int i = 0; i < 50; ++i) {
+        filter.update(z, R);
+        // Covariance should shrink (or stay the same) with every update towards a consistent measurement.
+        REQUIRE(filter.cov.trace() <= previous_trace + 1e-9);
+        previous_trace = filter.cov.trace();
+    }
+
+    REQUIRE(std::abs(filter.mean.x() - z.x()) < 1e-3);
+    REQUIRE(std::abs(filter.mean.y() - z.y()) < 1e-3);
+    REQUIRE(std::abs(filter.mean.z() - z.z()) < 1e-3);
+}
+
+TEST_CASE("PoseFilter update wraps the innovation across +-pi", "[PoseFilter]") {
+    PoseFilter filter;
+    // Mean sits just below +pi; measurement sits just above -pi. The true angular distance is small, but a
+    // naive (non-wrapped) subtraction would see a jump of almost 2*pi.
+    filter.reset(Eigen::Vector3d(0.0, 0.0, M_PI - 0.05), Eigen::Vector3d(0.1, 0.1, 0.1));
+
+    const Eigen::Vector3d z(0.0, 0.0, -M_PI + 0.05);
+    const Eigen::Matrix3d R = Eigen::Matrix3d::Identity() * 0.01;
+
+    filter.update(z, R);
+
+    // The updated mean should have moved only a small (wrapped) distance from its prior, not nearly 2*pi.
+    double raw_diff = std::abs(filter.mean.z() - (M_PI - 0.05));
+    REQUIRE(raw_diff < 0.2);
+
+    // Mean should stay within (-pi, pi].
+    REQUIRE(filter.mean.z() <= M_PI);
+    REQUIRE(filter.mean.z() > -M_PI);
+}
+
+TEST_CASE("PoseFilter predict grows covariance proportionally to motion", "[PoseFilter]") {
+    PoseFilter filter;
+    filter.reset(Eigen::Vector3d::Zero(), Eigen::Vector3d(0.1, 0.1, 0.1));
+
+    const Eigen::Vector3d rate(0.01, 0.02, 0.005);
+    const Eigen::Vector3d initial_diagonal = filter.cov.diagonal();
+
+    filter.predict(1.0, rate);
+    Eigen::Vector3d after_unit_motion = filter.cov.diagonal();
+    REQUIRE((after_unit_motion - initial_diagonal - rate).norm() < 1e-9);
+
+    filter.predict(2.0, rate);
+    Eigen::Vector3d after_more_motion = filter.cov.diagonal();
+    REQUIRE((after_more_motion - after_unit_motion - 2.0 * rate).norm() < 1e-9);
+
+    // More motion should always grow (never shrink) the covariance.
+    REQUIRE(after_more_motion.x() > after_unit_motion.x());
+}
+
+TEST_CASE("PoseFilter update contracts covariance given a finite measurement covariance", "[PoseFilter]") {
+    PoseFilter filter;
+    filter.reset(Eigen::Vector3d::Zero(), Eigen::Vector3d(1.0, 1.0, 1.0));
+
+    const double trace_before = filter.cov.trace();
+    filter.update(Eigen::Vector3d(0.1, -0.2, 0.05), Eigen::Matrix3d::Identity() * 0.1);
+    const double trace_after = filter.cov.trace();
+
+    REQUIRE(trace_after < trace_before);
+}

--- a/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
+++ b/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
@@ -20,20 +20,20 @@ targets:
 
     # Vision messages
     message.input.Image: false # You probably don't want this unless you're testing something very weird
-    message.output.CompressedImage: false
-    message.vision.Balls: false
-    message.vision.Goals: false
-    message.vision.Robots: false
-    message.vision.GreenHorizon: false
-    message.vision.FieldLines: false
-    message.vision.VisualMesh: false
+    message.output.CompressedImage: true
+    message.vision.Balls: true
+    message.vision.Goals: true
+    message.vision.Robots: true
+    message.vision.GreenHorizon: true
+    message.vision.FieldLines: true
+    message.vision.VisualMesh: true
     message.vision.FieldIntersections: 0.75
-    message.vision.BoundingBoxes: false
+    message.vision.BoundingBoxes: true
 
     # Localisation Messages
-    message.localisation.Ball: false
-    message.localisation.Field: false
-    message.localisation.Robots: false
+    message.localisation.Ball: true
+    message.localisation.Field: true
+    message.localisation.Robots: true
 
     # Log messages
     message.nuclear.LogMessage: false

--- a/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
+++ b/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
@@ -20,7 +20,7 @@ targets:
 
     # Vision messages
     message.input.Image: false # You probably don't want this unless you're testing something very weird
-    message.output.CompressedImage: true
+    message.output.CompressedImage: 10
     message.vision.Balls: true
     message.vision.Goals: true
     message.vision.Robots: true

--- a/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
+++ b/module/network/NetworkForwarder/data/config/NetworkForwarder.yaml
@@ -16,7 +16,7 @@ targets:
     message.eye.DataPoint: false
 
     # Sensor data
-    message.input.Sensors: false
+    message.input.Sensors: true
 
     # Vision messages
     message.input.Image: false # You probably don't want this unless you're testing something very weird
@@ -27,7 +27,7 @@ targets:
     message.vision.GreenHorizon: true
     message.vision.FieldLines: true
     message.vision.VisualMesh: true
-    message.vision.FieldIntersections: 0.75
+    message.vision.FieldIntersections: true
     message.vision.BoundingBoxes: true
 
     # Localisation Messages

--- a/module/purpose/Tester/data/config/Tester.yaml
+++ b/module/purpose/Tester/data/config/Tester.yaml
@@ -41,4 +41,4 @@ chatgpt_prompt: "Hello!"
 audiogpt_listen_duration: 5
 
 # Delay in seconds before creating director tree
-start_delay: 10
+start_delay: 15

--- a/module/purpose/Tester/data/config/Tester.yaml
+++ b/module/purpose/Tester/data/config/Tester.yaml
@@ -41,4 +41,4 @@ chatgpt_prompt: "Hello!"
 audiogpt_listen_duration: 5
 
 # Delay in seconds before creating director tree
-start_delay: 15
+start_delay: 20

--- a/roles/webots/behaviour.role
+++ b/roles/webots/behaviour.role
@@ -22,7 +22,7 @@ nuclear_role(
   vision::GreenHorizonDetector
   vision::FieldLineDetector
   vision::BallDetector
-  vision::Yolo
+  vision::RFDETR
   # Localisation
   localisation::FieldLocalisationNLopt
   localisation::BallLocalisation

--- a/roles/webots/localisation.role
+++ b/roles/webots/localisation.role
@@ -26,7 +26,8 @@ nuclear_role(
   vision::GreenHorizonDetector
   vision::FieldLineDetector
   vision::BallDetector
-  vision::Yolo
+  #vision::Yolo
+  vision::RFDETR
   # Localisation
   localisation::BallLocalisation
   localisation::FieldLocalisationNLopt


### PR DESCRIPTION
Wraps the NLopt field localisation in a 3-state Kalman filter: odometry motion grows the belief's covariance between frames, and each optimisation result is fused as a measurement whose covariance comes from the curvature of the cost function at the optimum — so poorly-observed directions (e.g. along a single visible line) are automatically distrusted. Updates are now accepted on the fraction of percepts explained (validity) rather than raw cost, Field.covariance/uncertainty are actually populated (previously always zero), and delocalisation recovery uses one-shot analytic pose candidates from goal-post and intersection pairs before falling back to the grid search, cutting resets from seconds to tens of milliseconds. Mirror handling is tidied up too: configurable half-field reset constraint, mirror-aware PenaltyReset check, and documentation of why vision alone can't resolve field symmetry.

Config-wise, exponential_filter.alpha, cost_threshold, max_over_cost and reset_on_cost are replaced by kalman.* and validity.* blocks — per-robot tuning reduces to process_noise (measured odometry drift) and measurement_scale (How trustable vision is)