### PR TITLE
Add `retrieve` tool

### DIFF
--- a/configs/.gitignore
+++ b/configs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# Copyright (c) 2026 NUbots
+#
+# This file is part of the NUbots codebase.
+# See https://github.com/NUbots/NUbots for further info.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+import glob
+import os
+import subprocess
+
+from termcolor import cprint
+
+import b
+from utility.dockerise import run_on_docker
+
+
+@run_on_docker
+def register(command):
+    command.description = "Retrieve files from the target system to the local system"
+
+    command.add_argument("host", help="The host or directory to retrieve the files from")
+
+    command.add_argument("target", help="The target directory/files to get")
+
+    command.add_argument("local", help="The local directory to retrieve the files to")
+
+    command.add_argument("--user", "-u", help="The user to retrieve the files with")
+
+@run_on_docker
+def run(host, target, local, user=None, **kwargs):
+    if not os.path.exists(local):
+        os.makedirs(local)
+
+    cprint(f"Retrieving files from {host}:{target} to {local}", "green")
+
+    if user is None:
+        user = "nubots"
+
+    # Use rsync for efficient incremental transfers over SSH
+    subprocess.run([
+        "rsync",
+        "-aP", # partial progression, archive mode
+        "-e",  # specify the remote shell to use
+        "ssh",
+        f"{user}@{host}:{target}",
+        f"{local}",
+    ], check=True)

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -101,7 +101,6 @@ def run(host, target, user=None, **kwargs):
             cprint(f"Files in '{TEMP_FOLDER}':", "green")
             print(files_in_temp)
 
-        all_matched = True
         for temp_file in files_in_temp:
             matches = []
             for root, _, filenames in os.walk(os.getcwd()):
@@ -137,16 +136,11 @@ def run(host, target, user=None, **kwargs):
                 # tell the user we couldn't find a match
                 if not best_match:
                     print("Unable to match.")
-                    all_matched = False
             else:
                 cprint(f"No local match found for {temp_file}", "yellow")
-                all_matched = False
 
-        # now remove all the temp files, but only if everything found a home
-        if all_matched:
-            shutil.rmtree(TEMP_FOLDER)
-        else:
-            cprint(f"Some files could not be matched — keeping '{TEMP_FOLDER}' for manual handling", "yellow")
+        # now remove all the temp files
+        shutil.rmtree(TEMP_FOLDER)
 
 
     if target == "recordings":

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -64,7 +64,9 @@ def rsync_from(host, user, remote_folder, local_folder):
             "-aP",  # partial progression, archive mode
             "-e",  # specify the remote shell to use
             "ssh",
-            f"{user}@{host}:{remote_folder}",
+            # trailing slash on the source makes rsync copy the folder's contents,
+            # not the folder itself (avoids recordings/recordings/)
+            f"{user}@{host}:{remote_folder.rstrip('/')}/",
             f"{local_folder}/",
         ],
         check=True,

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -27,6 +27,7 @@
 #
 
 import os
+import shutil
 import subprocess
 
 from termcolor import cprint
@@ -41,6 +42,15 @@ PRESETS = {
     "recordings": ("/home/nubots/recordings/", "recordings", False),
     "scripts": ("/home/nubots/scripts/", "scripts", True),
 }
+
+TEMP_FOLDER = "temp"
+
+ROBOT_NAMES = [
+    "kevin",
+    "sarah",
+    "billie",
+    "frankie",
+]
 
 
 @run_on_docker
@@ -76,36 +86,81 @@ def run(host, target, local, user=None, append_timestamp=False, **kwargs):
         for prefix in ("nugus", "n", "i", "igus")
     }.get(host, host)
 
-    preset_append_timestamp = False
-
-    # Expand preset names into their remote path and default local directory
-    if target in PRESETS:
-        remote_path, default_local, preset_append_timestamp = PRESETS[target]
-        target = remote_path
-        if local is None:
-            local = default_local
-    elif local is None:
-        raise SystemExit("A local directory is required when not using a preset")
-
-    append_timestamp = append_timestamp or preset_append_timestamp
-    os.makedirs(local, exist_ok=True)
-
-    if append_timestamp:  # make the timestamped local directory if requested / required
-        import datetime
-
-        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d_%H%M%S")
-        local = os.path.join(local, timestamp)
-        os.makedirs(local, exist_ok=True)
-
     cprint(f"Retrieving files from {host}:{target} to {local}", "green")
