### PR TITLE
Remove the `/configs` folder I accidentally added

### DIFF
--- a/configs/.gitignore
+++ b/configs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
In #1821, I added a `configs` folder by accident and never deleted it before I PR'ed it.

TLDR:
<img width="700" height="449" alt="image" src="https://github.com/user-attachments/assets/02613fd2-0367-4da5-973c-ff5ab55aad31" />

Here's the reason why:
1. At first in the `retrieve` tool, it would just copy all the configs back to `/configs`. It was simple.
2. Then I added logic for the configs to magically go back to your codebase so you could commit them straight from there
3. In my infinite wisdom, I never removed that folder
4. It got merged
