### PR TITLE
Fix Webots clock rtf estimation

### DIFF
--- a/module/platform/Webots/src/Webots.cpp
+++ b/module/platform/Webots/src/Webots.cpp
@@ -714,26 +714,29 @@ namespace module::platform {
             real_delta        = 0;
             current_sim_time  = 0;
             current_real_time = 0;
+            clock_window.clear();
 
             // Reset the local raw sensors buffer
             emit(std::make_unique<ResetWebotsServos>());
         }
 
-        // Save our previous deltas
-        const uint32_t prev_sim_delta  = sim_delta;
-        const uint64_t prev_real_delta = real_delta;
-
         // Update our current deltas
         real_delta = sensor_measurements.real_time - current_real_time;
         sim_delta  = sensor_measurements.time - current_sim_time;
 
-        // Calculate our custom rtf - the ratio of the past two sim deltas and the past two real time deltas,
-        // smoothed
-        const double ratio =
-            static_cast<double>(sim_delta + prev_sim_delta) / static_cast<double>(real_delta + prev_real_delta);
-
-        // Exponential filter to do the smoothing
-        rtf = rtf * clock_smoothing + (1.0 - clock_smoothing) * ratio;
+        // Calculate the real time factor as the slope of sim time against real time over a sliding
+        // real-time window. Messages arrive once per sim step, so on hosts fast enough to burst
+        // several sim steps between pacing sleeps, a per-message exponential filter over-weights the
+        // burst-rate ratio and locks the clock above the true rate. A time-weighted window does not.
+        clock_window.emplace_back(sensor_measurements.time, sensor_measurements.real_time);
+        while (clock_window.size() > 2 && sensor_measurements.real_time - clock_window.front().second > 2000) {
+            clock_window.pop_front();
+        }
+        const double window_sim  = static_cast<double>(sensor_measurements.time - clock_window.front().first);
+        const double window_real = static_cast<double>(sensor_measurements.real_time - clock_window.front().second);
+        if (window_real > 0.0) {
+            rtf = window_sim / window_real;
+        }
         NUClear::clock::set_clock(NUClear::clock::now(), rtf);
 
         // Update our current times

--- a/module/platform/Webots/src/Webots.hpp
+++ b/module/platform/Webots/src/Webots.hpp
@@ -35,11 +35,11 @@
 #include <deque>
 #include <map>
 #include <mutex>
-#include <utility>
 #include <nuclear>
 #include <string>
 #include <tinyrobotics/kinematics.hpp>
 #include <tinyrobotics/parser.hpp>
+#include <utility>
 #include <vector>
 
 #include "message/input/Image.hpp"

--- a/module/platform/Webots/src/Webots.hpp
+++ b/module/platform/Webots/src/Webots.hpp
@@ -32,8 +32,10 @@
 #include <Eigen/Geometry>
 #include <array>
 #include <atomic>
+#include <deque>
 #include <map>
 #include <mutex>
+#include <utility>
 #include <nuclear>
 #include <string>
 #include <tinyrobotics/kinematics.hpp>
@@ -92,6 +94,10 @@ namespace module::platform {
         double clock_smoothing = 0.0;
         /// @brief Real time factor of the simulation clock
         double rtf = 1.0;
+
+        /// @brief Sliding window of (sim time ticks, real time ms) pairs used to estimate the real
+        /// time factor as a time-weighted slope rather than a per-message average
+        std::deque<std::pair<uint32_t, uint64_t>> clock_window;
 
         /// @brief The time between two measurements, expressed in milliseconds
         int time_step;

--- a/module/platform/Webots/src/Webots.hpp
+++ b/module/platform/Webots/src/Webots.hpp
@@ -97,7 +97,7 @@ namespace module::platform {
 
         /// @brief Sliding window of (sim time ticks, real time ms) pairs used to estimate the real
         /// time factor as a time-weighted slope rather than a per-message average
-        std::deque<std::pair<uint32_t, uint64_t>> clock_window;
+        std::deque<std::pair<uint32_t, uint64_t>> clock_window{};
 
         /// @brief The time between two measurements, expressed in milliseconds
         int time_step;


### PR DESCRIPTION
Problem
 
On sufficiently fast machines, a robot in Webots cannot turn on the spot (at the very least in my machine). Low commanded yaw rates produce almost no rotation, higher rates reverse the turn direction entirely, and localisation collapses once the behaviour starts correcting. The same code, Webots version (R2022b), world, and configs work perfectly on slower machines (Alienware pop os), which made this look like a machine-specific mystery (OS, physics threading, servo mapping and friction were all ruled out by bisection and instrumentation).

Root cause

The real time factor used to slave the NUClear clock to Webots sim time was estimated as the ratio of the last two sim/real time deltas, exponentially smoothed per message. Sensor messages arrive once per sim step, and a host that computes a sim step faster than the basic time step executes steps in bursts between Webots' real-time pacing sleeps. Burst-rate messages vastly outnumber pacing-sleep messages, so the per-message filter converges to the burst rate (measured 1.37 on a fast machine, flapping 0.96-2.0 with the default smoothing) instead of the true average of ~1.0. The NUClear clock then runs fast relative to the simulation, desynchronising the walk phase and servo speed calculations: the robot cannot turn on the spot (higher commanded yaw rates reverse the turn direction) and downstream localisation collapses. Slow hosts take at least the basic time step of wall time per sim step, never burst, and are unaffected - which made this look like a machine-specific mystery.

This pull request estimates the rtf as the slope of sim time against real time over a sliding 2 second real-time window instead. This weights time rather than messages, is immune to step bursting, and tracks genuine speed changes. The window resets when the simulation time resets. The clock_smoothing config parameter is no longer used by this path.

Verified on the affected machine with a hip yaw command/measurement trace: before the fix rtf sat at ~1.37 and servo tracking lagged ~200ms behind commands; after the fix rtf tracks the Webots speed factor and keyboardwalk turns correctly in both directions, and the robocup role walks to the ready position and holds localisation.