-    subprocess.run(
+
+    subprocess.run( # this retrieves back to a temp folder - just for now
         [
             "rsync",
             "-aP",  # partial progression, archive mode
             "-e",  # specify the remote shell to use
             "ssh",
             f"{user}@{host}:{target}",
-            f"{local}",
+            f"{TEMP_FOLDER}/",
         ],
         check=True,
     )
+
+    # list every file in TEMP_FOLDER
+
+    files_in_temp = []
+
+    if not os.path.isdir(TEMP_FOLDER):
+        cprint(f"Temp folder '{TEMP_FOLDER}' does not exist", "red")
+        return
+
+    files = []
+    for root, _, filenames in os.walk(TEMP_FOLDER):
+        for fn in filenames:
+            files.append(os.path.relpath(os.path.join(root, fn), TEMP_FOLDER))
+
+    if not files:
+        cprint(f"No files found in '{TEMP_FOLDER}'", "yellow")
+    else:
+        cprint(f"Files in '{TEMP_FOLDER}':", "green")
+        for f in files:
+            files_in_temp.append(f)
+        print(files_in_temp)
+
+    for temp_file in files_in_temp:
+        matches = []
+        for root, _, filenames in os.walk(os.getcwd()):
+            # skip the temp folder itself, otherwise every file matches its own copy
+            if os.path.abspath(root).startswith(os.path.abspath(TEMP_FOLDER)):
+                continue
+            if os.path.basename(temp_file) in filenames:
+                matches.append(os.path.join(root, os.path.basename(temp_file)))
+        if matches:
+            cprint(f"{temp_file} found in {len(matches)} place(s):", "cyan")
+            for match in matches:
+                print(f"  {match}")
+
+            temp_parent_folder = os.path.basename(os.path.dirname(temp_file))
+
+            # first sort: parent folder name matches (ie. frankie/SomeConfig.yaml)
+            best_match = next(
+                (m for m in matches if os.path.basename(os.path.dirname(m)) == temp_parent_folder), None
+            )
+            if best_match:
+                print("Match for common parent folder name:", temp_parent_folder)
+
+                shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
+
+
+            # failing this...
+            # second sort: parent folder's name of match is config (ie. it's not robot specific)
+            if not best_match:
+                best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == "config"), None)
+                if best_match:
+                    print("Match for generic config.")
+
+                    shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
+
+
+            # failing this...
+            # tell the user we couldn't find a match
+            if not best_match:
+                print("Unable to match.")
+
+    # now remove all the temp files
+
+    shutil.rmtree(TEMP_FOLDER)

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -35,8 +35,8 @@ from termcolor import cprint
 from utility.dockerise import run_on_docker
 
 TEMP_FOLDER = "temp"
-CONFIG_FOLDER = "config"
-RECORDINGS_FOLDER = "recordings"
+CONFIG_FOLDER = "/home/nubots/config"
+RECORDINGS_FOLDER = "/home/nubots/recordings"
 SCRIPTS_FOLDER = "ican'trememberwherethisgoes"
 
 
@@ -48,7 +48,7 @@ def register(command):
 
     command.add_argument(
         "target",
-        help="The target to retrieve: config/recordings/scripts",
+        help="The target to retrieve: config/recordings/scripts/the_works",
     )
 
     command.add_argument("--user", "-u", help="The user to retrieve the files with", default="nubots")
@@ -64,90 +64,93 @@ def run(host, target, user=None, **kwargs):
         for prefix in ("nugus", "n", "i", "igus")
     }.get(host, host)
 
-    """
-    STAGE 1:
-    Copy all the configs back from the robot
-    """
+    if target == "config":
+        """
+        STAGE 1:
+        Copy all the configs back from the robot
+        """
 
-    cprint(f"Retrieving config from {host}:{target} to {TEMP_FOLDER}/", "green")
+        cprint(f"Retrieving config from {host}:{CONFIG_FOLDER} to {TEMP_FOLDER}/", "green")
 
-    subprocess.run(  # this retrieves back to a temp folder - just for now
-        [
-            "rsync",
-            "-aP",  # partial progression, archive mode
-            "-e",  # specify the remote shell to use
-            "ssh",
-            f"{user}@{host}:{target}",
-            f"{TEMP_FOLDER}/",
-        ],
-        check=True,
-    )
+        subprocess.run(  # this retrieves back to a temp folder - just for now
+            [
+                "rsync",
+                "-aP",  # partial progression, archive mode
+                "-e",  # specify the remote shell to use
+                "ssh",
+                f"{user}@{host}:{CONFIG_FOLDER}",
+                f"{TEMP_FOLDER}/",
+            ],
+            check=True,
+        )
 
-    # list every file in TEMP_FOLDER
+        # list every file in TEMP_FOLDER
 
-    if not os.path.isdir(TEMP_FOLDER):
-        cprint(f"Temp folder '{TEMP_FOLDER}' does not exist", "red")
-        return
+        if not os.path.isdir(TEMP_FOLDER):
+            cprint(f"Temp folder '{TEMP_FOLDER}' does not exist", "red")
+            return
 
-    files_in_temp = []
-    for root, _, filenames in os.walk(TEMP_FOLDER):
-        for fn in filenames:
-            files_in_temp.append(os.path.relpath(os.path.join(root, fn), TEMP_FOLDER))
+        files_in_temp = []
+        for root, _, filenames in os.walk(TEMP_FOLDER):
+            for fn in filenames:
+                files_in_temp.append(os.path.relpath(os.path.join(root, fn), TEMP_FOLDER))
 
-    if not files_in_temp:
-        cprint(f"No files found in '{TEMP_FOLDER}'", "yellow")
-    else:
-        cprint(f"Files in '{TEMP_FOLDER}':", "green")
-        print(files_in_temp)
+        if not files_in_temp:
+            cprint(f"No files found in '{TEMP_FOLDER}'", "yellow")
+        else:
+            cprint(f"Files in '{TEMP_FOLDER}':", "green")
+            print(files_in_temp)
 
-    all_matched = True
-    for temp_file in files_in_temp:
-        matches = []
-        for root, _, filenames in os.walk(os.getcwd()):
-            # skip the temp folder itself, otherwise every file matches its own copy
-            if os.path.abspath(root).startswith(os.path.abspath(TEMP_FOLDER)):
-                continue
-            if os.path.basename(temp_file) in filenames:
-                matches.append(os.path.join(root, os.path.basename(temp_file)))
-        if matches:
-            cprint(f"{temp_file} found in {len(matches)} place(s):", "cyan")
-            for match in matches:
-                print(f"  {match}")
+        all_matched = True
+        for temp_file in files_in_temp:
+            matches = []
+            for root, _, filenames in os.walk(os.getcwd()):
+                # skip the temp folder itself, otherwise every file matches its own copy
+                if os.path.abspath(root).startswith(os.path.abspath(TEMP_FOLDER)):
+                    continue
+                if os.path.basename(temp_file) in filenames:
+                    matches.append(os.path.join(root, os.path.basename(temp_file)))
+            if matches:
+                cprint(f"{temp_file} found in {len(matches)} place(s):", "cyan")
+                for match in matches:
+                    print(f"  {match}")
 
