### PR TITLE
Make compatible with uv 0.12+

### DIFF
--- a/b
+++ b/b
@@ -1,2 +1,3 @@
 #!/bin/bash
-exec "$(dirname "$0")/nuclear/b.py" "$@"
+dir="$(dirname "$0")"
+exec uv run --project "$dir" "$dir/nuclear/b.py" "$@"

--- a/nuclear/pyproject.toml
+++ b/nuclear/pyproject.toml
@@ -1,3 +1,12 @@
+[project]
+name = "nubots-nuclear"
+version = "0.0.1"
+requires-python = ">=3.10,<3.13"
+dependencies = []
+
+[tool.uv]
+package = false
+
 [tool.black]
 line-length = 120
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ dependencies = [
     "si-prefix==1.3.3",
     "Pillow==11.1.0",
 ]
+
+[tool.uv.workspace]
+members = ["nuclear"]

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,12 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 
+[manifest]
+members = [
+    "nubots",
+    "nubots-nuclear",
+]
+
 [[package]]
 name = "astroid"
 version = "3.3.9"
@@ -501,6 +507,11 @@ requires-dist = [
     { name = "tqdm", specifier = "==4.67.1" },
     { name = "xxhash", specifier = "==3.5.0" },
 ]
+
+[[package]]
+name = "nubots-nuclear"
+version = "0.0.1"
+source = { virtual = "nuclear" }
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
This adds the `nuclear/pyproject.toml` as a member of the main uv project so that uv versions 0.12+ don't ignore the activate python environment and create another in `nuclear/` and then lead to python dependency errors since `nuclear/pyproject.toml` lists no dependencies to install. 