-            temp_parent_folder = os.path.basename(os.path.dirname(temp_file))
+                temp_parent_folder = os.path.basename(os.path.dirname(temp_file))
 
-            # first sort: parent folder name matches (ie. frankie/SomeConfig.yaml)
-            best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == temp_parent_folder), None)
-            if best_match:
-                print("Match for common parent folder name:", temp_parent_folder)
-
-                shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
-
-            # failing this...
-            # second sort: parent folder's name of match is config (ie. it's not robot specific)
-            if not best_match:
-                best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == "config"), None)
+                # first sort: parent folder name matches (ie. frankie/SomeConfig.yaml)
+                best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == temp_parent_folder), None)
                 if best_match:
-                    print("Match for generic config.")
+                    print("Match for common parent folder name:", temp_parent_folder)
 
                     shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
 
-            # failing this...
-            # tell the user we couldn't find a match
-            if not best_match:
-                print("Unable to match.")
+                # failing this...
+                # second sort: parent folder's name of match is config (ie. it's not robot specific)
+                if not best_match:
+                    best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == "config"), None)
+                    if best_match:
+                        print("Match for generic config.")
+
+                        shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
+
+                # failing this...
+                # tell the user we couldn't find a match
+                if not best_match:
+                    print("Unable to match.")
+                    all_matched = False
+            else:
+                cprint(f"No local match found for {temp_file}", "yellow")
                 all_matched = False
+
+        # now remove all the temp files, but only if everything found a home
+        if all_matched:
+            shutil.rmtree(TEMP_FOLDER)
         else:
-            cprint(f"No local match found for {temp_file}", "yellow")
-            all_matched = False
+            cprint(f"Some files could not be matched — keeping '{TEMP_FOLDER}' for manual handling", "yellow")
 
-    # now remove all the temp files, but only if everything found a home
-    if all_matched:
-        shutil.rmtree(TEMP_FOLDER)
-    else:
-        cprint(f"Some files could not be matched — keeping '{TEMP_FOLDER}' for manual handling", "yellow")
 
-    """
-    STAGE 2:
-    Copy all the recordings back ONLY if the user wants it (these can be chunky bois)
-    """
+    if target == "recordings":
+        """
+        STAGE 2:
+        Copy all the recordings back ONLY if the user wants it (these can be chunky bois)
+        """

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -26,20 +26,19 @@
 # SOFTWARE.
 #
 
-import glob
 import os
 import subprocess
 
 from termcolor import cprint
 
-import b
 from utility.dockerise import run_on_docker
 
 # Preset names that expand to (remote path, default local directory)
+# Preset names that expand to (remote path, default local directory, append_timestamp)
 # Trailing slash on the remote path makes rsync copy the directory contents
 PRESETS = {
-    "configs": ("/home/nubots/config/", "configs", True), # append timestamp is True for configs
-    "logs": ("/home/nubots/recordings/", "recordings", False),
+    "configs": ("/home/nubots/config/", "configs", True),  # append timestamp for configs by default
+    "recordings": ("/home/nubots/recordings/", "recordings", False),
 }
 
 
@@ -47,7 +46,7 @@ PRESETS = {
 def register(command):
     command.description = "Retrieve files from the target system to the local system"
 
-    command.add_argument("host", help="The host or directory to retrieve the files from")
+    command.add_argument("host", help="The host to retrieve the files from")
 
     command.add_argument(
         "target",
@@ -66,7 +65,7 @@ def register(command):
     command.add_argument("--append-timestamp", "-t", action="store_true", help="Append a timestamp to the local name")
 
 @run_on_docker
-def run(host, target, local, user=None, **kwargs):
+def run(host, target, local, user=None, append_timestamp=False, **kwargs):
     # Replace hostname with its IP address if the hostname is already known
     num_robots = 4
     host = {
@@ -75,29 +74,31 @@ def run(host, target, local, user=None, **kwargs):
         for prefix in ("nugus", "n", "i", "igus")
     }.get(host, host)
 
+    preset_append_timestamp = False
+
     # Expand preset names into their remote path and default local directory
     if target in PRESETS:
-        remote_path, default_local, append_timestamp = PRESETS[target]
+        remote_path, default_local, preset_append_timestamp = PRESETS[target]
         target = remote_path
         if local is None:
             local = default_local
     elif local is None:
         raise SystemExit("A local directory is required when not using a preset")
 
-    if not os.path.exists(local):
-        os.makedirs(local)
-
-    cprint(f"Retrieving files from {host}:{target} to {local}", "green")
+    append_timestamp = append_timestamp or preset_append_timestamp
+    os.makedirs(local, exist_ok=True)
 
     if user is None:
         user = "nubots"
 
-    if append_timestamp: # make the timestamped local directory if the preset requires it
+    if append_timestamp:  # make the timestamped local directory if requested / required
         import datetime
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S") # this is UTC.
-        local = os.path.join(local, f"{timestamp}")
+
+        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d_%H%M%S")
+        local = os.path.join(local, timestamp)
         os.makedirs(local, exist_ok=True)
 
+    cprint(f"Retrieving files from {host}:{target} to {local}", "green")
     subprocess.run([
         "rsync",
         "-aP", # partial progression, archive mode

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -35,6 +35,13 @@ from termcolor import cprint
 import b
 from utility.dockerise import run_on_docker
 
+# Preset names that expand to (remote path, default local directory)
+# Trailing slash on the remote path makes rsync copy the directory contents
+PRESETS = {
+    "configs": ("/home/nubots/config/", "configs", True), # append timestamp is True for configs
+    "logs": ("/home/nubots/recordings/", "recordings", False),
+}
+
 
 @run_on_docker
 def register(command):
@@ -42,14 +49,41 @@ def register(command):
 
     command.add_argument("host", help="The host or directory to retrieve the files from")
 
-    command.add_argument("target", help="The target directory/files to get")
+    command.add_argument(
+        "target",
+        help=f"The target directory/files to get, or a preset name: {', '.join(PRESETS)}",
+    )
 
-    command.add_argument("local", help="The local directory to retrieve the files to")
+    command.add_argument(
+        "local",
+        nargs="?",
+        default=None,
+        help="The local directory to retrieve the files to (defaults per preset)",
+    )
 
     command.add_argument("--user", "-u", help="The user to retrieve the files with")
 
+    command.add_argument("--append-timestamp", "-t", action="store_true", help="Append a timestamp to the local name")
+
 @run_on_docker
 def run(host, target, local, user=None, **kwargs):
+    # Replace hostname with its IP address if the hostname is already known
+    num_robots = 4
+    host = {
+        "{}{}".format(prefix, num): "10.1.1.{}".format(num)
+        for num in range(1, num_robots + 1)
+        for prefix in ("nugus", "n", "i", "igus")
+    }.get(host, host)
+
+    # Expand preset names into their remote path and default local directory
+    if target in PRESETS:
+        remote_path, default_local, append_timestamp = PRESETS[target]
+        target = remote_path
+        if local is None:
+            local = default_local
+    elif local is None:
+        raise SystemExit("A local directory is required when not using a preset")
+
     if not os.path.exists(local):
         os.makedirs(local)
 
@@ -58,7 +92,12 @@ def run(host, target, local, user=None, **kwargs):
     if user is None:
         user = "nubots"
 
-    # Use rsync for efficient incremental transfers over SSH
+    if append_timestamp: # make the timestamped local directory if the preset requires it
+        import datetime
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S") # this is UTC.
+        local = os.path.join(local, f"{timestamp}")
+        os.makedirs(local, exist_ok=True)
+
     subprocess.run([
         "rsync",
         "-aP", # partial progression, archive mode

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -64,6 +64,7 @@ def register(command):
 
     command.add_argument("--append-timestamp", "-t", action="store_true", help="Append a timestamp to the local name")
 
+
 @run_on_docker
 def run(host, target, local, user=None, append_timestamp=False, **kwargs):
     # Replace hostname with its IP address if the hostname is already known
@@ -99,11 +100,14 @@ def run(host, target, local, user=None, append_timestamp=False, **kwargs):
         os.makedirs(local, exist_ok=True)
 
     cprint(f"Retrieving files from {host}:{target} to {local}", "green")
-    subprocess.run([
-        "rsync",
-        "-aP", # partial progression, archive mode
-        "-e",  # specify the remote shell to use
-        "ssh",
-        f"{user}@{host}:{target}",
-        f"{local}",
-    ], check=True)
+    subprocess.run(
+        [
+            "rsync",
+            "-aP",  # partial progression, archive mode
+            "-e",  # specify the remote shell to use
+            "ssh",
+            f"{user}@{host}:{target}",
+            f"{local}",
+        ],
+        check=True,
+    )

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -63,7 +63,7 @@ def run(host, target, user=None, **kwargs):
 
     cprint(f"Retrieving files from {host}:{target} to {TEMP_FOLDER}/", "green")
 
-    subprocess.run( # this retrieves back to a temp folder - just for now
+    subprocess.run(  # this retrieves back to a temp folder - just for now
         [
             "rsync",
             "-aP",  # partial progression, archive mode
@@ -109,14 +109,11 @@ def run(host, target, user=None, **kwargs):
             temp_parent_folder = os.path.basename(os.path.dirname(temp_file))
 
             # first sort: parent folder name matches (ie. frankie/SomeConfig.yaml)
-            best_match = next(
-                (m for m in matches if os.path.basename(os.path.dirname(m)) == temp_parent_folder), None
-            )
+            best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == temp_parent_folder), None)
             if best_match:
                 print("Match for common parent folder name:", temp_parent_folder)
 
                 shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
-
 
             # failing this...
             # second sort: parent folder's name of match is config (ie. it's not robot specific)
@@ -126,7 +123,6 @@ def run(host, target, user=None, **kwargs):
                     print("Match for generic config.")
 
                     shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
-
 
             # failing this...
             # tell the user we couldn't find a match

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -61,7 +61,12 @@ def run(host, target, user=None, **kwargs):
         for prefix in ("nugus", "n", "i", "igus")
     }.get(host, host)
 
-    cprint(f"Retrieving files from {host}:{target} to {TEMP_FOLDER}/", "green")
+    """
+    STAGE 1:
+    Copy all the configs back from the robot
+    """
+
+    cprint(f"Retrieving config from {host}:{target} to {TEMP_FOLDER}/", "green")
 
     subprocess.run(  # this retrieves back to a temp folder - just for now
         [

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -37,7 +37,7 @@ from utility.dockerise import run_on_docker
 TEMP_FOLDER = "temp"
 CONFIG_FOLDER = "/home/nubots/config"
 RECORDINGS_FOLDER = "/home/nubots/recordings"
-SCRIPTS_FOLDER = "ican'trememberwherethisgoes"
+SCRIPTS_FOLDER = "/home/nubots/scripts"
 
 
 @run_on_docker
@@ -149,7 +149,7 @@ def run(host, target, user=None, **kwargs):
         Copy all the recordings back ONLY if the user wants it (these can be chunky bois)
         """
 
-        subprocess.run(  # this retrieves back to a temp folder - just for now
+        subprocess.run(  # this retrieves back to the recordings folder :)
             [
                 "rsync",
                 "-aP",  # partial progression, archive mode
@@ -160,3 +160,81 @@ def run(host, target, user=None, **kwargs):
             ],
             check=True,
         )
+
+    if target == "scripts":
+        """
+        STAGE 3:
+        Copy all the scripts back and filter them very similar to how we did the configs
+        """
+
+        cprint(f"Retrieving config from {host}:{SCRIPTS_FOLDER} to {TEMP_FOLDER}/", "green")
+
+        subprocess.run(  # this retrieves back to a temp folder - just for now
+            [
+                "rsync",
+                "-aP",  # partial progression, archive mode
+                "-e",  # specify the remote shell to use
+                "ssh",
+                f"{user}@{host}:{SCRIPTS_FOLDER}",
+                f"{TEMP_FOLDER}/",
+            ],
+            check=True,
+        )
+
+        # list every file in TEMP_FOLDER
+
+        if not os.path.isdir(TEMP_FOLDER):
+            cprint(f"Temp folder '{TEMP_FOLDER}' does not exist", "red")
+            return
+
+        files_in_temp = []
+        for root, _, filenames in os.walk(TEMP_FOLDER):
+            for fn in filenames:
+                files_in_temp.append(os.path.relpath(os.path.join(root, fn), TEMP_FOLDER))
+
+        if not files_in_temp:
+            cprint(f"No files found in '{TEMP_FOLDER}'", "yellow")
+        else:
+            cprint(f"Files in '{TEMP_FOLDER}':", "green")
+            print(files_in_temp)
+
+        for temp_file in files_in_temp:
+            matches = []
+            for root, _, filenames in os.walk(os.getcwd()):
+                # skip the temp folder itself, otherwise every file matches its own copy
+                if os.path.abspath(root).startswith(os.path.abspath(TEMP_FOLDER)):
+                    continue
+                if os.path.basename(temp_file) in filenames:
+                    matches.append(os.path.join(root, os.path.basename(temp_file)))
+            if matches:
+                cprint(f"{temp_file} found in {len(matches)} place(s):", "cyan")
+                for match in matches:
+                    print(f"  {match}")
+
+                temp_parent_folder = os.path.basename(os.path.dirname(temp_file))
+
+                # first sort: parent folder name matches (ie. frankie/SomeConfig.yaml)
+                best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == temp_parent_folder), None)
+                if best_match:
+                    print("Match for common parent folder name:", temp_parent_folder)
+
+                    shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
+
+                # failing this...
+                # second sort: parent folder's name of match is config (ie. it's not robot specific)
+                if not best_match:
+                    best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == "nugus"), None)
+                    if best_match:
+                        print("Match for generic config.")
+
+                        shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
+
+                # failing this...
+                # tell the user we couldn't find a match
+                if not best_match:
+                    print("Unable to match.")
+            else:
+                cprint(f"No local match found for {temp_file}", "yellow")
+
+        # now remove all the temp files
+        shutil.rmtree(TEMP_FOLDER)

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -35,6 +35,9 @@ from termcolor import cprint
 from utility.dockerise import run_on_docker
 
 TEMP_FOLDER = "temp"
+CONFIG_FOLDER = "config"
+RECORDINGS_FOLDER = "recordings"
+SCRIPTS_FOLDER = "ican'trememberwherethisgoes"
 
 
 @run_on_docker
@@ -45,7 +48,7 @@ def register(command):
 
     command.add_argument(
         "target",
-        help="The target directory/files to get",
+        help="The target to retrieve: config/recordings/scripts",
     )
 
     command.add_argument("--user", "-u", help="The user to retrieve the files with", default="nubots")
@@ -143,3 +146,8 @@ def run(host, target, user=None, **kwargs):
         shutil.rmtree(TEMP_FOLDER)
     else:
         cprint(f"Some files could not be matched — keeping '{TEMP_FOLDER}' for manual handling", "yellow")
+
+    """
+    STAGE 2:
+    Copy all the recordings back ONLY if the user wants it (these can be chunky bois)
+    """

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -39,7 +39,7 @@ CONFIG_FOLDER = "/home/nubots/config"
 RECORDINGS_FOLDER = "/home/nubots/recordings"
 SCRIPTS_FOLDER = "/home/nubots/scripts"
 
-TARGETS = ("config", "recordings", "scripts", "the_works")
+TARGETS = ("config", "recordings", "scripts", "all")
 
 
 @run_on_docker
@@ -51,7 +51,7 @@ def register(command):
     command.add_argument(
         "target",
         choices=TARGETS,
-        help="The target to retrieve: config/recordings/scripts/the_works",
+        help="The target to retrieve: config/recordings/scripts/all",
     )
 
     command.add_argument("--user", "-u", help="The user to retrieve the files with", default="nubots")
@@ -161,13 +161,13 @@ def run(host, target, user=None, **kwargs):
     }.get(host, host)
 
     # STAGE 1: copy all the configs back from the robot
-    if target in ("config", "the_works"):
+    if target in ("config", "all"):
         retrieve_and_merge(host, user, CONFIG_FOLDER, "config")
 
     # STAGE 2: copy all the recordings back
-    if target in ("recordings", "the_works"):
+    if target in ("recordings", "all"):
         retrieve_recordings(host, user)
 
     # STAGE 3: copy all the scripts back, filtered very similar to the configs
-    if target in ("scripts", "the_works"):
+    if target in ("scripts", "all"):
         retrieve_and_merge(host, user, SCRIPTS_FOLDER, "nugus")

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -39,6 +39,8 @@ CONFIG_FOLDER = "/home/nubots/config"
 RECORDINGS_FOLDER = "/home/nubots/recordings"
 SCRIPTS_FOLDER = "/home/nubots/scripts"
 
+TARGETS = ("config", "recordings", "scripts", "the_works")
+
 
 @run_on_docker
 def register(command):
@@ -48,10 +50,102 @@ def register(command):
 
     command.add_argument(
         "target",
+        choices=TARGETS,
         help="The target to retrieve: config/recordings/scripts/the_works",
     )
 
     command.add_argument("--user", "-u", help="The user to retrieve the files with", default="nubots")
+
+
+def rsync_from(host, user, remote_folder, local_folder):
+    subprocess.run(
+        [
+            "rsync",
+            "-aP",  # partial progression, archive mode
+            "-e",  # specify the remote shell to use
+            "ssh",
+            f"{user}@{host}:{remote_folder}",
+            f"{local_folder}/",
+        ],
+        check=True,
+    )
+
+
+def retrieve_and_merge(host, user, remote_folder, generic_parent):
+    """
+    Retrieve remote_folder into TEMP_FOLDER, copy each file over its best local
+    match (parent folder name first, then generic_parent), then delete TEMP_FOLDER.
+    """
+    cprint(f"Retrieving from {host}:{remote_folder} to {TEMP_FOLDER}/", "green")
+
+    rsync_from(host, user, remote_folder, TEMP_FOLDER)
+
+    # list every file in TEMP_FOLDER
+
+    if not os.path.isdir(TEMP_FOLDER):
+        cprint(f"Temp folder '{TEMP_FOLDER}' does not exist", "red")
+        return
+
+    files_in_temp = []
+    for root, _, filenames in os.walk(TEMP_FOLDER):
+        for fn in filenames:
+            files_in_temp.append(os.path.relpath(os.path.join(root, fn), TEMP_FOLDER))
+
+    if not files_in_temp:
+        cprint(f"No files found in '{TEMP_FOLDER}'", "yellow")
+    else:
+        cprint(f"Files in '{TEMP_FOLDER}':", "green")
+        print(files_in_temp)
+
+    for temp_file in files_in_temp:
+        matches = []
+        for root, _, filenames in os.walk(os.getcwd()):
+            # skip the temp folder itself, otherwise every file matches its own copy
+            if os.path.abspath(root).startswith(os.path.abspath(TEMP_FOLDER)):
+                continue
+            if os.path.basename(temp_file) in filenames:
+                matches.append(os.path.join(root, os.path.basename(temp_file)))
+        if matches:
+            cprint(f"{temp_file} found in {len(matches)} place(s):", "cyan")
+            for match in matches:
+                print(f"  {match}")
+
+            temp_parent_folder = os.path.basename(os.path.dirname(temp_file))
+
+            # first sort: parent folder name matches (ie. frankie/SomeConfig.yaml)
+            best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == temp_parent_folder), None)
+            if best_match:
+                print("Match for common parent folder name:", temp_parent_folder)
+
+                shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
+
+            # failing this...
+            # second sort: parent folder's name of match is the generic one (ie. it's not robot specific)
+            if not best_match:
+                best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == generic_parent), None)
+                if best_match:
+                    print(f"Match for generic parent folder: {generic_parent}")
+
+                    shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
+
+            # failing this...
+            # tell the user we couldn't find a match
+            if not best_match:
+                print("Unable to match.")
+        else:
+            cprint(f"No local match found for {temp_file}", "yellow")
+
+    # now remove all the temp files
+    shutil.rmtree(TEMP_FOLDER)
+
+
+def retrieve_recordings(host, user):
+    """
+    Copy all the recordings back ONLY if the user wants it (these can be chunky bois)
+    """
+    cprint(f"Retrieving recordings from {host}:{RECORDINGS_FOLDER} to recordings/", "green")
+
+    rsync_from(host, user, RECORDINGS_FOLDER, "recordings")
 
 
 @run_on_docker
@@ -64,177 +158,14 @@ def run(host, target, user=None, **kwargs):
         for prefix in ("nugus", "n", "i", "igus")
     }.get(host, host)
 
-    if target == "config":
-        """
-        STAGE 1:
-        Copy all the configs back from the robot
-        """
+    # STAGE 1: copy all the configs back from the robot
+    if target in ("config", "the_works"):
+        retrieve_and_merge(host, user, CONFIG_FOLDER, "config")
 
-        cprint(f"Retrieving config from {host}:{CONFIG_FOLDER} to {TEMP_FOLDER}/", "green")
+    # STAGE 2: copy all the recordings back
+    if target in ("recordings", "the_works"):
+        retrieve_recordings(host, user)
 
-        subprocess.run(  # this retrieves back to a temp folder - just for now
-            [
-                "rsync",
-                "-aP",  # partial progression, archive mode
-                "-e",  # specify the remote shell to use
-                "ssh",
-                f"{user}@{host}:{CONFIG_FOLDER}",
-                f"{TEMP_FOLDER}/",
-            ],
-            check=True,
-        )
-
-        # list every file in TEMP_FOLDER
-
-        if not os.path.isdir(TEMP_FOLDER):
-            cprint(f"Temp folder '{TEMP_FOLDER}' does not exist", "red")
-            return
-
-        files_in_temp = []
-        for root, _, filenames in os.walk(TEMP_FOLDER):
-            for fn in filenames:
-                files_in_temp.append(os.path.relpath(os.path.join(root, fn), TEMP_FOLDER))
-
-        if not files_in_temp:
-            cprint(f"No files found in '{TEMP_FOLDER}'", "yellow")
-        else:
-            cprint(f"Files in '{TEMP_FOLDER}':", "green")
-            print(files_in_temp)
-
-        for temp_file in files_in_temp:
-            matches = []
-            for root, _, filenames in os.walk(os.getcwd()):
-                # skip the temp folder itself, otherwise every file matches its own copy
-                if os.path.abspath(root).startswith(os.path.abspath(TEMP_FOLDER)):
-                    continue
-                if os.path.basename(temp_file) in filenames:
-                    matches.append(os.path.join(root, os.path.basename(temp_file)))
-            if matches:
-                cprint(f"{temp_file} found in {len(matches)} place(s):", "cyan")
-                for match in matches:
-                    print(f"  {match}")
-
-                temp_parent_folder = os.path.basename(os.path.dirname(temp_file))
-
-                # first sort: parent folder name matches (ie. frankie/SomeConfig.yaml)
-                best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == temp_parent_folder), None)
-                if best_match:
-                    print("Match for common parent folder name:", temp_parent_folder)
-
-                    shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
-
-                # failing this...
-                # second sort: parent folder's name of match is config (ie. it's not robot specific)
-                if not best_match:
-                    best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == "config"), None)
-                    if best_match:
-                        print("Match for generic config.")
-
-                        shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
-
-                # failing this...
-                # tell the user we couldn't find a match
-                if not best_match:
-                    print("Unable to match.")
-            else:
-                cprint(f"No local match found for {temp_file}", "yellow")
-
-        # now remove all the temp files
-        shutil.rmtree(TEMP_FOLDER)
-
-
-    if target == "recordings":
-        """
-        STAGE 2:
-        Copy all the recordings back ONLY if the user wants it (these can be chunky bois)
-        """
-
-        subprocess.run(  # this retrieves back to the recordings folder :)
-            [
-                "rsync",
-                "-aP",  # partial progression, archive mode
-                "-e",  # specify the remote shell to use
-                "ssh",
-                f"{user}@{host}:{RECORDINGS_FOLDER}",
-                f"recordings/",
-            ],
-            check=True,
-        )
-
-    if target == "scripts":
-        """
-        STAGE 3:
-        Copy all the scripts back and filter them very similar to how we did the configs
-        """
-
-        cprint(f"Retrieving config from {host}:{SCRIPTS_FOLDER} to {TEMP_FOLDER}/", "green")
-
-        subprocess.run(  # this retrieves back to a temp folder - just for now
-            [
-                "rsync",
-                "-aP",  # partial progression, archive mode
-                "-e",  # specify the remote shell to use
-                "ssh",
-                f"{user}@{host}:{SCRIPTS_FOLDER}",
-                f"{TEMP_FOLDER}/",
-            ],
-            check=True,
-        )
-
-        # list every file in TEMP_FOLDER
-
-        if not os.path.isdir(TEMP_FOLDER):
-            cprint(f"Temp folder '{TEMP_FOLDER}' does not exist", "red")
-            return
-
-        files_in_temp = []
-        for root, _, filenames in os.walk(TEMP_FOLDER):
-            for fn in filenames:
-                files_in_temp.append(os.path.relpath(os.path.join(root, fn), TEMP_FOLDER))
-
-        if not files_in_temp:
-            cprint(f"No files found in '{TEMP_FOLDER}'", "yellow")
-        else:
-            cprint(f"Files in '{TEMP_FOLDER}':", "green")
-            print(files_in_temp)
-
-        for temp_file in files_in_temp:
-            matches = []
-            for root, _, filenames in os.walk(os.getcwd()):
-                # skip the temp folder itself, otherwise every file matches its own copy
-                if os.path.abspath(root).startswith(os.path.abspath(TEMP_FOLDER)):
-                    continue
-                if os.path.basename(temp_file) in filenames:
-                    matches.append(os.path.join(root, os.path.basename(temp_file)))
-            if matches:
-                cprint(f"{temp_file} found in {len(matches)} place(s):", "cyan")
-                for match in matches:
-                    print(f"  {match}")
-
-                temp_parent_folder = os.path.basename(os.path.dirname(temp_file))
-
-                # first sort: parent folder name matches (ie. frankie/SomeConfig.yaml)
-                best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == temp_parent_folder), None)
-                if best_match:
-                    print("Match for common parent folder name:", temp_parent_folder)
-
-                    shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
-
-                # failing this...
-                # second sort: parent folder's name of match is config (ie. it's not robot specific)
-                if not best_match:
-                    best_match = next((m for m in matches if os.path.basename(os.path.dirname(m)) == "nugus"), None)
-                    if best_match:
-                        print("Match for generic config.")
-
-                        shutil.copy(os.path.join(TEMP_FOLDER, temp_file), best_match)
-
-                # failing this...
-                # tell the user we couldn't find a match
-                if not best_match:
-                    print("Unable to match.")
-            else:
-                cprint(f"No local match found for {temp_file}", "yellow")
-
-        # now remove all the temp files
-        shutil.rmtree(TEMP_FOLDER)
+    # STAGE 3: copy all the scripts back, filtered very similar to the configs
+    if target in ("scripts", "the_works"):
+        retrieve_and_merge(host, user, SCRIPTS_FOLDER, "nugus")

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -154,3 +154,15 @@ def run(host, target, user=None, **kwargs):
         STAGE 2:
         Copy all the recordings back ONLY if the user wants it (these can be chunky bois)
         """
+
+        subprocess.run(  # this retrieves back to a temp folder - just for now
+            [
+                "rsync",
+                "-aP",  # partial progression, archive mode
+                "-e",  # specify the remote shell to use
+                "ssh",
+                f"{user}@{host}:{RECORDINGS_FOLDER}",
+                f"recordings/",
+            ],
+            check=True,
+        )

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -60,7 +60,7 @@ def register(command):
         help="The local directory to retrieve the files to (defaults per preset)",
     )
 
-    command.add_argument("--user", "-u", help="The user to retrieve the files with")
+    command.add_argument("--user", "-u", help="The user to retrieve the files with", default="nubots")
 
     command.add_argument("--append-timestamp", "-t", action="store_true", help="Append a timestamp to the local name")
 
@@ -88,9 +88,6 @@ def run(host, target, local, user=None, append_timestamp=False, **kwargs):
 
     append_timestamp = append_timestamp or preset_append_timestamp
     os.makedirs(local, exist_ok=True)
-
-    if user is None:
-        user = "nubots"
 
     if append_timestamp:  # make the timestamped local directory if requested / required
         import datetime

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -39,6 +39,7 @@ from utility.dockerise import run_on_docker
 PRESETS = {
     "configs": ("/home/nubots/config/", "configs", True),  # append timestamp for configs by default
     "recordings": ("/home/nubots/recordings/", "recordings", False),
+    "scripts": ("/home/nubots/scripts/", "scripts", True),
 }
 
 

--- a/tools/retrieve.py
+++ b/tools/retrieve.py
@@ -34,23 +34,7 @@ from termcolor import cprint
 
 from utility.dockerise import run_on_docker
 
-# Preset names that expand to (remote path, default local directory)
-# Preset names that expand to (remote path, default local directory, append_timestamp)
-# Trailing slash on the remote path makes rsync copy the directory contents
-PRESETS = {
-    "configs": ("/home/nubots/config/", "configs", True),  # append timestamp for configs by default
-    "recordings": ("/home/nubots/recordings/", "recordings", False),
-    "scripts": ("/home/nubots/scripts/", "scripts", True),
-}
-
 TEMP_FOLDER = "temp"
-
-ROBOT_NAMES = [
-    "kevin",
-    "sarah",
-    "billie",
-    "frankie",
-]
 
 
 @run_on_docker
@@ -61,23 +45,14 @@ def register(command):
 
     command.add_argument(
         "target",
-        help=f"The target directory/files to get, or a preset name: {', '.join(PRESETS)}",
-    )
-
-    command.add_argument(
-        "local",
-        nargs="?",
-        default=None,
-        help="The local directory to retrieve the files to (defaults per preset)",
+        help="The target directory/files to get",
     )
 
     command.add_argument("--user", "-u", help="The user to retrieve the files with", default="nubots")
 
-    command.add_argument("--append-timestamp", "-t", action="store_true", help="Append a timestamp to the local name")
-
 
 @run_on_docker
-def run(host, target, local, user=None, append_timestamp=False, **kwargs):
+def run(host, target, user=None, **kwargs):
     # Replace hostname with its IP address if the hostname is already known
     num_robots = 4
     host = {
@@ -86,7 +61,7 @@ def run(host, target, local, user=None, append_timestamp=False, **kwargs):
         for prefix in ("nugus", "n", "i", "igus")
     }.get(host, host)
 
-    cprint(f"Retrieving files from {host}:{target} to {local}", "green")
+    cprint(f"Retrieving files from {host}:{target} to {TEMP_FOLDER}/", "green")
 
     subprocess.run( # this retrieves back to a temp folder - just for now
         [
@@ -102,25 +77,22 @@ def run(host, target, local, user=None, append_timestamp=False, **kwargs):
 
     # list every file in TEMP_FOLDER
 
-    files_in_temp = []
-
     if not os.path.isdir(TEMP_FOLDER):
         cprint(f"Temp folder '{TEMP_FOLDER}' does not exist", "red")
         return
 
-    files = []
+    files_in_temp = []
     for root, _, filenames in os.walk(TEMP_FOLDER):
         for fn in filenames:
-            files.append(os.path.relpath(os.path.join(root, fn), TEMP_FOLDER))
+            files_in_temp.append(os.path.relpath(os.path.join(root, fn), TEMP_FOLDER))
 
-    if not files:
+    if not files_in_temp:
         cprint(f"No files found in '{TEMP_FOLDER}'", "yellow")
     else:
         cprint(f"Files in '{TEMP_FOLDER}':", "green")
-        for f in files:
-            files_in_temp.append(f)
         print(files_in_temp)
 
+    all_matched = True
     for temp_file in files_in_temp:
         matches = []
         for root, _, filenames in os.walk(os.getcwd()):
@@ -160,7 +132,13 @@ def run(host, target, local, user=None, append_timestamp=False, **kwargs):
             # tell the user we couldn't find a match
             if not best_match:
                 print("Unable to match.")
+                all_matched = False
+        else:
+            cprint(f"No local match found for {temp_file}", "yellow")
+            all_matched = False
 
-    # now remove all the temp files
-
-    shutil.rmtree(TEMP_FOLDER)
+    # now remove all the temp files, but only if everything found a home
+    if all_matched:
+        shutil.rmtree(TEMP_FOLDER)
+    else:
+        cprint(f"Some files could not be matched — keeping '{TEMP_FOLDER}' for manual handling", "yellow")


### PR DESCRIPTION
I'm quite lazy. I also noticed at Robocup that sometimes configs from tuning were lost because there's no easy way to tell when it was taken. The retrieval process of configs and recordings is slightly painful - not only because I have the memory of a goldfish when it comes to how the `scp` command works.

This script can retrieve any specific file, but can also retrieve recordings and configs; the latter it will move into a timestamped folder - this solves my "when did we get that config off the robot" problem.

The timestamp is UTC.

NOTE: This PR adds a new folder, alike the `recordings` folder that is gitignore'd.
